### PR TITLE
fix(message): stop Simple Mode saves deleting scriptures and topics

### DIFF
--- a/admin/src/Model/CwmmessageModel.php
+++ b/admin/src/Model/CwmmessageModel.php
@@ -384,15 +384,21 @@ class CwmmessageModel extends AdminModel
         $input  = $app->getInput();
         $image  = HTMLHelper::cleanImageURL((string)$data['image']);
 
-        // Extract subform data before table binding strips it
-        $scripturesData = $data['scriptures'] ?? [];
+        // Extract subform data before table binding strips it.
+        //
+        // Null means the form never submitted the field, which is not the same
+        // as submitting it empty. Each of these persists by replacing every
+        // existing row for the study, so a field the layout did not render
+        // would otherwise read as "the user removed them all" — Simple Mode
+        // hides scriptures and topics, and saving there deleted both.
+        $scripturesData = $data['scriptures'] ?? null;
         unset($data['scriptures']);
 
-        $teachersData = $data['teachers'] ?? [];
+        $teachersData = $data['teachers'] ?? null;
         unset($data['teachers']);
 
         // topic_ids is a legacy fallback key; the TopicsForm field submits under 'topics'.
-        $topicsData = $data['topic_ids'] ?? $data['topics'] ?? '';
+        $topicsData = $data['topic_ids'] ?? $data['topics'] ?? null;
         unset($data['topic_ids'], $data['topics']);
 
         $studyIntro = (string) ($data['studyintro'] ?? '');
@@ -552,14 +558,22 @@ class CwmmessageModel extends AdminModel
     /**
      * Process and save scripture references from the subform data.
      *
-     * @param   array  $scripturesData  Subform array of ['reference_text' => ..., 'bible_version' => ...]
+     * @param   ?array  $scripturesData  Subform array of ['reference_text' => ..., 'bible_version' => ...],
+     *                                   or null when the form did not submit the field at all.
      *
      * @return  void
      *
      * @since  10.1.0
      */
