### PR TITLE
fix(plugins): J7 plugin construction, finder database access, and disabled-plugin fatal

### DIFF
--- a/plugins/finder/proclaim/services/provider.php
+++ b/plugins/finder/proclaim/services/provider.php
@@ -17,7 +17,6 @@ use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\Database\DatabaseInterface;
 use Joomla\DI\Container;
 use Joomla\DI\ServiceProviderInterface;
-use Joomla\Event\DispatcherInterface;
 
 return new class () implements ServiceProviderInterface {
     /**
@@ -34,10 +33,16 @@ return new class () implements ServiceProviderInterface {
         $container->set(
             PluginInterface::class,
             function (Container $container) {
-                $dispatcher = $container->get(DispatcherInterface::class);
-                $plugin     = new Proclaim(
-                    $dispatcher,
-                    (array)PluginHelper::getPlugin('finder', 'proclaim')
+                // Config first, then the database: Joomla 7 types the finder
+                // Adapter's second parameter as ?DatabaseInterface, so the old
+                // dispatcher-first form fatals before the constructor body runs.
+                // CMSPlugin has warned since 6.x that passing a dispatcher will
+                // not be supported in 7.0, and core's own finder plugins build
+                // this way. setDatabase() stays for 5.x/6.x, where the
+                // constructor takes no database argument.
+                $plugin = new Proclaim(
+                    (array) PluginHelper::getPlugin('finder', 'proclaim'),
+                    $container->get(DatabaseInterface::class)
                 );
                 $plugin->setApplication(Factory::getApplication());
                 $plugin->setDatabase($container->get(DatabaseInterface::class));

--- a/plugins/finder/proclaim/services/provider.php
+++ b/plugins/finder/proclaim/services/provider.php
@@ -40,8 +40,17 @@ return new class () implements ServiceProviderInterface {
                 // not be supported in 7.0, and core's own finder plugins build
                 // this way. setDatabase() stays for 5.x/6.x, where the
                 // constructor takes no database argument.
+                // A disabled plugin has no row, so getPlugin() returns null and
+                // the config arrives empty. The finder Adapter dereferences
+                // $this->params in its constructor, so that empty config fatals
+                // the whole request with "call to a member function get() on
+                // null" — on 5.x and 6.x as well as 7. Give params something to
+                // read; the plugin still does nothing while disabled.
+                $config = (array) PluginHelper::getPlugin('finder', 'proclaim');
+                $config['params'] ??= '{}';
+
                 $plugin = new Proclaim(
-                    (array) PluginHelper::getPlugin('finder', 'proclaim'),
+                    $config,
                     $container->get(DatabaseInterface::class)
                 );
                 $plugin->setApplication(Factory::getApplication());

--- a/plugins/finder/proclaim/src/Extension/Proclaim.php
+++ b/plugins/finder/proclaim/src/Extension/Proclaim.php
@@ -286,14 +286,15 @@ final class Proclaim extends Adapter implements SubscriberInterface
      */
     protected function checkSeriesAccess(Table $row): void
     {
-        $query = $this->db->createQuery()
-            ->select($this->db->quoteName('access'))
-            ->from($this->db->quoteName('#__bsms_series'))
-            ->where($this->db->quoteName('id') . ' = ' . (int) $row->id);
-        $this->db->setQuery($query);
+        $db    = $this->getDatabase();
+        $query = $db->createQuery()
+            ->select($db->quoteName('access'))
+            ->from($db->quoteName('#__bsms_series'))
+            ->where($db->quoteName('id') . ' = ' . (int) $row->id);
+        $db->setQuery($query);
 
         // Store the access level to determine if it changes
-        $this->old_seriesAccess = (int) $this->db->loadResult();
+        $this->old_seriesAccess = (int) $db->loadResult();
     }
 
     /**
@@ -308,12 +309,13 @@ final class Proclaim extends Adapter implements SubscriberInterface
      */
     protected function seriesAccessChange(Table $row): void
     {
+        $db    = $this->getDatabase();
         $query = clone $this->getStateQuery();
-        $query->where($this->db->quoteName('s.id') . ' = ' . (int) $row->id);
+        $query->where($db->quoteName('s.id') . ' = ' . (int) $row->id);
 
         // Get the access level.
-        $this->db->setQuery($query);
-        $items = $this->db->loadObjectList();
+        $db->setQuery($query);
+        $items = $db->loadObjectList();
 
         // Adjust the access level for each item within the Series.
         foreach ($items as $item) {
@@ -338,6 +340,8 @@ final class Proclaim extends Adapter implements SubscriberInterface
      */
     protected function seriesStateChange(array $pks, int $value): void
     {
+        $db = $this->getDatabase();
+
         /*
          * The item's published state is tied to the category
          * published state so we need to look up all published states
@@ -345,11 +349,11 @@ final class Proclaim extends Adapter implements SubscriberInterface
          */
         foreach ($pks as $pk) {
             $query = clone $this->getStateQuery();
-            $query->where($this->db->quoteName('s.id') . ' = ' . (int) $pk);
+            $query->where($db->quoteName('s.id') . ' = ' . (int) $pk);
 
             // Get the published states.
-            $this->db->setQuery($query);
-            $items = $this->db->loadObjectList();
+            $db->setQuery($query);
+            $items = $db->loadObjectList();
 
             // Adjust the state for each item within the category.
             foreach ($items as $item) {
@@ -372,9 +376,8 @@ final class Proclaim extends Adapter implements SubscriberInterface
      */
     protected function getStateQuery(): QueryInterface
     {
-        $query = $this->db->createQuery();
-
-        $db = $this->db;
+        $db    = $this->getDatabase();
+        $query = $db->createQuery();
 
         // Item ID
         $query->select($db->quoteName('a.id'));

--- a/plugins/system/proclaim/services/provider.php
+++ b/plugins/system/proclaim/services/provider.php
@@ -16,7 +16,6 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\DI\Container;
 use Joomla\DI\ServiceProviderInterface;
-use Joomla\Event\DispatcherInterface;
 
 return new class () implements ServiceProviderInterface {
     /**
@@ -33,8 +32,11 @@ return new class () implements ServiceProviderInterface {
         $container->set(
             PluginInterface::class,
             function (Container $container) {
+                // CMSPlugin has warned since 6.x that passing a dispatcher to
+                // the constructor will not be supported in 7.0, where the class
+                // stops implementing DispatcherAwareInterface. Config-first is
+                // the supported form on every version we target.
                 $plugin = new Proclaim(
-                    $container->get(DispatcherInterface::class),
                     (array) PluginHelper::getPlugin('system', 'proclaim')
                 );
                 $plugin->setApplication(Factory::getApplication());

--- a/plugins/task/proclaim/services/provider.php
+++ b/plugins/task/proclaim/services/provider.php
@@ -16,7 +16,6 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\DI\Container;
 use Joomla\DI\ServiceProviderInterface;
-use Joomla\Event\DispatcherInterface;
 
 return new class () implements ServiceProviderInterface {
     /**
@@ -33,8 +32,11 @@ return new class () implements ServiceProviderInterface {
         $container->set(
             PluginInterface::class,
             function (Container $container) {
+                // CMSPlugin has warned since 6.x that passing a dispatcher to
+                // the constructor will not be supported in 7.0, where the class
+                // stops implementing DispatcherAwareInterface. Config-first is
+                // the supported form on every version we target.
                 $plugin = new Proclaim(
-                    $container->get(DispatcherInterface::class),
                     (array) PluginHelper::getPlugin('task', 'proclaim')
                 );
                 $plugin->setApplication(Factory::getApplication());

--- a/plugins/task/proclaim/src/Extension/Proclaim.php
+++ b/plugins/task/proclaim/src/Extension/Proclaim.php
@@ -25,7 +25,6 @@ use Joomla\Component\Scheduler\Administrator\Event\ExecuteTaskEvent;
 use Joomla\Component\Scheduler\Administrator\Task\Status;
 use Joomla\Component\Scheduler\Administrator\Traits\TaskPluginTrait;
 use Joomla\Database\DatabaseInterface;
-use Joomla\Event\DispatcherInterface;
 use Joomla\Event\SubscriberInterface;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -137,14 +136,18 @@ final class Proclaim extends CMSPlugin implements SubscriberInterface
     /**
      * Constructor.
      *
-     * @param   DispatcherInterface  $dispatcher     The dispatcher
-     * @param   array                $config         An optional associative array of configuration settings
+     * Takes the config alone. CMSPlugin has warned since 6.x that passing a
+     * dispatcher here will not be supported in 7.0, where the class stops
+     * implementing DispatcherAwareInterface; the dispatcher is injected by the
+     * plugin system rather than constructed in.
+     *
+     * @param   array  $config  An optional associative array of configuration settings
      *
      * @since   4.2.0
      */
-    public function __construct(DispatcherInterface $dispatcher, array $config)
+    public function __construct($config = [])
     {
-        parent::__construct($dispatcher, $config);
+        parent::__construct($config);
 
         // Always load CWM API if it exists.
         $api = JPATH_ADMINISTRATOR . '/components/com_proclaim/api.php';

--- a/plugins/webservices/proclaim/services/provider.php
+++ b/plugins/webservices/proclaim/services/provider.php
@@ -15,7 +15,6 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\DI\Container;
 use Joomla\DI\ServiceProviderInterface;
-use Joomla\Event\DispatcherInterface;
 
 return new class () implements ServiceProviderInterface {
     /**
@@ -32,8 +31,11 @@ return new class () implements ServiceProviderInterface {
         $container->set(
             PluginInterface::class,
             function (Container $container) {
+                // CMSPlugin has warned since 6.x that passing a dispatcher to
+                // the constructor will not be supported in 7.0, where the class
+                // stops implementing DispatcherAwareInterface. Config-first is
+                // the supported form on every version we target.
                 $plugin = new Proclaim(
-                    $container->get(DispatcherInterface::class),
                     (array) PluginHelper::getPlugin('webservices', 'proclaim')
                 );
                 $plugin->setApplication(Factory::getApplication());


### PR DESCRIPTION
Fixes #1943. Three related breakages, each found by constructing the plugins against real Joomla 5, 6 and 7 installs rather than reading signatures.

### 1. Dispatcher-first construction fatals on J7

J7 changed the finder adapter's signature:

| | `Adapter::__construct` |
|---|---|
| J6.1 | `($config)` |
| J7.0 | `($config, ?DatabaseInterface $db = null)` |

Our provider passed the config array into what is now a `?DatabaseInterface` parameter, so it threw before the constructor body ran. Upstream kept the legacy `if ($config instanceof DispatcherInterface)` branch *inside* that body, which no dispatcher-first caller can reach any more — the type declaration rejects the array first.

Now config-first with the database second, matching core's own J7 finder plugins. `setDatabase()` stays for 5.x/6.x, where the constructor takes no database argument.

The other three providers carried the same deprecated form. Only finder fatalled — only `Adapter` added a typed parameter — but `CMSPlugin` has warned since 6.x that a dispatcher argument will not be supported in 7.0. `plg_task_proclaim` also declared its **own** dispatcher-first constructor, so changing its provider alone left it throwing.

### 2. `$this->db` is null on J7

J7 moved `Adapter` onto `DatabaseAwareTrait` — it calls `setDatabase()`, and every core usage went from `$this->db` to `$this->getDatabase()`. The legacy `protected $db` is still declared but **nothing populates it**, so this plugin's fourteen reads returned null:

```
Call to a member function createQuery() on null
```

Each affected method now takes a local from `getDatabase()`, as core rewrote its own.

### 3. A disabled plugin fatals the request

`PluginHelper::getPlugin()` returns null for a disabled plugin, so the config arrives empty, and the Adapter constructor dereferences `$this->params`.

**This one is neither new nor J7-specific** — constructing with an empty config fails identically on J6:

```
j6-dev    empty config: FAIL  Call to a member function get() on null
j70-dev   empty config: FAIL  Call to a member function get() on null
```

The constructor fix only changed which error surfaced first on J7. `params` now defaults to `'{}'`; the plugin still does nothing while disabled.

### Testing

Every plugin built through the DI container on three real installs:

| | J5 | J6 | **J7** |
|---|---|---|---|
| finder / system / task / webservices / schemaorg | ✅ | ✅ | ✅ |

Plus `getStateQuery()` invoked to exercise the database path, and finder constructed with the plugin **disabled**. Confirmed working on the reporter's J7 site.

j62-dev shows two unrelated failures, identical with the change stashed — pre-existing state on that install.

`composer test:unit` — 2102 tests, 3984 assertions. `composer lint` — 0 of 624.

🤖 Generated with [Claude Code](https://claude.com/claude-code)