### PR TITLE
docs(templatecode): stop telling people to put CSS in a template override

### DIFF
--- a/admin/language/en-GB/en-GB.com_proclaim.ini
+++ b/admin/language/en-GB/en-GB.com_proclaim.ini
@@ -3395,7 +3395,7 @@ JBS_TPL_DUPLICATE = "Duplicate"
 
 ; Template Code
 JBS_TPLCODE_CODE = "Template php/html code"
-JBS_TPLCODE_CODE_DESC = "Put the php and HTML code here. This will be an actual template file. Put in your own CSS tags too"
+JBS_TPLCODE_CODE_DESC = "The PHP and HTML for a real template file, written to disk inside Proclaim's own component folder. Do not put styling here: Proclaim removes and replaces files in that folder when it updates, so CSS written into one can be lost. Use Custom CSS instead — the Custom CSS tab in Administration for every Proclaim page, a template's own Custom CSS field for just that template, or Section Custom CSS for a single landing page section. All three are stored with your settings, so they are included in a backup and survive an update."
 JBS_TPLCODE_DESC = "Override Template files for each view"
 JBS_TPLCODE_FILENAME = "Filename for the template (no .php)"
 JBS_TPLCODE_FILENAME_DESC = "Will create a file in the template view folder for the type specified. Name must be unique."


### PR DESCRIPTION
Fixes #1919, and with it the last outstanding item from discussion #1719.

### Before

```ini
JBS_TPLCODE_CODE_DESC = "Put the php and HTML code here. This will be an actual template file. Put in your own CSS tags too"
```

"Put in your own CSS tags too" points at exactly the practice Custom CSS was built to replace, and asks someone who only wants to restyle something to write PHP.

It is also a real risk rather than just bad advice. `CwmtemplatecodeTable` writes these to `components/com_proclaim/tmpl/Cwmsermons` and six sibling folders, and `proclaim.script.php` carries a list of folders under `components/com_proclaim` that it removes on update. CSS written into a file there can go with them.

### After

The description now says what the field is for — the PHP and HTML of a real template file — and names the three places styling belongs:

| level | where |
|---|---|
| every Proclaim page | Administration → **Custom CSS** tab |
| one template | that template's **Custom CSS** field |
| one landing section | **Section Custom CSS** |

All three are stored in params, so a backup keeps them and an update leaves them alone — which is the whole point of them existing.

### Scope

Only `en-GB` changes, per the convention followed for #1817 and #1795; the six translated copies follow from `cwm-sync-languages`.

### Testing

- `parse_ini_file(..., INI_SCANNER_RAW)` — 3775 keys, unchanged from before. (The plain scanner fails on this file both before and after; that is pre-existing and not what Joomla uses.)
- `codespell` with the CI ignore list — clean
- `composer lint` — 0 of 626

🤖 Generated with [Claude Code](https://claude.com/claude-code)