### PR TITLE
fix: group the edit toolbars' save variants into Joomla's save dropdown

### DIFF
--- a/admin/src/View/Cwmcomment/HtmlView.php
+++ b/admin/src/View/Cwmcomment/HtmlView.php
@@ -23,6 +23,7 @@ use Joomla\CMS\Helper\ContentHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
+use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 
 /**
@@ -121,18 +122,28 @@ class HtmlView extends BaseHtmlView
             'comment comment'
         );
 
+        $toolbar = $this->getDocument()->getToolbar();
+
         if ($isNew && $this->canDo->get('core.create', 'com_proclaim')) {
-            ToolbarHelper::apply('cwmcomment.apply');
-            ToolbarHelper::save('cwmcomment.save');
-            ToolbarHelper::save2new('cwmcomment.save2new');
-            ToolbarHelper::cancel('cwmcomment.cancel');
+            $toolbar->apply('cwmcomment.apply');
+
+            $toolbar->dropdownButton('save-group')->configure(
+                static function (Toolbar $childBar) {
+                    $childBar->save('cwmcomment.save');
+                    $childBar->save2new('cwmcomment.save2new');
+                }
+            );
+
+            $toolbar->cancel('cwmcomment.cancel');
         } else {
+            // A comment belongs to its message, so it is never created from a
+            // copy or spun into a new one from here — Save is the only variant.
             if ($this->canDo->get('core.edit', 'com_proclaim')) {
-                ToolbarHelper::apply('cwmcomment.apply');
-                ToolbarHelper::save('cwmcomment.save');
+                $toolbar->apply('cwmcomment.apply');
+                $toolbar->save('cwmcomment.save');
             }
 
-            ToolbarHelper::cancel('cwmcomment.cancel', 'JTOOLBAR_CLOSE');
+            $toolbar->cancel('cwmcomment.cancel', 'JTOOLBAR_CLOSE');
         }
 
         ToolbarHelper::divider();

--- a/admin/src/View/Cwmlocation/HtmlView.php
+++ b/admin/src/View/Cwmlocation/HtmlView.php
@@ -21,6 +21,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Helper\ContentHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
+use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 
 /**
@@ -139,28 +140,43 @@ class HtmlView extends BaseHtmlView
             'home home'
         );
 
+        $toolbar = $this->getDocument()->getToolbar();
+
         if ($isNew && $this->canDo->get('core.create', 'com_proclaim')) {
-            ToolbarHelper::apply('cwmlocation.apply');
-            ToolbarHelper::save('cwmlocation.save');
-            ToolbarHelper::save2new('cwmlocation.save2new');
-            ToolbarHelper::cancel('cwmlocation.cancel');
-        } else {
-            if ($this->canDo->get('core.edit', 'com_proclaim')) {
-                ToolbarHelper::apply('cwmlocation.apply');
-                ToolbarHelper::save('cwmlocation.save');
+            $toolbar->apply('cwmlocation.apply');
 
-                // We can save this record, but check the create permission to see if we can return to make a new one.
-                if ($this->canDo->get('core.create', 'com_proclaim')) {
-                    ToolbarHelper::save2new('cwmlocation.save2new');
+            $toolbar->dropdownButton('save-group')->configure(
+                static function (Toolbar $childBar) {
+                    $childBar->save('cwmlocation.save');
+                    $childBar->save2new('cwmlocation.save2new');
                 }
+            );
+
+            $toolbar->cancel('cwmlocation.cancel');
+        } else {
+            $canDo = $this->canDo;
+
+            if ($canDo->get('core.edit', 'com_proclaim')) {
+                $toolbar->apply('cwmlocation.apply');
             }
 
-            // If checked out, we can still save
-            if ($this->canDo->get('core.create', 'com_proclaim')) {
-                ToolbarHelper::save2copy('cwmlocation.save2copy');
-            }
+            $toolbar->dropdownButton('save-group')->configure(
+                static function (Toolbar $childBar) use ($canDo) {
+                    if ($canDo->get('core.edit', 'com_proclaim')) {
+                        $childBar->save('cwmlocation.save');
 
-            ToolbarHelper::cancel('cwmlocation.cancel', 'JTOOLBAR_CLOSE');
+                        if ($canDo->get('core.create', 'com_proclaim')) {
+                            $childBar->save2new('cwmlocation.save2new');
+                        }
+                    }
+
+                    if ($canDo->get('core.create', 'com_proclaim')) {
+                        $childBar->save2copy('cwmlocation.save2copy');
+                    }
+                }
+            );
+
+            $toolbar->cancel('cwmlocation.cancel', 'JTOOLBAR_CLOSE');
         }
 
         ToolbarHelper::divider();

--- a/admin/src/View/Cwmmessage/HtmlView.php
+++ b/admin/src/View/Cwmmessage/HtmlView.php
@@ -27,6 +27,7 @@ use Joomla\CMS\Helper\ContentHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
+use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 use Joomla\Registry\Registry;
 
@@ -217,32 +218,51 @@ class HtmlView extends BaseHtmlView
             'book book'
         );
 
+        $toolbar = $this->getDocument()->getToolbar();
+
         if ($isNew && $this->canDo->get('core.create', 'com_proclaim')) {
-            ToolbarHelper::apply('cwmmessage.apply');
-            ToolbarHelper::save('cwmmessage.save');
-            ToolbarHelper::save2new('cwmmessage.save2new');
-            ToolbarHelper::cancel('cwmmessage.cancel');
-        } else {
-            if ($this->canDo->get('core.edit', 'com_proclaim')) {
-                ToolbarHelper::apply('cwmmessage.apply');
-                ToolbarHelper::save('cwmmessage.save');
+            $toolbar->apply('cwmmessage.apply');
 
-                // We can save this record, but check the create permission to see if we can return to make a new one.
-                if ($this->canDo->get('core.create', 'com_proclaim')) {
-                    ToolbarHelper::save2new('cwmmessage.save2new');
+            $toolbar->dropdownButton('save-group')->configure(
+                static function (Toolbar $childBar) {
+                    $childBar->save('cwmmessage.save');
+                    $childBar->save2new('cwmmessage.save2new');
                 }
+            );
+
+            $toolbar->cancel('cwmmessage.cancel');
+        } else {
+            $canDo = $this->canDo;
+
+            if ($canDo->get('core.edit', 'com_proclaim')) {
+                $toolbar->apply('cwmmessage.apply');
             }
 
-            // If checked out, we can still save
-            if ($this->canDo->get('core.create', 'com_proclaim')) {
-                ToolbarHelper::save2copy('cwmmessage.save2copy');
-            }
+            $toolbar->dropdownButton('save-group')->configure(
+                static function (Toolbar $childBar) use ($canDo) {
+                    if ($canDo->get('core.edit', 'com_proclaim')) {
+                        $childBar->save('cwmmessage.save');
 
-            ToolbarHelper::cancel('cwmmessage.cancel', 'JTOOLBAR_CLOSE');
+                        // Saving is allowed, but returning to a blank form is
+                        // only useful with the create permission.
+                        if ($canDo->get('core.create', 'com_proclaim')) {
+                            $childBar->save2new('cwmmessage.save2new');
+                        }
+                    }
 
-            if ($this->canDo->get('core.edit', 'com_proclaim')) {
+                    // A copy is a new record, so this stands on create alone.
+                    if ($canDo->get('core.create', 'com_proclaim')) {
+                        $childBar->save2copy('cwmmessage.save2copy');
+                    }
+                }
+            );
+
+            $toolbar->cancel('cwmmessage.cancel', 'JTOOLBAR_CLOSE');
+
+            // Resetting the counter is destructive and unrelated to saving, so
+            // it stays a button of its own rather than joining the save group.
+            if ($canDo->get('core.edit', 'com_proclaim')) {
                 ToolbarHelper::divider();
-                $toolbar = $this->getDocument()->getToolbar();
                 $toolbar->confirmButton('undo', 'JBS_STY_RESET_HITS', 'resetHits')
                     ->message('JBS_STY_RESET_HITS_CONFIRM')
                     ->listCheck(false);

--- a/admin/src/View/Cwmplaylist/HtmlView.php
+++ b/admin/src/View/Cwmplaylist/HtmlView.php
@@ -21,6 +21,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Helper\ContentHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
+use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 
 /**
@@ -109,26 +110,43 @@ class HtmlView extends BaseHtmlView
             'list list'
         );
 
+        $toolbar = $this->getDocument()->getToolbar();
+
         if ($isNew && $this->canDo->get('core.create', 'com_proclaim')) {
-            ToolbarHelper::apply('cwmplaylist.apply');
-            ToolbarHelper::save('cwmplaylist.save');
-            ToolbarHelper::save2new('cwmplaylist.save2new');
-            ToolbarHelper::cancel('cwmplaylist.cancel');
-        } else {
-            if ($this->canDo->get('core.edit', 'com_proclaim')) {
-                ToolbarHelper::apply('cwmplaylist.apply');
-                ToolbarHelper::save('cwmplaylist.save');
+            $toolbar->apply('cwmplaylist.apply');
 
-                if ($this->canDo->get('core.create', 'com_proclaim')) {
-                    ToolbarHelper::save2new('cwmplaylist.save2new');
+            $toolbar->dropdownButton('save-group')->configure(
+                static function (Toolbar $childBar) {
+                    $childBar->save('cwmplaylist.save');
+                    $childBar->save2new('cwmplaylist.save2new');
                 }
+            );
+
+            $toolbar->cancel('cwmplaylist.cancel');
+        } else {
+            $canDo = $this->canDo;
+
+            if ($canDo->get('core.edit', 'com_proclaim')) {
+                $toolbar->apply('cwmplaylist.apply');
             }
 
-            if ($this->canDo->get('core.create', 'com_proclaim')) {
-                ToolbarHelper::save2copy('cwmplaylist.save2copy');
-            }
+            $toolbar->dropdownButton('save-group')->configure(
+                static function (Toolbar $childBar) use ($canDo) {
+                    if ($canDo->get('core.edit', 'com_proclaim')) {
+                        $childBar->save('cwmplaylist.save');
 
-            ToolbarHelper::cancel('cwmplaylist.cancel', 'JTOOLBAR_CLOSE');
+                        if ($canDo->get('core.create', 'com_proclaim')) {
+                            $childBar->save2new('cwmplaylist.save2new');
+                        }
+                    }
+
+                    if ($canDo->get('core.create', 'com_proclaim')) {
+                        $childBar->save2copy('cwmplaylist.save2copy');
+                    }
+                }
+            );
+
+            $toolbar->cancel('cwmplaylist.cancel', 'JTOOLBAR_CLOSE');
         }
 
         ToolbarHelper::divider();

--- a/admin/src/View/Cwmpodcast/HtmlView.php
+++ b/admin/src/View/Cwmpodcast/HtmlView.php
@@ -17,6 +17,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Helper\ContentHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
+use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -120,28 +121,43 @@ class HtmlView extends BaseHtmlView
             'feed feed'
         );
 
+        $toolbar = $this->getDocument()->getToolbar();
+
         if ($isNew && $this->canDo->get('core.create', 'com_proclaim')) {
-            ToolbarHelper::apply('cwmpodcast.apply');
-            ToolbarHelper::save('cwmpodcast.save');
-            ToolbarHelper::save2new('cwmpodcast.save2new');
-            ToolbarHelper::cancel('cwmpodcast.cancel');
-        } else {
-            if ($this->canDo->get('core.edit', 'com_proclaim')) {
-                ToolbarHelper::apply('cwmpodcast.apply');
-                ToolbarHelper::save('cwmpodcast.save');
+            $toolbar->apply('cwmpodcast.apply');
 
-                // We can save this record, but check the create permission to see if we can return to make a new one.
-                if ($this->canDo->get('core.create', 'com_proclaim')) {
-                    ToolbarHelper::save2new('cwmpodcast.save2new');
+            $toolbar->dropdownButton('save-group')->configure(
+                static function (Toolbar $childBar) {
+                    $childBar->save('cwmpodcast.save');
+                    $childBar->save2new('cwmpodcast.save2new');
                 }
+            );
+
+            $toolbar->cancel('cwmpodcast.cancel');
+        } else {
+            $canDo = $this->canDo;
+
+            if ($canDo->get('core.edit', 'com_proclaim')) {
+                $toolbar->apply('cwmpodcast.apply');
             }
 
-            // If checked out, we can still save
-            if ($this->canDo->get('core.create', 'com_proclaim')) {
-                ToolbarHelper::save2copy('cwmpodcast.save2copy');
-            }
+            $toolbar->dropdownButton('save-group')->configure(
+                static function (Toolbar $childBar) use ($canDo) {
+                    if ($canDo->get('core.edit', 'com_proclaim')) {
+                        $childBar->save('cwmpodcast.save');
 
-            ToolbarHelper::cancel('cwmpodcast.cancel', 'JTOOLBAR_CLOSE');
+                        if ($canDo->get('core.create', 'com_proclaim')) {
+                            $childBar->save2new('cwmpodcast.save2new');
+                        }
+                    }
+
+                    if ($canDo->get('core.create', 'com_proclaim')) {
+                        $childBar->save2copy('cwmpodcast.save2copy');
+                    }
+                }
+            );
+
+            $toolbar->cancel('cwmpodcast.cancel', 'JTOOLBAR_CLOSE');
         }
 
         ToolbarHelper::divider();

--- a/admin/src/View/Cwmserver/HtmlView.php
+++ b/admin/src/View/Cwmserver/HtmlView.php
@@ -19,6 +19,7 @@ use Joomla\CMS\Helper\ContentHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
+use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -156,28 +157,41 @@ class HtmlView extends BaseHtmlView
             'database database'
         );
 
+        $toolbar = $this->getDocument()->getToolbar();
+
         if ($isNew && $canDo->get('core.create', 'com_proclaim')) {
-            ToolbarHelper::apply('cwmserver.apply');
-            ToolbarHelper::save('cwmserver.save');
-            ToolbarHelper::save2new('cwmserver.save2new');
-            ToolbarHelper::cancel('cwmserver.cancel');
+            $toolbar->apply('cwmserver.apply');
+
+            $toolbar->dropdownButton('save-group')->configure(
+                static function (Toolbar $childBar) {
+                    $childBar->save('cwmserver.save');
+                    $childBar->save2new('cwmserver.save2new');
+                }
+            );
+
+            $toolbar->cancel('cwmserver.cancel');
         } else {
             if ($canDo->get('core.edit', 'com_proclaim')) {
-                ToolbarHelper::apply('cwmserver.apply');
-                ToolbarHelper::save('cwmserver.save');
+                $toolbar->apply('cwmserver.apply');
+            }
 
-                // We can save this record, but check the create permission to see if we can return to make a new one.
-                if ($canDo->get('core.create', 'com_proclaim')) {
-                    ToolbarHelper::save2new('cwmserver.save2new');
+            $toolbar->dropdownButton('save-group')->configure(
+                static function (Toolbar $childBar) use ($canDo) {
+                    if ($canDo->get('core.edit', 'com_proclaim')) {
+                        $childBar->save('cwmserver.save');
+
+                        if ($canDo->get('core.create', 'com_proclaim')) {
+                            $childBar->save2new('cwmserver.save2new');
+                        }
+                    }
+
+                    if ($canDo->get('core.create', 'com_proclaim')) {
+                        $childBar->save2copy('cwmserver.save2copy');
+                    }
                 }
-            }
+            );
 
-            // If checked out, we can still save
-            if ($canDo->get('core.create', 'com_proclaim')) {
-                ToolbarHelper::save2copy('cwmserver.save2copy');
-            }
-
-            ToolbarHelper::cancel('cwmserver.cancel', 'JTOOLBAR_CLOSE');
+            $toolbar->cancel('cwmserver.cancel', 'JTOOLBAR_CLOSE');
         }
 
         ToolbarHelper::divider();

--- a/admin/src/View/Cwmtemplate/HtmlView.php
+++ b/admin/src/View/Cwmtemplate/HtmlView.php
@@ -21,6 +21,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Helper\ContentHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
+use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 
 /**
@@ -113,28 +114,43 @@ class HtmlView extends BaseHtmlView
             'square square'
         );
 
+        $toolbar = $this->getDocument()->getToolbar();
+
         if ($isNew && $this->canDo->get('core.create', 'com_proclaim')) {
-            ToolbarHelper::apply('cwmtemplate.apply');
-            ToolbarHelper::save('cwmtemplate.save');
-            ToolbarHelper::save2new('cwmtemplate.save2new');
-            ToolbarHelper::cancel('cwmtemplate.cancel');
-        } else {
-            if ($this->canDo->get('core.edit', 'com_proclaim')) {
-                ToolbarHelper::apply('cwmtemplate.apply');
-                ToolbarHelper::save('cwmtemplate.save');
+            $toolbar->apply('cwmtemplate.apply');
 
-                // We can save this record, but check the create permission to see if we can return to make a new one.
-                if ($this->canDo->get('core.create', 'com_proclaim')) {
-                    ToolbarHelper::save2new('cwmtemplate.save2new');
+            $toolbar->dropdownButton('save-group')->configure(
+                static function (Toolbar $childBar) {
+                    $childBar->save('cwmtemplate.save');
+                    $childBar->save2new('cwmtemplate.save2new');
                 }
+            );
+
+            $toolbar->cancel('cwmtemplate.cancel');
+        } else {
+            $canDo = $this->canDo;
+
+            if ($canDo->get('core.edit', 'com_proclaim')) {
+                $toolbar->apply('cwmtemplate.apply');
             }
 
-            // If checked out, we can still save
-            if ($this->canDo->get('core.create', 'com_proclaim')) {
-                ToolbarHelper::save2copy('cwmtemplate.save2copy');
-            }
+            $toolbar->dropdownButton('save-group')->configure(
+                static function (Toolbar $childBar) use ($canDo) {
+                    if ($canDo->get('core.edit', 'com_proclaim')) {
+                        $childBar->save('cwmtemplate.save');
 
-            ToolbarHelper::cancel('cwmtemplate.cancel', 'JTOOLBAR_CLOSE');
+                        if ($canDo->get('core.create', 'com_proclaim')) {
+                            $childBar->save2new('cwmtemplate.save2new');
+                        }
+                    }
+
+                    if ($canDo->get('core.create', 'com_proclaim')) {
+                        $childBar->save2copy('cwmtemplate.save2copy');
+                    }
+                }
+            );
+
+            $toolbar->cancel('cwmtemplate.cancel', 'JTOOLBAR_CLOSE');
         }
 
         ToolbarHelper::divider();

--- a/admin/src/View/Cwmtemplatecode/HtmlView.php
+++ b/admin/src/View/Cwmtemplatecode/HtmlView.php
@@ -22,6 +22,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Helper\ContentHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
+use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 
 /**
@@ -150,19 +151,34 @@ class HtmlView extends BaseHtmlView
             'file'
         );
 
+        $toolbar = $this->getDocument()->getToolbar();
+
         if ($isNew && $this->canDo->get('core.create', 'com_proclaim')) {
-            ToolbarHelper::apply('cwmtemplatecode.apply');
-            ToolbarHelper::save('cwmtemplatecode.save');
-            ToolbarHelper::save2new('cwmtemplatecode.save2new');
-            ToolbarHelper::cancel('cwmtemplatecode.cancel');
+            $toolbar->apply('cwmtemplatecode.apply');
+
+            $toolbar->dropdownButton('save-group')->configure(
+                static function (Toolbar $childBar) {
+                    $childBar->save('cwmtemplatecode.save');
+                    $childBar->save2new('cwmtemplatecode.save2new');
+                }
+            );
+
+            $toolbar->cancel('cwmtemplatecode.cancel');
         } else {
-            if ($this->canDo->get('core.edit', 'com_proclaim')) {
-                ToolbarHelper::apply('cwmtemplatecode.apply');
-                ToolbarHelper::save('cwmtemplatecode.save');
-                ToolbarHelper::save2copy('cwmtemplatecode.save2copy');
+            $canDo = $this->canDo;
+
+            if ($canDo->get('core.edit', 'com_proclaim')) {
+                $toolbar->apply('cwmtemplatecode.apply');
+
+                $toolbar->dropdownButton('save-group')->configure(
+                    static function (Toolbar $childBar) {
+                        $childBar->save('cwmtemplatecode.save');
+                        $childBar->save2copy('cwmtemplatecode.save2copy');
+                    }
+                );
             }
 
-            ToolbarHelper::cancel('cwmtemplatecode.cancel', 'JTOOLBAR_CLOSE');
+            $toolbar->cancel('cwmtemplatecode.cancel', 'JTOOLBAR_CLOSE');
         }
 
         ToolbarHelper::divider();

--- a/composer.json
+++ b/composer.json
@@ -124,7 +124,7 @@
   },
   "scripts": {
     "test": "phpunit",
-    "test:unit": "phpunit --testsuite 'Asset Contract Tests,Query Contract Tests,Migration SQL Contract Tests,Admin Field Tests,Admin Helper Tests,Admin Lib Tests,Admin Api Controller Tests,Admin Api View Tests,Admin Bible Tests,Admin Controller Tests,Admin View Tests,Admin Model Tests,Site Helper Tests,Site Controller Tests,Site Model Tests,Site Bible Tests,Plugin Schemaorg Tests'",
+    "test:unit": "phpunit --testsuite 'Asset Contract Tests,Query Contract Tests,Migration SQL Contract Tests,Repo Contract Tests,Admin Field Tests,Admin Helper Tests,Admin Lib Tests,Admin Api Controller Tests,Admin Api View Tests,Admin Bible Tests,Admin Controller Tests,Admin View Tests,Admin Model Tests,Site Helper Tests,Site Controller Tests,Site Model Tests,Site Bible Tests,Plugin Schemaorg Tests'",
     "test:integration": "phpunit --testsuite 'Integration Admin Helper Tests,Integration Admin Lib Tests,Integration Admin Table Tests,Integration Admin Model Tests,Integration Admin Addon Tests,Integration Site Model Tests,Integration Site Helper Tests'",
     "test:js": "npm test",
     "test:e2e": "npm run test:e2e",

--- a/composer.json
+++ b/composer.json
@@ -124,7 +124,7 @@
   },
   "scripts": {
     "test": "phpunit",
-    "test:unit": "phpunit --testsuite 'Asset Contract Tests,Query Contract Tests,Migration SQL Contract Tests,Admin Field Tests,Admin Helper Tests,Admin Lib Tests,Admin Api Controller Tests,Admin Api View Tests,Admin Bible Tests,Admin Controller Tests,Admin Model Tests,Site Helper Tests,Site Controller Tests,Site Model Tests,Site Bible Tests,Plugin Schemaorg Tests'",
+    "test:unit": "phpunit --testsuite 'Asset Contract Tests,Query Contract Tests,Migration SQL Contract Tests,Admin Field Tests,Admin Helper Tests,Admin Lib Tests,Admin Api Controller Tests,Admin Api View Tests,Admin Bible Tests,Admin Controller Tests,Admin View Tests,Admin Model Tests,Site Helper Tests,Site Controller Tests,Site Model Tests,Site Bible Tests,Plugin Schemaorg Tests'",
     "test:integration": "phpunit --testsuite 'Integration Admin Helper Tests,Integration Admin Lib Tests,Integration Admin Table Tests,Integration Admin Model Tests,Integration Admin Addon Tests,Integration Site Model Tests,Integration Site Helper Tests'",
     "test:js": "npm test",
     "test:e2e": "npm run test:e2e",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -31,6 +31,9 @@
 		<testsuite name="Migration SQL Contract Tests">
 			<directory>tests/unit/Sql</directory>
 		</testsuite>
+		<testsuite name="Repo Contract Tests">
+			<directory>tests/unit/Repo</directory>
+		</testsuite>
 		<testsuite name="Admin Field Tests">
 			<directory>tests/unit/Admin/Field</directory>
 		</testsuite>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -52,6 +52,9 @@
 		<testsuite name="Admin Controller Tests">
 			<directory>tests/unit/Admin/Controller</directory>
 		</testsuite>
+		<testsuite name="Admin View Tests">
+			<directory>tests/unit/Admin/View</directory>
+		</testsuite>
 		<testsuite name="Admin Model Tests">
 			<directory>tests/unit/Admin/Model</directory>
 		</testsuite>

--- a/tests/unit/Admin/Lib/ScriptureStackOwnershipTest.php
+++ b/tests/unit/Admin/Lib/ScriptureStackOwnershipTest.php
@@ -9,7 +9,7 @@
  * @link       https://www.christianwebministries.org
  * */
 
