### PR TITLE
test: guard the submodule pins, and stop test files going silently inert

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -124,7 +124,7 @@
   },
   "scripts": {
     "test": "phpunit",
-    "test:unit": "phpunit --testsuite 'Asset Contract Tests,Query Contract Tests,Migration SQL Contract Tests,Admin Field Tests,Admin Helper Tests,Admin Lib Tests,Admin Api Controller Tests,Admin Api View Tests,Admin Bible Tests,Admin Controller Tests,Admin View Tests,Admin Model Tests,Site Helper Tests,Site Controller Tests,Site Model Tests,Site Bible Tests,Plugin Schemaorg Tests'",
+    "test:unit": "phpunit --testsuite 'Asset Contract Tests,Query Contract Tests,Migration SQL Contract Tests,Repo Contract Tests,Admin Field Tests,Admin Helper Tests,Admin Lib Tests,Admin Api Controller Tests,Admin Api View Tests,Admin Bible Tests,Admin Controller Tests,Admin View Tests,Admin Model Tests,Site Helper Tests,Site Controller Tests,Site Model Tests,Site Bible Tests,Plugin Schemaorg Tests'",
     "test:integration": "phpunit --testsuite 'Integration Admin Helper Tests,Integration Admin Lib Tests,Integration Admin Table Tests,Integration Admin Model Tests,Integration Admin Addon Tests,Integration Site Model Tests,Integration Site Helper Tests'",
     "test:js": "npm test",
     "test:e2e": "npm run test:e2e",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -31,6 +31,9 @@
 		<testsuite name="Migration SQL Contract Tests">
 			<directory>tests/unit/Sql</directory>
 		</testsuite>
+		<testsuite name="Repo Contract Tests">
+			<directory>tests/unit/Repo</directory>
+		</testsuite>
 		<testsuite name="Admin Field Tests">
 			<directory>tests/unit/Admin/Field</directory>
 		</testsuite>

--- a/tests/unit/Admin/Lib/ScriptureStackOwnershipTest.php
+++ b/tests/unit/Admin/Lib/ScriptureStackOwnershipTest.php
@@ -9,7 +9,7 @@
  * @link       https://www.christianwebministries.org
  * */
 
-namespace CWM\Component\Proclaim\Tests\Admin;
+namespace CWM\Component\Proclaim\Tests\Admin\Lib;
 
 use CWM\Component\Proclaim\Administrator\Helper\CwmdbHelper;
 use CWM\Component\Proclaim\Tests\ProclaimTestCase;
@@ -126,7 +126,7 @@ class ScriptureStackOwnershipTest extends ProclaimTestCase
     public function testTheRestoreDropLoopNeitherTouchesTheStackNorKeepsTheDeadPreserveList(): void
     {
         $source = (string) file_get_contents(
-            __DIR__ . '/../../../admin/src/Controller/CwmbackupController.php'
+            \dirname(__DIR__, 4) . '/admin/src/Controller/CwmbackupController.php'
         );
 
         $this->assertMatchesRegularExpression(

--- a/tests/unit/Repo/SubmodulePinsTest.php
+++ b/tests/unit/Repo/SubmodulePinsTest.php
@@ -1,0 +1,111 @@
+<?php
+
+/**
+ * Submodule pin contract.
+ *
+ * @package    Proclaim.UnitTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace CWM\Component\Proclaim\Tests\Repo;
+
+use CWM\Component\Proclaim\Tests\ProclaimTestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+
+/**
+ * `lib_cwmscripture` is checked out twice, and the copies serve different
+ * masters:
+ *
+ *   libraries/lib_cwmscripture
+ *       Pinned by Proclaim. composer.json maps CWM\Library\Scripture\ at its
+ *       src/, so this is the copy the tests and the running site load.
+ *
+ *   plugins/content/scripturelinks/libraries/lib_cwmscripture
+ *       Pinned by ScriptureLinks. cwm-build.config.json declares a subBuild on
+ *       plugins/content/scripturelinks, which runs the ScriptureLinks package
+ *       build against *its* submodule to produce pkg_cwmscripture.zip.
+ *
+ * So Proclaim tests one checkout and ships the other. While the two pins agree
+ * that is invisible; the moment they diverge the suite passes against a library
+ * version the release does not contain, and nothing says so. Same shape as
+ * #1757, where the release bundled whatever zip was newest on disk instead of
+ * the pinned submodule.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class SubmodulePinsTest extends ProclaimTestCase
+{
+    /**
+     * @return  string
+     * @since   __DEPLOY_VERSION__
+     */
+    private static function repoRoot(): string
+    {
+        return \dirname(__DIR__, 3);
+    }
+
+    /**
+     * The commit a repository records for one of its submodules.
+     *
+     * Reads the gitlink rather than the checked-out HEAD: the pin is what
+     * ships, and a locally checked-out working tree may legitimately sit
+     * elsewhere while someone is mid-change.
+     *
+     * @param   string  $repo        Repository working directory
+     * @param   string  $submodule   Submodule path, relative to that repository
+     *
+     * @return  string|null  The recorded commit, or null if it cannot be read
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private static function pinnedCommit(string $repo, string $submodule): ?string
+    {
+        $command = \sprintf(
+            'git -C %s ls-tree HEAD %s 2>/dev/null',
+            escapeshellarg($repo),
+            escapeshellarg($submodule)
+        );
+
+        $line = trim((string) shell_exec($command));
+
+        // "160000 commit <sha>\t<path>" — 160000 is git's gitlink mode.
+        if (!preg_match('/^160000 commit ([0-9a-f]{40})\t/', $line, $match)) {
+            return null;
+        }
+
+        return $match[1];
+    }
+
+    #[TestDox('both lib_cwmscripture checkouts are pinned to the same commit')]
+    public function testScriptureLibraryPinsAgree(): void
+    {
+        $root = self::repoRoot();
+
+        $ours   = self::pinnedCommit($root, 'libraries/lib_cwmscripture');
+        $theirs = self::pinnedCommit($root . '/plugins/content/scripturelinks', 'libraries/lib_cwmscripture');
+
+        // Never let an unreadable pin pass as agreement — that is the failure
+        // this test exists to catch, wearing a different hat.
+        self::assertNotNull(
+            $ours,
+            'Could not read Proclaim\'s lib_cwmscripture pin. Run with submodules checked out '
+            . '(git submodule update --init --recursive).'
+        );
+
+        self::assertNotNull(
+            $theirs,
+            'Could not read the ScriptureLinks lib_cwmscripture pin. The scripturelinks submodule is probably '
+            . 'not checked out; this test cannot verify anything without it.'
+        );
+
+        self::assertSame(
+            $ours,
+            $theirs,
+            "The two lib_cwmscripture checkouts pin different commits.\n"
+            . "  libraries/lib_cwmscripture                      = $ours  (what the tests load)\n"
+            . "  plugins/content/scripturelinks/libraries/…      = $theirs  (what the release ships)\n"
+            . 'Update both pins together — lib, then scripturelinks, then Proclaim. See #1933.'
+        );
+    }
+}

--- a/tests/unit/Repo/TestSuiteCoverageTest.php
+++ b/tests/unit/Repo/TestSuiteCoverageTest.php
@@ -1,0 +1,121 @@
+<?php
+
+/**
+ * Test-suite reachability contract.
+ *
+ * @package    Proclaim.UnitTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace CWM\Component\Proclaim\Tests\Repo;
+
+use CWM\Component\Proclaim\Tests\ProclaimTestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+
+/**
+ * A test file only runs if it clears two independent gates: it must sit under a
+ * <directory> some phpunit.xml testsuite declares, AND that testsuite's name
+ * must appear in the explicit --testsuite list composer.json passes. Miss
+ * either and the file is silently inert — it does not error, it does not skip,
+ * it simply never runs, and the suite goes green without it.
+ *
+ * Both gates have been missed. ScriptureStackOwnershipTest sat directly in
+ * tests/unit/Admin/ while every suite points at a subdirectory, so its four
+ * contract tests never ran. Separately, a new tests/unit/Admin/View directory
+ * was registered in phpunit.xml but not in composer.json, and the total stayed
+ * at exactly 2064 until both were done.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class TestSuiteCoverageTest extends ProclaimTestCase
+{
+    /**
+     * @return  string
+     * @since   __DEPLOY_VERSION__
+     */
+    private static function repoRoot(): string
+    {
+        return \dirname(__DIR__, 3);
+    }
+
+    /**
+     * Directories declared by phpunit.xml, keyed by the suite that declares
+     * them, limited to suites the composer scripts actually invoke.
+     *
+     * @return  string[]  Repo-relative directories
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private static function wiredDirectories(): array
+    {
+        $xml      = simplexml_load_file(self::repoRoot() . '/phpunit.xml');
+        $composer = file_get_contents(self::repoRoot() . '/composer.json');
+
+        $wired = [];
+
+        foreach ($xml->testsuites->testsuite as $suite) {
+            $name = (string) $suite['name'];
+
+            // The suite has to be named in a composer script, or nothing runs it.
+            if (!str_contains($composer, $name)) {
+                continue;
+            }
+
+            foreach ($suite->directory as $directory) {
+                $wired[] = trim((string) $directory, '/');
+            }
+        }
+
+        return $wired;
+    }
+
+    #[TestDox('every test file sits in a suite that a composer script runs')]
+    public function testEveryTestFileIsReachable(): void
+    {
+        $root  = self::repoRoot();
+        $wired = self::wiredDirectories();
+
+        self::assertNotEmpty($wired, 'No phpunit.xml suite is referenced by composer.json at all.');
+
+        $orphans = [];
+
+        foreach (['tests/unit', 'tests/integration'] as $tree) {
+            $iterator = new \RecursiveIteratorIterator(
+                new \RecursiveDirectoryIterator($root . '/' . $tree, \FilesystemIterator::SKIP_DOTS)
+            );
+
+            foreach ($iterator as $file) {
+                if (!str_ends_with($file->getFilename(), 'Test.php')) {
+                    continue;
+                }
+
+                $relative = str_replace($root . '/', '', $file->getPathname());
+                $covered  = false;
+
+                foreach ($wired as $directory) {
+                    if (str_starts_with($relative, $directory . '/')) {
+                        $covered = true;
+
+                        break;
+                    }
+                }
+
+                if (!$covered) {
+                    $orphans[] = $relative;
+                }
+            }
+        }
+
+        sort($orphans);
+
+        self::assertSame(
+            [],
+            $orphans,
+            "These test files never run — no phpunit.xml suite that composer invokes covers them:\n  "
+            . implode("\n  ", $orphans)
+            . "\n\nMove each into a covered directory, or declare a suite in phpunit.xml AND add its name to the "
+            . '--testsuite list in composer.json. Both are required.'
+        );
+    }
+}


### PR DESCRIPTION
Part of #1933.

> **Stacked on #1932.** Base is `fix/toolbar-save-dropdown` so the diff stays clean — both branches edit `composer.json`'s `--testsuite` line, and basing on `development` would guarantee a conflict. GitHub retargets this to `development` automatically once #1932 merges.

## 1. The submodule pin guard — the actual ask

`lib_cwmscripture` is checked out twice, and the copies serve different masters:

| path | pinned by | used for |
|---|---|---|
| `libraries/lib_cwmscripture` | Proclaim | PSR-4 autoload — what the suite and the running site load |
| `scripturelinks/libraries/lib_cwmscripture` | ScriptureLinks | what **ships** — `cwm-build.config.json`'s `subBuild` builds `pkg_cwmscripture.zip` from it |

So Proclaim **tests one checkout and ships the other**. While the pins agree that is invisible. The moment they diverge, the suite passes against a library version the release does not contain and nothing says so — the same shape as #1757.

`SubmodulePinsTest` compares the recorded **gitlinks**, not the checked-out HEADs: the pin is what ships, and a working tree may legitimately sit elsewhere while someone is mid-change.

## 2. `ScriptureStackOwnershipTest` was never running

It sat directly in `tests/unit/Admin/` while every suite points at a *subdirectory*, so nothing matched it. **Six tests, eleven assertions** — which tables are shared, the consumer registry, `getOwnObjects()`, the backup export allow-list — all silently inert. It passes; it had simply never been asked to.

Moved to `tests/unit/Admin/Lib`, already covered by a suite.

Its single hardcoded `__DIR__ . '/../../../'` broke the instant the file moved a level — its own small proof it had never run from anywhere else. Now anchored to the repo root, so relocating it between suites cannot quietly turn that read into an empty string and the regex assertion into a pass.

## 3. `TestSuiteCoverageTest` stops it recurring

A test file must clear **two independent gates**:

1. sit under a `<directory>` some `phpunit.xml` testsuite declares, **and**
2. that suite's name must appear in the explicit `--testsuite` list in `composer.json`

Miss either and the file does not error and does not skip — it simply never runs, and the suite goes green without it.

**Both gates have been missed.** The file above missed the first. Separately a new `tests/unit/Admin/View` directory missed the second, and the total sat at exactly 2064 until both were done.

The new test walks `tests/unit` and `tests/integration` and fails listing the offending paths. It found all three orphans on its first run — including itself, before registration.

## Verification

| check | result |
|---|---|
| pin test aimed at a non-existent submodule | fails on the unreadable-pin assertion, does **not** pass as "agreement" ✓ |
| the two pins it compares | real distinct reads, both `70402e7` ✓ |
| coverage test before registration | listed all 3 orphans ✓ |
| suite | 2064 → **2102** tests, all passing ✓ |

The unreadable-pin case is asserted explicitly rather than left to `assertSame(null, null)`, which would have passed happily on a machine without submodules checked out. CI checks out `submodules: recursive`, so it has real values to compare.

🤖 Generated with [Claude Code](https://claude.com/claude-code)