### PR TITLE
fix(simplemode): keep secondary references out of Simple Mode

### DIFF
--- a/admin/tmpl/cwmcpanel/default.php
+++ b/admin/tmpl/cwmcpanel/default.php
@@ -127,6 +127,7 @@ echo Route::_('index.php?option=com_proclaim&view=cpanel'); ?>" method="post" na
             // <details>, which Atum renders as a full-width bordered box.
             $simpleHidden = [
                 'JBS_STY_STUDY_TEXT',
+                'JBS_CMN_SECONDARY_REFERENCES',
                 'JBS_CMN_TOPICS',
                 'JBS_CMN_LOCATIONS',
                 'JBS_CMN_COMMENTS',

--- a/admin/tmpl/cwmmessage/edit.php
+++ b/admin/tmpl/cwmmessage/edit.php
@@ -327,7 +327,12 @@ echo Route::_(
                     <?php echo $this->form->renderField('studyintro'); ?>
                     <div class="scripture-stacked mb-3">
                         <?php echo $this->form->renderField('scriptures'); ?>
-                        <?php echo $this->form->renderField('secondary_reference'); ?>
+                        <?php
+                        // Not scripture: film, literature, web sites. A simple
+                        // entry tags the passage it preached on and stops there.
+                        if (!$this->simple->mode) : ?>
+                            <?php echo $this->form->renderField('secondary_reference'); ?>
+                        <?php endif; ?>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Follow-up to #1946.

Un-gating the description and scripture references moved their whole `col-lg-7` column out of the Simple Mode branch — and `secondary_reference` was sitting in it, so it came along unintentionally.

It should not have. The field is *"Secondary references like film, literature, web sites or similar"* — not scripture at all. A simple entry tags the passage it preached on and stops there, so this belongs with the study text on the hidden side.

### Changes

- `secondary_reference` gated on its own inside the scripture block, leaving `scriptures` visible
- added to the list the dashboard notice names, which was otherwise under-reporting what Simple Mode hides

### Not a data risk

It is `type="text"`, a plain column, so `Table::bind()` leaves it alone when the form does not submit it. Anything already entered survives a save from a screen that does not show it — unlike the junction fields, which needed the separate fix.

### Testing

`composer test:unit` — 2121 tests, 4116 assertions. `composer lint` — 0 of 626. `composer lint:comments` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)