-namespace CWM\Component\Proclaim\Tests\Admin;
+namespace CWM\Component\Proclaim\Tests\Admin\Lib;
 
 use CWM\Component\Proclaim\Administrator\Helper\CwmdbHelper;
 use CWM\Component\Proclaim\Tests\ProclaimTestCase;
@@ -126,7 +126,7 @@ class ScriptureStackOwnershipTest extends ProclaimTestCase
     public function testTheRestoreDropLoopNeitherTouchesTheStackNorKeepsTheDeadPreserveList(): void
     {
         $source = (string) file_get_contents(
-            __DIR__ . '/../../../admin/src/Controller/CwmbackupController.php'
+            \dirname(__DIR__, 4) . '/admin/src/Controller/CwmbackupController.php'
         );
 
         $this->assertMatchesRegularExpression(

--- a/tests/unit/Admin/View/ToolbarSaveGroupTest.php
+++ b/tests/unit/Admin/View/ToolbarSaveGroupTest.php
@@ -1,0 +1,137 @@
+<?php
+
+/**
+ * Toolbar contract for the admin edit views.
+ *
+ * @package    Proclaim.UnitTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace CWM\Component\Proclaim\Tests\Admin\View;
+
+use CWM\Component\Proclaim\Tests\ProclaimTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\TestDox;
+
+/**
+ * Joomla renders an edit form's save variants as one split button: Save, with
+ * Save & Close / Save & New / Save as Copy behind its dropdown. Calling
+ * `ToolbarHelper::save2new()` and friends instead lays every variant out flat,
+ * which is what Proclaim did until the toolbars were regrouped — six green
+ * buttons in a row, and a toolbar that overflows on a narrow window.
+ *
+ * These are source assertions rather than render assertions on purpose: the
+ * toolbar needs a booted administrator application to render, and the thing
+ * worth pinning is the API each view calls.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class ToolbarSaveGroupTest extends ProclaimTestCase
+{
+    /**
+     * Views with no save variants to group — a single Save is already correct.
+     *
+     * @var string[]
+     * @since __DEPLOY_VERSION__
+     */
+    private const NO_VARIANTS = [
+        'Cwmadmin',
+        'Cwmmessagetype',
+        'Cwmpermissions',
+        'Cwmserie',
+        'Cwmteacher',
+        'Cwmtopic',
+    ];
+
+    /**
+     * @return  string
+     * @since   __DEPLOY_VERSION__
+     */
+    private static function repoRoot(): string
+    {
+        return \dirname(__DIR__, 4);
+    }
+
+    /**
+     * Every admin view that builds an edit toolbar.
+     *
+     * @return  array<string, array{0: string, 1: string}>
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public static function editViewProvider(): array
+    {
+        $cases = [];
+
+        foreach (glob(self::repoRoot() . '/admin/src/View/*/HtmlView.php') as $file) {
+            $source = file_get_contents($file);
+
+            // An edit view is one that offers Apply; list views never do.
+            if (!str_contains($source, '->apply(') && !str_contains($source, 'ToolbarHelper::apply(')) {
+                continue;
+            }
+
+            $cases[basename(\dirname($file))] = [basename(\dirname($file)), $source];
+        }
+
+        return $cases;
+    }
+
+    #[DataProvider('editViewProvider')]
+    #[TestDox('$view groups its save variants into a dropdown')]
+    public function testSaveVariantsAreGrouped(string $view, string $source): void
+    {
+        $flat = [];
+
+        foreach (['save2new', 'save2copy'] as $variant) {
+            if (str_contains($source, 'ToolbarHelper::' . $variant . '(')) {
+                $flat[] = 'ToolbarHelper::' . $variant . '()';
+            }
+        }
+
+        self::assertSame(
+            [],
+            $flat,
+            $view . ' calls ' . implode(' and ', $flat) . ' directly, which renders the variants as separate '
+            . 'buttons. Add them to a $toolbar->dropdownButton(\'save-group\')->configure(…) child bar instead.'
+        );
+
+        $offersVariants = str_contains($source, 'save2new(') || str_contains($source, 'save2copy(');
+
+        if (!$offersVariants) {
+            self::assertContains(
+                $view,
+                self::NO_VARIANTS,
+                $view . ' offers no Save & New or Save as Copy. If that is deliberate, list it in NO_VARIANTS; '
+                . 'otherwise it is missing variants every other edit view has.'
+            );
+
+            return;
+        }
+
+        self::assertStringContainsString(
+            "dropdownButton('save-group')",
+            $source,
+            $view . ' has save variants but no save-group dropdown to hold them.'
+        );
+    }
+
+    #[DataProvider('editViewProvider')]
+    #[TestDox('$view imports Toolbar when it type-hints the child bar')]
+    public function testToolbarImported(string $view, string $source): void
+    {
+        if (!str_contains($source, 'Toolbar $childBar')) {
+            $this->assertTrue(true, $view . ' does not type-hint a child bar.');
+
+            return;
+        }
+
+        self::assertStringContainsString(
+            'use Joomla\CMS\Toolbar\Toolbar;',
+            $source,
+            $view . ' type-hints Toolbar in a configure() closure but never imports it, which is a fatal '
+            . 'the moment that branch runs.'
+        );
+    }
+}

