### PR TITLE
fix: stop template export selecting the retired text column (#1918)

### DIFF
--- a/admin/src/Controller/CwmtemplatesController.php
+++ b/admin/src/Controller/CwmtemplatesController.php
@@ -307,16 +307,25 @@ class CwmtemplatesController extends AdminController
 
         if (!$exporttemplate) {
             $message = Text::_('JBS_TPL_NO_FILE_SELECTED');
-            $this->setRedirect('index.php?option=com_proclaim&view=cwmtemplates', $message);
+
+            return $this->setRedirect('index.php?option=com_proclaim&view=cwmtemplates', $message);
         }
 
         $db    = Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->createQuery();
-        $query->select($db->quoteName(['t.id', 't.type', 't.params', 't.title', 't.text']));
+        $query->select($db->quoteName(['t.id', 't.type', 't.params', 't.title']));
         $query->from($db->quoteName('#__bsms_templates', 't'));
         $query->where($db->quoteName('t.id') . ' = ' . (int) $exporttemplate);
         $db->setQuery($query);
-        $result       = $db->loadObject();
+        $result = $db->loadObject();
+
+        // A deleted or non-existent id yields no row, which the export cannot describe.
+        if (!$result) {
+            $message = Text::_('JBS_TPL_NO_FILE_SELECTED');
+
+            return $this->setRedirect('index.php?option=com_proclaim&view=cwmtemplates', $message);
+        }
+
         $objects[]    = $this->getExportSetting($result);
         $filecontents = implode(' ', $objects);
         $filename     = $result->title . '.sql';
@@ -332,6 +341,22 @@ class CwmtemplatesController extends AdminController
         $message = Text::_('JBS_TPL_EXPORT_SUCCESS');
 
         return $this->setRedirect('index.php?option=com_proclaim&view=cwmtemplates', $message);
+    }
+
+    /**
+     * Check whether a table is present in the current database.
+     *
+     * @param   string  $table  Table name in `#__` prefixed form
+     *
+     * @return  bool
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function tableExists(string $table): bool
+    {
+        $db = Factory::getContainer()->get(DatabaseInterface::class);
+
+        return \in_array(str_replace('#__', $db->getPrefix(), $table), $db->getTableList(), true);
     }
 
     /**
@@ -351,22 +376,27 @@ class CwmtemplatesController extends AdminController
         $params  = $registry;
         $db      = Factory::getContainer()->get(DatabaseInterface::class);
         $objects = '';
-        $css     = $params->get('css');
-        $css     = substr($css, 0, -4);
+        $css     = substr((string) $params->get('css', ''), 0, -4);
 
-        if ($css) {
-            $objects = "--\n-- CSS Style Code\n--\n";
-            $query2  = $db->createQuery();
+        // #__bsms_styles is a pre-10.0 table the install schema never creates, so
+        // only sites upgraded from 7.x still carry it — and the seeded default
+        // template names a stylesheet on every site regardless. Export the style
+        // when it is really there and skip it otherwise, rather than dying.
+        if ($css && $this->tableExists('#__bsms_styles')) {
+            $query2 = $db->createQuery();
             $query2->select($db->quoteName('style') . '.*');
             $query2->from($db->quoteName('#__bsms_styles', 'style'));
             $query2->where($db->quoteName('style.filename') . ' = ' . $db->q($css));
             $db->setQuery($query2);
-            $db->execute();
             $cssresult = $db->loadObject();
-            $objects .= "\nINSERT INTO #__bsms_styles SET `published` = '1',\n`filename` = " . $db->q(
-                $cssresult->filename
-            )
-                . ",\n`stylecode` = " . $db->q($cssresult->stylecode) . ";\n";
+
+            if ($cssresult) {
+                $objects = "--\n-- CSS Style Code\n--\n";
+                $objects .= "\nINSERT INTO #__bsms_styles SET `published` = '1',\n`filename` = " . $db->q(
+                    $cssresult->filename
+                )
+                    . ",\n`stylecode` = " . $db->q($cssresult->stylecode) . ";\n";
+            }
         }
 
         // Get the individual template files
@@ -417,8 +447,7 @@ class CwmtemplatesController extends AdminController
         // Create the main template insert
         $objects .= "\nINSERT INTO #__bsms_templates SET `type` = " . $db->q($result->type) . ",";
         $objects .= "\n`params` = " . $db->q($result->params) . ",";
-        $objects .= "\n`title` = " . $db->q($result->title) . ",";
-        $objects .= "\n`text` = " . $db->q($result->text) . ";";
+        $objects .= "\n`title` = " . $db->q($result->title) . ";";
 
         $objects .= "\n-- --------------------------------------------------------\n\n";
 


### PR DESCRIPTION
Closes #1918

## What was broken

Templates → Export died with `Unknown column 't.text' in 'field list'`. `#__bsms_templates.text` was in the 10.0.0 baseline but is not in the current install schema, and postflight's `dropLegacyTemplateColumns()` removes it from upgraded sites — so no supported site still has it. Reproduced on j62-dev.

## Why the fix touches four places, not one

**Both halves of the column reference.** Dropping `text` from the `SELECT` alone would leave `$result->text` in `getExportSetting()` as an undefined-property read — a warning, not an error — and the emitted `INSERT` would still name a column no site has, relocating the failure into `templateImport()` on the receiving end.

**The statement terminator.** It lived on the `text` line. Removing that line without moving the `;` onto `title` would emit an `INSERT` ending in a bare comma; `DatabaseDriver::splitSql()` would then hand the importer an unterminated statement. Export would look like it succeeded.

**The CSS branch — this one is why fixing `text` alone was not enough.** `getExportSetting()` reads `#__bsms_styles`, a pre-10.0 table that the install schema **never creates** (it appears only in `uninstall.mysql.utf8.sql`). It is absent on all four dev sites, while the seeded default template in the install SQL carries `"css":"biblestudy.css"` — so on a clean install the branch runs and hits a nonexistent table. Export would still have been fatal, just one line later. It is now guarded on the table being present and the row loading, degrading to omitting the style rather than killing the request.

**Two adjacent fatals in the same method.** The no-selection guard set a redirect but did not `return`, falling through to a lookup of id `0` and then dereferencing the resulting `null`; a deleted id took the same path.

## Verification

`getExportSetting()` invoked against **j5-dev, j6-dev, j62-dev and j70-dev** (2 upgraded, 2 clean installs). Each produces exactly one properly terminated `INSERT` naming only `type`, `params`, `title` — all real columns. The pre-fix `SELECT` was confirmed fatal against the same data.

`composer lint:fix` clean, `composer lint:comments` clean, Admin Controller Tests 89/89 pass.

## Not fixed here

Export now produces a valid file. The export→import **round trip** remains broken independently, and is not claimed fixed:

- `tmpl` is `NOT NULL` with no default and is never emitted — error 1364 on import under `STRICT_TRANS_TABLES`.
- `templateImport()` updates `#__bsms_styles` off a `#__bsms_templatecode` id, which reads as a wrong-table typo and would fatal on any site without that table.
- `#__bsms_styles` is dropped on uninstall but created by nothing — a schema inconsistency deliberately left alone rather than resolved in a patch release.

These belong with #843, which already proposes replacing this MySQL-only exporter with a params-only JSON one. Filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)