### PR TITLE
chore(deps): bump cwm/build-tools to ^1.32 and pin the cycle suffix empty

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -86,7 +86,7 @@
     "roave/security-advisories": "dev-latest",
     "pdepend/pdepend": "^2.16",
     "phpmd/phpmd": "^2.15",
-    "cwm/build-tools": "^1.31",
+    "cwm/build-tools": "^1.32",
     "joomla/database": "^4.0",
     "joomla/registry": "^4.0",
     "joomla/di": "^4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f76f742c33c4c2d7938f7189881c712b",
+    "content-hash": "eadfee55594f85f647f24be114c82462",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -548,16 +548,16 @@
         },
         {
             "name": "cwm/build-tools",
-            "version": "v1.31.0",
+            "version": "v1.32.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Joomla-Bible-Study/cwm-build-tools.git",
-                "reference": "f9921bb1a2249524020d044f2a97a211cf273390"
+                "reference": "9478395521ac28a8b4c022593d047ee7c8d1a0fb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Joomla-Bible-Study/cwm-build-tools/zipball/f9921bb1a2249524020d044f2a97a211cf273390",
-                "reference": "f9921bb1a2249524020d044f2a97a211cf273390",
+                "url": "https://api.github.com/repos/Joomla-Bible-Study/cwm-build-tools/zipball/9478395521ac28a8b4c022593d047ee7c8d1a0fb",
+                "reference": "9478395521ac28a8b4c022593d047ee7c8d1a0fb",
                 "shasum": ""
             },
             "require": {
@@ -665,10 +665,10 @@
                 "release"
             ],
             "support": {
-                "source": "https://github.com/Joomla-Bible-Study/cwm-build-tools/tree/v1.31.0",
+                "source": "https://github.com/Joomla-Bible-Study/cwm-build-tools/tree/v1.32.0",
                 "issues": "https://github.com/Joomla-Bible-Study/cwm-build-tools/issues"
             },
-            "time": "2026-08-19T14:13:35+00:00"
+            "time": "2026-08-19T22:51:15+00:00"
         },
         {
             "name": "danog/advanced-json-rpc",

--- a/cwm-build.config.json
+++ b/cwm-build.config.json
@@ -218,6 +218,11 @@
         "itemDescription": "pkg_proclaim download"
     },
     "versionTracking": {
+        "_activeDevelopment_comment": "devSuffix is deliberately empty. A cycle runs on the plain next version (10.5.11 while 10.5.11 is in development), which is what @since __DEPLOY_VERSION__ should resolve to anyway -- `@since 10.5.11` is already correct during that cycle. A -dev suffix would add a rename step before every release and buys nothing: build/test-upgrade.sh gates on the manifest matching active_development and differing from current, which the plain version satisfies. It is also unsafe on the publish path -- cwm_maturity_for_version() only recognises -alpha/-beta/-rc and classifies anything else as stable, so a published -dev build would be offered to every site (cwm-build-tools#155). Use -alpha1 for an edge release.",
+        "activeDevelopment": {
+            "advanceOnRelease": true,
+            "devSuffix": ""
+        },
         "substituteTokens": {
             "paths": [
                 "admin/",


### PR DESCRIPTION
Picks up **cwm/build-tools v1.32.0**, which makes `cwm-release` reopen `active_development` after a stable release — closing the gap that left the pointer naming an already-published version four times, most recently v10.5.10. Requested as cwm-build-tools#153.

## Why `devSuffix` is set, and set to empty

`advanceOnRelease` defaults to `true`, so the new behaviour arrives without config. `devSuffix` defaults to **empty**, and the `component` profile does not set it — so the value is stated explicitly here rather than inherited, because a silent default is easy to override by accident and the decision is worth recording next to it.

Empty is the right value. A cycle now runs on the plain next version — `10.5.11` while 10.5.11 is in development — which is what `@since __DEPLOY_VERSION__` should resolve to anyway.

Dropping `-dev` also removes the rename step every release previously needed (the *"open the … release cycle"* commits), and costs nothing: `build/test-upgrade.sh` gates on the package manifest matching `active_development` and differing from `current`, both of which the plain version satisfies.

## Verified rather than assumed

Ran the tracker's release path against a scratch copy, both ways:

| Config | Releasing 10.5.11 → `active_development` |
|---|---|
| `devSuffix: "-dev"` | `10.5.12-dev` |
| `devSuffix: ""` (this PR) | `10.5.12` |

## Related

`-dev` is unsafe on the publish path — `cwm_maturity_for_version()` recognises only `-alpha`/`-beta`/`-rc` and classifies anything else as **stable**, so a published `-dev` build would be offered to every site as a normal update (cwm-build-tools#155). Nothing has ever shipped with it, but it should not sit in the manifests waiting for the first edge release. Edge builds should use `-alpha1`.

Pairs with #1922 (opens the 10.5.11 cycle). Either order works.