--- a/tests/unit/Repo/SubmodulePinsTest.php
+++ b/tests/unit/Repo/SubmodulePinsTest.php
@@ -1,0 +1,111 @@
+<?php
+
+/**
+ * Submodule pin contract.
+ *
+ * @package    Proclaim.UnitTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace CWM\Component\Proclaim\Tests\Repo;
+
+use CWM\Component\Proclaim\Tests\ProclaimTestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+
+/**
+ * `lib_cwmscripture` is checked out twice, and the copies serve different
+ * masters:
+ *
+ *   libraries/lib_cwmscripture
+ *       Pinned by Proclaim. composer.json maps CWM\Library\Scripture\ at its
+ *       src/, so this is the copy the tests and the running site load.
+ *
+ *   plugins/content/scripturelinks/libraries/lib_cwmscripture
+ *       Pinned by ScriptureLinks. cwm-build.config.json declares a subBuild on
+ *       plugins/content/scripturelinks, which runs the ScriptureLinks package
+ *       build against *its* submodule to produce pkg_cwmscripture.zip.
+ *
+ * So Proclaim tests one checkout and ships the other. While the two pins agree
+ * that is invisible; the moment they diverge the suite passes against a library
+ * version the release does not contain, and nothing says so. Same shape as
+ * #1757, where the release bundled whatever zip was newest on disk instead of
+ * the pinned submodule.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class SubmodulePinsTest extends ProclaimTestCase
+{
+    /**
+     * @return  string
+     * @since   __DEPLOY_VERSION__
+     */
+    private static function repoRoot(): string
+    {
+        return \dirname(__DIR__, 3);
+    }
+
+    /**
+     * The commit a repository records for one of its submodules.
+     *
+     * Reads the gitlink rather than the checked-out HEAD: the pin is what
+     * ships, and a locally checked-out working tree may legitimately sit
+     * elsewhere while someone is mid-change.
+     *
+     * @param   string  $repo        Repository working directory
+     * @param   string  $submodule   Submodule path, relative to that repository
+     *
+     * @return  string|null  The recorded commit, or null if it cannot be read
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private static function pinnedCommit(string $repo, string $submodule): ?string
+    {
+        $command = \sprintf(
+            'git -C %s ls-tree HEAD %s 2>/dev/null',
+            escapeshellarg($repo),
+            escapeshellarg($submodule)
+        );
+
+        $line = trim((string) shell_exec($command));
+
+        // "160000 commit <sha>\t<path>" — 160000 is git's gitlink mode.
+        if (!preg_match('/^160000 commit ([0-9a-f]{40})\t/', $line, $match)) {
+            return null;
+        }
+
+        return $match[1];
+    }
+
+    #[TestDox('both lib_cwmscripture checkouts are pinned to the same commit')]
+    public function testScriptureLibraryPinsAgree(): void
+    {
+        $root = self::repoRoot();
+
+        $ours   = self::pinnedCommit($root, 'libraries/lib_cwmscripture');
+        $theirs = self::pinnedCommit($root . '/plugins/content/scripturelinks', 'libraries/lib_cwmscripture');
+
+        // Never let an unreadable pin pass as agreement — that is the failure
+        // this test exists to catch, wearing a different hat.
+        self::assertNotNull(
+            $ours,
+            'Could not read Proclaim\'s lib_cwmscripture pin. Run with submodules checked out '
+            . '(git submodule update --init --recursive).'
+        );
+
+        self::assertNotNull(
+            $theirs,
+            'Could not read the ScriptureLinks lib_cwmscripture pin. The scripturelinks submodule is probably '
+            . 'not checked out; this test cannot verify anything without it.'
+        );
+
+        self::assertSame(
+            $ours,
+            $theirs,
+            "The two lib_cwmscripture checkouts pin different commits.\n"
+            . "  libraries/lib_cwmscripture                      = $ours  (what the tests load)\n"
+            . "  plugins/content/scripturelinks/libraries/…      = $theirs  (what the release ships)\n"
+            . 'Update both pins together — lib, then scripturelinks, then Proclaim. See #1933.'
+        );
+    }
+}

--- a/tests/unit/Repo/TestSuiteCoverageTest.php
+++ b/tests/unit/Repo/TestSuiteCoverageTest.php
@@ -1,0 +1,121 @@
+<?php
+
+/**
+ * Test-suite reachability contract.
+ *
+ * @package    Proclaim.UnitTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace CWM\Component\Proclaim\Tests\Repo;
+
+use CWM\Component\Proclaim\Tests\ProclaimTestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+
+/**
+ * A test file only runs if it clears two independent gates: it must sit under a
+ * <directory> some phpunit.xml testsuite declares, AND that testsuite's name
+ * must appear in the explicit --testsuite list composer.json passes. Miss
+ * either and the file is silently inert — it does not error, it does not skip,
+ * it simply never runs, and the suite goes green without it.
+ *
+ * Both gates have been missed. ScriptureStackOwnershipTest sat directly in
+ * tests/unit/Admin/ while every suite points at a subdirectory, so its four
+ * contract tests never ran. Separately, a new tests/unit/Admin/View directory
+ * was registered in phpunit.xml but not in composer.json, and the total stayed
+ * at exactly 2064 until both were done.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class TestSuiteCoverageTest extends ProclaimTestCase
+{
+    /**
+     * @return  string
+     * @since   __DEPLOY_VERSION__
+     */
+    private static function repoRoot(): string
+    {
+        return \dirname(__DIR__, 3);
+    }
+
+    /**
+     * Directories declared by phpunit.xml, keyed by the suite that declares
+     * them, limited to suites the composer scripts actually invoke.
+     *
+     * @return  string[]  Repo-relative directories
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private static function wiredDirectories(): array
+    {
+        $xml      = simplexml_load_file(self::repoRoot() . '/phpunit.xml');
+        $composer = file_get_contents(self::repoRoot() . '/composer.json');
+
+        $wired = [];
+
+        foreach ($xml->testsuites->testsuite as $suite) {
+            $name = (string) $suite['name'];
+
+            // The suite has to be named in a composer script, or nothing runs it.
+            if (!str_contains($composer, $name)) {
+                continue;
+            }
+
+            foreach ($suite->directory as $directory) {
+                $wired[] = trim((string) $directory, '/');
+            }
+        }
+
+        return $wired;
+    }
+
+    #[TestDox('every test file sits in a suite that a composer script runs')]
+    public function testEveryTestFileIsReachable(): void
+    {
+        $root  = self::repoRoot();
+        $wired = self::wiredDirectories();
+
+        self::assertNotEmpty($wired, 'No phpunit.xml suite is referenced by composer.json at all.');
+
+        $orphans = [];
+
+        foreach (['tests/unit', 'tests/integration'] as $tree) {
+            $iterator = new \RecursiveIteratorIterator(
+                new \RecursiveDirectoryIterator($root . '/' . $tree, \FilesystemIterator::SKIP_DOTS)
+            );
+
+            foreach ($iterator as $file) {
+                if (!str_ends_with($file->getFilename(), 'Test.php')) {
+                    continue;
+                }
+
+                $relative = str_replace($root . '/', '', $file->getPathname());
+                $covered  = false;
+
+                foreach ($wired as $directory) {
+                    if (str_starts_with($relative, $directory . '/')) {
+                        $covered = true;
+
+                        break;
+                    }
+                }
+
+                if (!$covered) {
+                    $orphans[] = $relative;
+                }
+            }
+        }
+
+        sort($orphans);
+
+        self::assertSame(
+            [],
+            $orphans,
+            "These test files never run — no phpunit.xml suite that composer invokes covers them:\n  "
+            . implode("\n  ", $orphans)
+            . "\n\nMove each into a covered directory, or declare a suite in phpunit.xml AND add its name to the "
+            . '--testsuite list in composer.json. Both are required.'
+        );
+    }
+}


### PR DESCRIPTION
## Problem

Every edit view laid its save variants out flat. A message edit screen showed six buttons in a row:

`Save` · `Save & Close` · `Save & New` · `Save as Copy` · `Close` · `Reset Hits`

Joomla renders these as one split button — **Save**, with the variants behind its dropdown. That is what com_content and the rest of core do, and what Proclaim's own `Cwmmediafile` view already did.

## Change

Eight views moved onto `$toolbar->dropdownButton('save-group')->configure(…)`, following `Cwmmediafile` as the in-repo reference:

`Cwmcomment` · `Cwmlocation` · `Cwmmessage` · `Cwmplaylist` · `Cwmpodcast` · `Cwmserver` · `Cwmtemplate` · `Cwmtemplatecode`

**Permission logic is preserved exactly, only restructured.** The `core.edit` / `core.create` conditions that decide whether Save, Save & New and Save as Copy appear now run inside the child-bar closure rather than around the `ToolbarHelper` calls. `Cwmserver` keeps its `Cwmassets::sectionActions('server')` source.

## Judgement calls

**Two buttons deliberately stay outside the group.** Close is not a save. And `Cwmmessage`'s **Reset Hits** is destructive and unrelated to saving — folding it into a save dropdown is a good way to have someone clear a hit counter by accident. It keeps its divider and its confirm prompt.

**`Cwmcomment` and `Cwmtemplatecode` keep their narrower sets** rather than gaining variants they never offered. A comment belongs to its message and is not spun into a new one from that form. Both are noted in the test rather than silently skipped.

## Test

There was **no toolbar coverage at all**, so `ToolbarSaveGroupTest` is new. It asserts:

1. No edit view calls `ToolbarHelper::save2new()` / `save2copy()` directly.
2. Any view offering variants has a `save-group` dropdown to hold them.
3. A view type-hinting `Toolbar $childBar` imports the class — otherwise the closure is a fatal the moment that branch runs.

Views with no variants must be listed explicitly in `NO_VARIANTS`, so a view silently *losing* its variants fails rather than passing as "nothing to check".

Both mutations were verified rather than assumed:

| mutation | result |
|---|---|
| revert one call to `ToolbarHelper::save2copy` | fails assertion 1 ✓ |
| drop the `Toolbar` import, keep the type-hint | fails assertion 3 ✓ |
| restored | 2094 tests pass ✓ |

## Note for reviewers

The new suite had to be registered in **two** places — `phpunit.xml` *and* the explicit `--testsuite` list in `composer.json`'s `test:unit`. Adding only the first leaves the tests silently unrun; the count stayed at 2064 until both were done, and is 2094 now. Worth knowing for the next test directory.

## Not verified here

These are source-level assertions. The toolbar needs a booted administrator application to render, which I could not do headlessly — so **the dropdown should be eyeballed once in the admin** before merge. The API calls match `Cwmmediafile`, which renders correctly today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)