-    private function saveScriptures(array $scripturesData): void
+    private function saveScriptures(?array $scripturesData): void
     {
+        // Not submitted at all — leave the existing references alone.
+        // writeScriptures() deletes every row for the study before inserting,
+        // so passing an empty set here erases them.
+        if ($scripturesData === null) {
+            return;
+        }
+
         $studyId = (int) $this->getState($this->getName() . '.id');
 
         if ($studyId <= 0) {
@@ -604,14 +618,22 @@ class CwmmessageModel extends AdminModel
     /**
      * Save teachers from the subform data to the junction table.
      *
-     * @param   array  $teachersData  Subform array of ['teacher_id' => int]
+     * @param   ?array  $teachersData  Subform array of ['teacher_id' => int], or null when the form
+     *                                 did not submit the field at all.
      *
      * @return  void
      *
      * @since  10.1.0
      */
-    private function saveTeachers(array $teachersData): void
+    private function saveTeachers(?array $teachersData): void
     {
+        // Not submitted at all — leave the existing assignments alone. The
+        // layout renders this field today, but the helper replaces every row
+        // for the study, so hiding it would silently unassign every teacher.
+        if ($teachersData === null) {
+            return;
+        }
+
         $studyId = (int) $this->getState($this->getName() . '.id');
 
         if ($studyId <= 0) {
@@ -661,7 +683,8 @@ class CwmmessageModel extends AdminModel
      * topic if no match exists). If no tags were submitted at all, existing
      * topics are auto-matched from the study's intro/body text.
      *
-     * @param   array|string  $topicsRaw   Comma-separated string or array of topic IDs/text tags.
+     * @param   array|string|null  $topicsRaw   Comma-separated string or array of topic IDs/text tags,
+     *                                          or null when the form did not submit the field at all.
      * @param   string        $studyIntro  The study's intro text, used for auto-matching when no tags are given.
      * @param   string        $studyText   The study's body text, used for auto-matching when no tags are given.
      * @param   string        $language    Language code to use when creating a new topic from free text.
@@ -670,8 +693,16 @@ class CwmmessageModel extends AdminModel
      *
      * @since  10.5.6
      */
-    private function saveTopics(array|string $topicsRaw, string $studyIntro, string $studyText, string $language): void
+    private function saveTopics(array|string|null $topicsRaw, string $studyIntro, string $studyText, string $language): void
     {
+        // Not submitted at all — leave the existing topics alone. Falling
+        // through would reach the auto-match branch with the description and
+        // study text also unsubmitted, match nothing, and then replace every
+        // row for the study with an empty set.
+        if ($topicsRaw === null) {
+            return;
+        }
+
         $studyId = (int) $this->getState($this->getName() . '.id');
 
         if ($studyId <= 0) {

--- a/tests/integration/Admin/Model/CwmmessageSubformOmissionTest.php
+++ b/tests/integration/Admin/Model/CwmmessageSubformOmissionTest.php
@@ -1,0 +1,229 @@
+<?php
+
+/**
+ * Part of Proclaim Package
+ *
+ * @package    Proclaim.UnitTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace CWM\Component\Proclaim\Tests\Integration\Admin\Model;
+
+use CWM\Component\Proclaim\Administrator\Helper\CwmscriptureHelper;
+use CWM\Component\Proclaim\Administrator\Model\CwmmessageModel;
+use CWM\Component\Proclaim\Tests\Integration\IntegrationTestCase;
+use Joomla\CMS\Factory;
+use Joomla\Database\DatabaseDriver;
+use PHPUnit\Framework\Attributes\TestDox;
+
+/**
+ * Scriptures and topics persist by replacing every row a study owns, so the
+ * value the model receives has to distinguish two different things:
+ *
+ *   []    the form rendered the field and the user emptied it  → clear the rows
+ *   null  the form never rendered the field at all             → leave them be
+ *
+ * Simple Mode hides both fields, so a save there submitted neither. Both
+ * arrived as "empty", and every scripture reference and topic on the message
+ * was deleted — silently, on a screen that never showed them.
+ *
+ * These tests pin both directions: omission must preserve, and an explicit
+ * empty set must still clear, because collapsing them the other way would
+ * break the user's ability to remove the last reference.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class CwmmessageSubformOmissionTest extends IntegrationTestCase
+{
+    private ?DatabaseDriver $db = null;
+
+    private int $studyId = 0;
+
+    private int $topicId = 0;
+
+    /**
+     * @return  void
+     * @since   __DEPLOY_VERSION__
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (!\defined('PROCLAIM_TEST_DB_AVAILABLE') || !PROCLAIM_TEST_DB_AVAILABLE) {
+            $this->markTestSkipped('Database not available for integration tests');
+        }
+
+        $this->db = Factory::getContainer()->get(DatabaseDriver::class);
+        $this->db->transactionStart(true);
+
+        $study = (object) [
+            'published'  => 0,
+            'studytitle' => 'simple-mode omission fixture',
+            'language'   => '*',
+        ];
+        $this->db->insertObject('#__bsms_studies', $study, 'id');
+        $this->studyId = (int) $this->db->insertid();
+
+        $topic = (object) ['topic_text' => 'omission fixture topic', 'published' => 1, 'language' => '*'];
+        $this->db->insertObject('#__bsms_topics', $topic, 'id');
+        $this->topicId = (int) $this->db->insertid();
+    }
+
+    /**
+     * @return  void
+     * @since   __DEPLOY_VERSION__
+     */
+    protected function tearDown(): void
+    {
+        $this->db?->transactionRollback(true);
+
+        parent::tearDown();
+    }
+
+    /**
+     * Call one of the model's private subform writers with the study id in
+     * state, the way save() reaches them.
+     *
+     * @param   string  $method  Method name
+     * @param   array   $args    Positional arguments
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function invoke(string $method, array $args): void
+    {
+        // No mock: the model is only a carrier for the state the writers read,
+        // and getMockBuilder() is soft-deprecated in PHPUnit 12.
+        $model = (new \ReflectionClass(CwmmessageModel::class))->newInstanceWithoutConstructor();
+        $model->setState('cwmmessage.id', $this->studyId);
+
+        $ref = new \ReflectionMethod(CwmmessageModel::class, $method);
+        $ref->invokeArgs($model, $args);
+    }
+
+    /**
+     * @return  int  Reference rows owned by the fixture study.
+     * @since   __DEPLOY_VERSION__
+     */
+    private function countReferences(): int
+    {
+        return (int) $this->db->setQuery(
+            $this->db->createQuery()
+                ->select('COUNT(*)')
+                ->from($this->db->quoteName('#__bsms_study_scriptures'))
+                ->where($this->db->quoteName('study_id') . ' = ' . $this->studyId)
+        )->loadResult();
+    }
+
+    /**
+     * @return  int  Topic rows owned by the fixture study.
+     * @since   __DEPLOY_VERSION__
+     */
+    private function countTopics(): int
+    {
+        return (int) $this->db->setQuery(
+            $this->db->createQuery()
+                ->select('COUNT(*)')
+                ->from($this->db->quoteName('#__bsms_studytopics'))
+                ->where($this->db->quoteName('study_id') . ' = ' . $this->studyId)
+        )->loadResult();
+    }
+
+    /**
+     * @return  object  A reference shaped like ScriptureReference.
+     * @since   __DEPLOY_VERSION__
+     */
+    private function ref(int $book): object
+    {
+        return (object) [
+            'booknumber'    => $book,
+            'chapterBegin'  => 1,
+            'verseBegin'    => 1,
+            'chapterEnd'    => 1,
+            'verseEnd'      => 2,
+            'bibleVersion'  => 'kjv',
+            'referenceText' => 'Book ' . $book . ' 1:1-2',
+        ];
+    }
+
+    #[TestDox('Omitting the scriptures subform leaves existing references alone')]
+    public function testOmittedScripturesArePreserved(): void
+    {
+        CwmscriptureHelper::saveScriptures($this->studyId, [$this->ref(1), $this->ref(2)]);
+        $this->assertSame(2, $this->countReferences(), 'fixture should start with two references');
+
+        $this->invoke('saveScriptures', [null]);
+
+        $this->assertSame(
+            2,
+            $this->countReferences(),
+            'A form that never rendered the scriptures field must not delete the references it could not show.'
+        );
+    }
+
+    #[TestDox('An explicitly emptied scriptures subform still clears the references')]
+    public function testEmptyScripturesStillClear(): void
+    {
+        CwmscriptureHelper::saveScriptures($this->studyId, [$this->ref(1)]);
+        $this->assertSame(1, $this->countReferences());
+
+        // Straight at the helper: the model guard only decides whether to call
+        // it, and the point here is that an explicit empty set still clears —
+        // removing the last reference has to stay possible.
+        CwmscriptureHelper::saveScriptures($this->studyId, []);
+
+        $this->assertSame(
+            0,
+            $this->countReferences(),
+            'Omission and emptying are different inputs; emptying must still clear.'
+        );
+    }
+
+    #[TestDox('Omitting the topics field leaves existing topics alone')]
+    public function testOmittedTopicsArePreserved(): void
+    {
+        $row = (object) ['study_id' => $this->studyId, 'topic_id' => $this->topicId];
+        $this->db->insertObject('#__bsms_studytopics', $row, 'id');
+        $this->assertSame(1, $this->countTopics(), 'fixture should start with one topic');
+
+        $this->invoke('saveTopics', [null, '', '', '*']);
+
+        $this->assertSame(
+            1,
+            $this->countTopics(),
+            'A form that never rendered the topics field must not unassign the topics it could not show.'
+        );
+    }
+
+    #[TestDox('Omitting the teachers subform leaves existing assignments alone')]
+    public function testOmittedTeachersArePreserved(): void
+    {
+        $row = (object) ['study_id' => $this->studyId, 'teacher_id' => 1, 'ordering' => 0];
+        $this->db->insertObject('#__bsms_study_teachers', $row, 'id');
+        $this->assertSame(1, $this->countTeachers(), 'fixture should start with one teacher');
+
+        $this->invoke('saveTeachers', [null]);
+
+        $this->assertSame(
+            1,
+            $this->countTeachers(),
+            'Omitting the teachers subform must not unassign the teachers it could not show.'
+        );
+    }
+
+    /**
+     * @return  int  Teacher rows owned by the fixture study.
+     * @since   __DEPLOY_VERSION__
+     */
+    private function countTeachers(): int
+    {
+        return (int) $this->db->setQuery(
+            $this->db->createQuery()
+                ->select('COUNT(*)')
+                ->from($this->db->quoteName('#__bsms_study_teachers'))
+                ->where($this->db->quoteName('study_id') . ' = ' . $this->studyId)
+        )->loadResult();
+    }
+}


### PR DESCRIPTION
Fixes #1940 — saving a message with Simple Mode on deleted every scripture reference and topic it had, silently, from a screen that never displayed them.

### Cause

Scriptures, topics and teachers each persist by deleting every row the study owns and reinserting. `save()` handed them a value that could not distinguish two different inputs:

```php
$scripturesData = $data['scriptures'] ?? [];   // hidden field and emptied field look identical
```

Simple Mode hides the scripture subform (`edit.php:282`) and the whole Item Information tab containing topics (`:346`), so neither was submitted — and `saveScriptures()` / `saveTopics()` are called unconditionally from five branches in `save()`. Empty input meant "replace everything with nothing".

### Change

`null` now means "the form never submitted this" and returns early; `[]` still means "the user cleared it" and still clears, so removing the last reference remains possible. The guard sits in the three writers rather than at the five call sites.

Teachers gets the same guard even though it is not currently reachable — that field only survives because it happens to sit in the ungated column.

### Not affected

`studyintro` / `studytext` are plain columns and `Table::bind()` ignores absent keys, so the text itself was always preserved. Only the junction tables were losing data.

### Testing

New `tests/integration/Admin/Model/CwmmessageSubformOmissionTest` — 4 tests pinning both directions:

- omitted scriptures / topics / teachers are preserved
- an explicitly emptied scripture set still clears

Verified the test is load-bearing: with the model fix stashed it reports **3 errors**; with the fix, **OK (4 tests, 8 assertions)**.

Also green: `Admin Model Tests`, `Integration Admin Model Tests`, `Integration Admin Helper Tests` — 403 tests, 3956 assertions. `composer lint` clean at 0 of 625.

### Follow-up

The broader Simple Mode review is tracked separately — including that `studyintro` is still published on the front end (listings, teacher cards, podcast episode descriptions) while being uneditable in Simple Mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)