### PR TITLE
Potential fix for code scanning alert no. 25: DOM text reinterpreted as HTML

### DIFF
--- a/media/js/cwmcore.js
+++ b/media/js/cwmcore.js
@@ -116,6 +116,17 @@ $(function () {
     // Removed unused functions tmplListItem, tmplSingleItem, tmplModuleList, tmplModuleItem, tmplPopup
 });
 
+/**
+ * Returns true if the URL is a relative path (does not begin with scheme or '//')
+ */
+function isSafeRelativeUrl(url) {
+    // Only allow URLs that do not start with a scheme or '//'
+    return typeof url === 'string' &&
+        url.trim().length > 0 &&
+        !/^[a-z][a-z0-9+.-]*:/.test(url) && // No scheme like http:, https:, javascript:, data:, etc.
+        !/^\/\//.test(url); // Not protocol-relative
+}
+
 function goTo()
 {
     let sE = null, url;
@@ -128,11 +139,11 @@ function goTo()
     }
 
     if (sE && (url = sE.options[sE.selectedIndex].value)) {
-        try {
-            new URL(url);
+        if (isSafeRelativeUrl(url)) {
             location.href = url;
-        } catch (e) {
-            console.error('Invalid URL:', url);
+        } else {
+            alert('Navigation to external or potentially unsafe URL is not allowed.');
+            console.error('Unsafe navigation attempt:', url);
         }
     }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/Joomla-Bible-Study/Proclaim/security/code-scanning/25](https://github.com/Joomla-Bible-Study/Proclaim/security/code-scanning/25)

The problem is that a URL taken from a DOM element (`urlList`) is used to navigate the browser without robust validation, opening the possibility of malicious values leading to client-side redirects (or even navigation to javascript: URLs in some browsers). The best fix is:  
- Only allow navigation to URLs from an allowlist (pre-defined, trusted set of URLs).  
- Alternatively, restrict the URLs to relative paths and/or same-origin, to prevent navigation to arbitrary origins.  
- You should change the function beginning around line 119 (`goTo`) in `media/js/cwmcore.js` so that before assigning `location.href = url;`, you check if the URL is relative (does not start with a scheme or domain), or matches an explicit allowlist.

Concrete steps:  
- Add a helper function that checks whether the URL is relative (does not start with a scheme such as `http:` or `https:`, nor with double slash `//`).
- Change `goTo` to only assign `location.href = url` if the check passes.
- If not, alert the user or log, and do not perform navigation.

No new dependencies are required; this can be done in vanilla JS.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
