### PR TITLE
fix(templatecode): write layouts where the front end reads them

### DIFF
--- a/admin/src/Controller/CwmbackupController.php
+++ b/admin/src/Controller/CwmbackupController.php
@@ -26,6 +26,7 @@ use CWM\Component\Proclaim\Administrator\Lib\Cwmassets;
 use CWM\Component\Proclaim\Administrator\Lib\Cwmbackup;
 use CWM\Component\Proclaim\Administrator\Lib\Cwmrestore;
 use CWM\Component\Proclaim\Administrator\Lib\CwmscriptureMigration;
+use CWM\Component\Proclaim\Administrator\Table\CwmtemplatecodeTable;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Installer\InstallerHelper;
 use Joomla\CMS\Language\Text;
@@ -1072,26 +1073,19 @@ class CwmbackupController extends BaseController
                 return 0;
             }
 
-            // Type to path mapping (matches CwmtemplatecodeTable::store())
-            $typePaths = [
-                1 => JPATH_ROOT . '/components/com_proclaim/tmpl/Cwmsermons/',
-                2 => JPATH_ROOT . '/components/com_proclaim/tmpl/Cwmsermon/',
-                3 => JPATH_ROOT . '/components/com_proclaim/tmpl/Cwmteachers/',
-                4 => JPATH_ROOT . '/components/com_proclaim/tmpl/Cwmteacher/',
-                5 => JPATH_ROOT . '/components/com_proclaim/tmpl/Cwmseriesdisplays/',
-                6 => JPATH_ROOT . '/components/com_proclaim/tmpl/Cwmseriesdisplay/',
-                7 => JPATH_ROOT . '/modules/mod_proclaim/tmpl/',
-            ];
-
+            // ⚠️ Taken from CwmtemplatecodeTable, not copied. This map used to
+            // live here as well, and both copies still named the capitalised
+            // directories the package stopped shipping in 2022 -- so a restore
+            // rewrote layouts a case-sensitive host would never read.
             foreach ($records as $record) {
                 $type = (int) $record->type;
 
-                if (!isset($typePaths[$type])) {
+                if (!isset(CwmtemplatecodeTable::LAYOUT_DIRECTORIES[$type])) {
                     Log::add('Unknown templatecode type: ' . $type . ' for ID ' . $record->id, Log::WARNING, 'com_proclaim');
                     continue;
                 }
 
-                $directory = $typePaths[$type];
+                $directory = JPATH_ROOT . '/' . CwmtemplatecodeTable::LAYOUT_DIRECTORIES[$type] . '/';
                 $filename  = 'default_' . $record->filename . '.php';
                 $filepath  = $directory . $filename;
 

--- a/admin/src/Field/SermonsTemplateFileField.php
+++ b/admin/src/Field/SermonsTemplateFileField.php
@@ -16,6 +16,7 @@ namespace CWM\Component\Proclaim\Administrator\Field;
 
 // phpcs:enable PSR1.Files.SideEffects
 
+use CWM\Component\Proclaim\Administrator\Table\CwmtemplatecodeTable;
 use Joomla\CMS\Form\Field\ListField;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
@@ -79,7 +80,9 @@ class SermonsTemplateFileField extends ListField
         self::$cachedOptions   = [];
         self::$cachedOptions[] = HTMLHelper::_('select.option', '0', Text::_('JBS_CMN_USE_DEFAULT'));
 
-        $path = JPATH_SITE . '/components/com_proclaim/tmpl/cwmsermons';
+        // The directory a type 1 record writes into, so the list and the
+        // writer cannot disagree about where sermon list layouts live.
+        $path = JPATH_SITE . '/' . CwmtemplatecodeTable::LAYOUT_DIRECTORIES[1];
 
         if (!is_dir($path)) {
             return array_merge(parent::getOptions(), self::$cachedOptions);

--- a/admin/src/Table/CwmtemplatecodeTable.php
+++ b/admin/src/Table/CwmtemplatecodeTable.php
@@ -133,6 +133,102 @@ class CwmtemplatecodeTable extends Table
     public ?string $checked_out_time = null;
 
     /**
+     * Where a record of each type writes its layout, relative to the site root.
+     *
+     * ⚠️ Lower case, because that is what the package ships and what Joomla
+     * looks for. The folders were renamed in 2022 (50b3cd85e, "Renaming tmpl
+     * folders as joomla wants them small case … Found this out because it
+     * wouldn't work on Dreamhost") and these paths were not renamed with them.
+     *
+     * On a case-insensitive filesystem — macOS, most Windows — the old
+     * capitalised spelling resolved to the same file and nothing looked wrong.
+     * On a case-sensitive one, which is essentially all Linux hosting, writing
+     * to `tmpl/Cwmsermons` created a second directory the front end never
+     * reads: editing template code appeared to save and changed nothing.
+     *
+     * Kept in one place because there were three copies of this map — here in
+     * store(), here again in delete(), and a third in
+     * CwmbackupController::recreateTemplatecodeFiles() — and drifting apart is
+     * how the rename came to be missed twice over.
+     *
+     * @var    array<int, string>
+     * @since  __DEPLOY_VERSION__
+     */
+    public const array LAYOUT_DIRECTORIES = [
+        1 => 'components/com_proclaim/tmpl/cwmsermons',
+        2 => 'components/com_proclaim/tmpl/cwmsermon',
+        3 => 'components/com_proclaim/tmpl/cwmteachers',
+        4 => 'components/com_proclaim/tmpl/cwmteacher',
+        5 => 'components/com_proclaim/tmpl/cwmseriesdisplays',
+        6 => 'components/com_proclaim/tmpl/cwmseriesdisplay',
+        7 => 'modules/mod_proclaim/tmpl',
+    ];
+
+    /**
+     * The absolute path a record of this type and filename writes to.
+     *
+     * @param   int     $type      The record's template type
+     * @param   string  $filename  The layout filename, including `default_`
+     *
+     * @return  string|null  Null for a type with no layout directory
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public static function layoutPath(int $type, string $filename): ?string
+    {
+        if (!isset(self::LAYOUT_DIRECTORIES[$type])) {
+            return null;
+        }
+
+        return JPATH_ROOT . '/' . self::LAYOUT_DIRECTORIES[$type] . '/' . $filename;
+    }
+
+    /**
+     * Delete the copy an older version wrote to the capitalised directory.
+     *
+     * ⚠️ Guarded on realpath rather than on the name. Where the two spellings
+     * are the same file — every case-insensitive filesystem, which includes the
+     * machine most of this is developed on — deleting the "stray" would delete
+     * the layout just written. They are only ever different files on the hosts
+     * that had the bug in the first place.
+     *
+     * @param   int     $type      The record's template type
+     * @param   string  $filename  The layout filename
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private static function removeCapitalisedTwin(int $type, string $filename): void
+    {
+        $correct = self::layoutPath($type, $filename);
+
+        if ($correct === null || !isset(self::LAYOUT_DIRECTORIES[$type])) {
+            return;
+        }
+
+        $directory = self::LAYOUT_DIRECTORIES[$type];
+        $base      = basename($directory);
+
+        // mod_proclaim's `tmpl` has no capitalised variant to worry about.
+        if (!str_starts_with($base, 'cwm')) {
+            return;
+        }
+
+        $stray = JPATH_ROOT . '/' . \dirname($directory) . '/' . ucfirst($base) . '/' . $filename;
+
+        if (!is_file($stray)) {
+            return;
+        }
+
+        if (realpath($stray) === realpath($correct)) {
+            return;
+        }
+
+        File::delete($stray);
+    }
+
+    /**
      * Constructor
      *
      * @param     $db  DatabaseInterface connector object
@@ -230,39 +326,7 @@ class CwmtemplatecodeTable extends Table
         $templateType = $this->type;
         $filename     = 'default_' . $this->filename . '.php';
 
-        switch ($templateType) {
-            case 1:
-                // Sermons
-                $file = JPATH_ROOT . DIRECTORY_SEPARATOR . 'components/com_proclaim/tmpl/Cwmsermons' . DIRECTORY_SEPARATOR . $filename;
-                break;
-            case 2:
-                // Sermon
-                $file = JPATH_ROOT . DIRECTORY_SEPARATOR . 'components/com_proclaim/tmpl/Cwmsermon' . DIRECTORY_SEPARATOR . $filename;
-                break;
-            case 3:
-                // Teachers
-                $file = JPATH_ROOT . DIRECTORY_SEPARATOR . 'components/com_proclaim/tmpl/Cwmteachers' . DIRECTORY_SEPARATOR . $filename;
-                break;
-            case 4:
-                // Teacher
-                $file = JPATH_ROOT . DIRECTORY_SEPARATOR . 'components/com_proclaim/tmpl/Cwmteacher' . DIRECTORY_SEPARATOR . $filename;
-                break;
-            case 5:
-                // Seriesdisplays
-                $file = JPATH_ROOT . DIRECTORY_SEPARATOR . 'components/com_proclaim/tmpl/Cwmseriesdisplays' . DIRECTORY_SEPARATOR . $filename;
-                break;
-            case 6:
-                // Seriesdisplay
-                $file = JPATH_ROOT . DIRECTORY_SEPARATOR . 'components/com_proclaim/tmpl/Cwmseriesdisplay' . DIRECTORY_SEPARATOR . $filename;
-                break;
-            case 7:
-                // Module's Display
-                $file = JPATH_ROOT . DIRECTORY_SEPARATOR . 'modules/mod_proclaim/tmpl' . DIRECTORY_SEPARATOR . $filename;
-                break;
-            default:
-                $file = null;
-                break;
-        }
+        $file = self::layoutPath((int) $templateType, $filename);
 
         $templateCodeContent = $this->templatecode;
 
@@ -279,6 +343,11 @@ class CwmtemplatecodeTable extends Table
 
             return false;
         }
+
+        // An older version of this method wrote to the capitalised directory.
+        // On a case-sensitive host that copy is still sitting there, ignored by
+        // the front end and confusing to anyone who finds it.
+        self::removeCapitalisedTwin((int) $templateType, $filename);
 
         $result = parent::store($updateNulls);
 
@@ -307,45 +376,16 @@ class CwmtemplatecodeTable extends Table
         $filename     = 'default_' . $this->filename . '.php';
         $templateType = $this->type;
 
-        switch ($templateType) {
-            case 1:
-                // Sermons
-                $file = JPATH_ROOT . DIRECTORY_SEPARATOR . 'components/com_proclaim/tmpl/Cwmsermons' . DIRECTORY_SEPARATOR . $filename;
-                break;
-            case 2:
-                // Sermon
-                $file = JPATH_ROOT . DIRECTORY_SEPARATOR . 'components/com_proclaim/tmpl/Cwmsermon' . DIRECTORY_SEPARATOR . $filename;
-                break;
-            case 3:
-                // Teachers
-                $file = JPATH_ROOT . DIRECTORY_SEPARATOR . 'components/com_proclaim/tmpl/Cwmteachers' . DIRECTORY_SEPARATOR . $filename;
-                break;
-            case 4:
-                // Teacher
-                $file = JPATH_ROOT . DIRECTORY_SEPARATOR . 'components/com_proclaim/tmpl/Cwmteacher' . DIRECTORY_SEPARATOR . $filename;
-                break;
-            case 5:
-                // Seriesdisplays
-                $file = JPATH_ROOT . DIRECTORY_SEPARATOR . 'components/com_proclaim/tmpl/Cwmseriesdisplays' . DIRECTORY_SEPARATOR . $filename;
-                break;
-            case 6:
-                // Seriesdisplay
-                $file = JPATH_ROOT . DIRECTORY_SEPARATOR . 'components/com_proclaim/tmpl/Cwmseriesdisplay' . DIRECTORY_SEPARATOR . $filename;
-                break;
-            case 7:
-                // Module's Display
-                $file = JPATH_ROOT . DIRECTORY_SEPARATOR . 'modules/mod_proclaim/tmpl' . DIRECTORY_SEPARATOR . $filename;
-                break;
-            default:
-                $file = null;
-                break;
-        }
+        $file = self::layoutPath((int) $templateType, $filename);
 
-        if (file_exists($file) && !File::delete($file)) {
+        if ($file !== null && file_exists($file) && !File::delete($file)) {
             Factory::getApplication()->enqueueMessage('JBS_STYLE_FILENAME_NOT_DELETED', 'error');
 
             return false;
         }
+
+        // And the one an older version may have written beside it.
+        self::removeCapitalisedTwin((int) $templateType, $filename);
 
         return parent::delete($pk);
     }

--- a/composer.json
+++ b/composer.json
@@ -124,7 +124,7 @@
   },
   "scripts": {
     "test": "phpunit",
-    "test:unit": "phpunit --testsuite 'Asset Contract Tests,Query Contract Tests,Migration SQL Contract Tests,Repo Contract Tests,Language Contract Tests,Admin Field Tests,Admin Helper Tests,Admin Lib Tests,Admin Api Controller Tests,Admin Api View Tests,Admin Bible Tests,Admin Controller Tests,Admin View Tests,Admin Model Tests,Site Helper Tests,Site Controller Tests,Site Model Tests,Site Bible Tests,Plugin Schemaorg Tests'",
+    "test:unit": "phpunit --testsuite 'Asset Contract Tests,Query Contract Tests,Migration SQL Contract Tests,Repo Contract Tests,Language Contract Tests,Admin Field Tests,Admin Helper Tests,Admin Lib Tests,Admin Api Controller Tests,Admin Api View Tests,Admin Bible Tests,Admin Controller Tests,Admin View Tests,Admin Table Tests,Admin Model Tests,Site Helper Tests,Site Controller Tests,Site Model Tests,Site Bible Tests,Plugin Schemaorg Tests'",
     "test:integration": "phpunit --testsuite 'Integration Admin Helper Tests,Integration Admin Lib Tests,Integration Admin Table Tests,Integration Admin Model Tests,Integration Admin Addon Tests,Integration Site Model Tests,Integration Site Helper Tests'",
     "test:js": "npm test",
     "test:e2e": "npm run test:e2e",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -61,6 +61,9 @@
 		<testsuite name="Admin View Tests">
 			<directory>tests/unit/Admin/View</directory>
 		</testsuite>
+		<testsuite name="Admin Table Tests">
+			<directory>tests/unit/Admin/Table</directory>
+		</testsuite>
 		<testsuite name="Admin Model Tests">
 			<directory>tests/unit/Admin/Model</directory>
 		</testsuite>

--- a/proclaim.script.php
+++ b/proclaim.script.php
@@ -403,14 +403,16 @@ class com_proclaimInstallerScript extends InstallerScript
         '/components/com_proclaim/src/View/CWMTerms'       => '/components/com_proclaim/src/View/Cwmterms',
         '/components/com_proclaim/src/View/CWMcommentform' => '/components/com_proclaim/src/View/Cwmcommentform',
         '/components/com_proclaim/src/View/Teacher'        => '/components/com_proclaim/src/View/Cwmteacher',
-        // Site tmpl folders - CWM prefix renamed to Cwm
-        '/components/com_proclaim/tmpl/CWMCommentForm'   => '/components/com_proclaim/tmpl/Cwmcommentform',
-        '/components/com_proclaim/tmpl/CWMCommentList'   => '/components/com_proclaim/tmpl/Cwmcommentlist',
-        '/components/com_proclaim/tmpl/CWMMediaFileForm' => '/components/com_proclaim/tmpl/Cwmmediafileform',
-        '/components/com_proclaim/tmpl/CWMMediaFileList' => '/components/com_proclaim/tmpl/Cwmmediafilelist',
-        '/components/com_proclaim/tmpl/CWMMessageForm'   => '/components/com_proclaim/tmpl/Cwmmessageform',
-        '/components/com_proclaim/tmpl/CWMMessageList'   => '/components/com_proclaim/tmpl/Cwmmessagelist',
-        '/components/com_proclaim/tmpl/Teacher'          => '/components/com_proclaim/tmpl/Cwmteacher',
+        // ⚠️ The site tmpl folders are deliberately not renamed here.
+        //
+        // They used to be, onto capitalised names — Cwmcommentform, Cwmteacher
+        // — which the package stopped shipping when the folders went lower case
+        // in 2022 (50b3cd85e). Renames run before deletions, and the delete
+        // list names the *old* folder, so on a case-sensitive host each rename
+        // moved a legacy folder to a name nothing reads and nothing removes,
+        // leaving it there for good. Every one of them is already in
+        // $deleteFolders, so letting the deletion have them is both simpler and
+        // correct: none of these layouts exists in the package any more.
     ];
 
     /**
@@ -503,7 +505,7 @@ class com_proclaimInstallerScript extends InstallerScript
                 . '</li>';
         }
 
-        $summary = sprintf(
+        $summary = \sprintf(
             '%d ran, %d skipped%s in %ss, upgrading from %s.',
             \count($ran),
             $skipped,
@@ -604,7 +606,7 @@ class com_proclaimInstallerScript extends InstallerScript
                 'secs'  => 0.0,
             ];
 
-            $this->logInstall(sprintf('  skip  %-26s not needed past %s', $name, $since));
+            $this->logInstall(\sprintf('  skip  %-26s not needed past %s', $name, $since));
 
             return;
         }
@@ -623,7 +625,7 @@ class com_proclaimInstallerScript extends InstallerScript
                 'secs'  => $secs,
             ];
 
-            $this->logInstall(sprintf('  ran   %-26s %6.3fs', $name, $secs));
+            $this->logInstall(\sprintf('  ran   %-26s %6.3fs', $name, $secs));
         } catch (\Throwable $e) {
             $this->stepLog[] = [
                 'name'  => $name,
@@ -632,7 +634,7 @@ class com_proclaimInstallerScript extends InstallerScript
                 'secs'  => microtime(true) - $started,
             ];
 
-            $this->logInstall(sprintf('  FAIL  %-26s %s', $name, $e->getMessage()));
+            $this->logInstall(\sprintf('  FAIL  %-26s %s', $name, $e->getMessage()));
         }
     }
 
@@ -677,7 +679,7 @@ class com_proclaimInstallerScript extends InstallerScript
             $error = $e->getMessage() !== '' ? $e->getMessage() : $e::class;
 
             Factory::getApplication()->enqueueMessage(
-                sprintf(
+                \sprintf(
                     'Proclaim: the "%s" step of this update did not complete (%s). '
                     . 'The update itself is installed; the com_proclaim.install log has the detail.',
                     $name,
@@ -698,8 +700,8 @@ class com_proclaimInstallerScript extends InstallerScript
             // line it replaces. The gate matches this shape instead.
             $this->logInstall(
                 $error === ''
-                    ? sprintf('  task  %-26s %6.3fs', $name, $secs)
-                    : sprintf('  task  %-26s %6.3fs FAILED: %s', $name, $secs, $error)
+                    ? \sprintf('  task  %-26s %6.3fs', $name, $secs)
+                    : \sprintf('  task  %-26s %6.3fs FAILED: %s', $name, $secs, $error)
             );
         }
     }
@@ -754,7 +756,7 @@ class com_proclaimInstallerScript extends InstallerScript
             $this->fromVersion = $this->readInstalledVersion();
         }
 
-        $this->logInstall(sprintf(
+        $this->logInstall(\sprintf(
             'preflight: %s, from %s, PHP %s, Joomla %s',
             $type,
             $this->fromVersion !== '' ? $this->fromVersion : 'n/a',
@@ -1990,7 +1992,7 @@ class com_proclaimInstallerScript extends InstallerScript
             ? $class::VERSION
             : 'unknown';
 
-        $msg = sprintf(
+        $msg = \sprintf(
             'Proclaim: the installed scripture library is %s, older than the %s this release expects. '
             . 'Scripture still displays, using the previous lookup path. Update pkg_cwmscripture '
             . 'to get the faster and more reliable one.',
@@ -2029,7 +2031,7 @@ class com_proclaimInstallerScript extends InstallerScript
         // download shows up in neither number and has to be timed separately.
         $beforeUs = microtime(true) - $this->startedAt;
 
-        $this->logInstall(sprintf(
+        $this->logInstall(\sprintf(
             'postflight: %.2fs elapsed since preflight (unpack, file copy, schema) — download NOT included',
             $beforeUs
         ));
@@ -2318,7 +2320,7 @@ class com_proclaimInstallerScript extends InstallerScript
 
         // ⚠️ The leading "N step(s) in Ns" is parsed by build/verify-install-log.php,
         // which cross-checks it against the per-step lines. Keep it at the front.
-        $this->logInstall(sprintf(
+        $this->logInstall(\sprintf(
             'postflight: %d step(s) in %.3fs, %d task(s) in %.2fs; postflight total %.2fs; whole install %.2fs',
             \count($this->stepLog),
             array_sum(array_column($this->stepLog, 'secs')),

--- a/tests/unit/Admin/Table/TemplatecodeLayoutPathTest.php
+++ b/tests/unit/Admin/Table/TemplatecodeLayoutPathTest.php
@@ -1,0 +1,174 @@
+<?php
+
+/**
+ * Where template code is written has to be where the front end reads.
+ *
+ * The two are connected by nothing but a string. The layout folders went lower
+ * case in 2022 — "Renaming tmpl folders as joomla wants them small case (like
+ * com_contact). Found this out because it wouldn't work on Dreamhost" — and the
+ * map that writes into them was not renamed with them. On macOS, where this is
+ * developed, both spellings are the same file and nothing looked wrong; on the
+ * Linux hosts the rename was made for, saving template code wrote a file the
+ * site never loaded.
+ *
+ * @package    Proclaim.UnitTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ *
+ * @since __DEPLOY_VERSION__
+ */
+
+namespace CWM\Component\Proclaim\Tests\Admin\Table;
+
+use CWM\Component\Proclaim\Administrator\Table\CwmtemplatecodeTable;
+use CWM\Component\Proclaim\Tests\ProclaimTestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+
+/**
+ * @since __DEPLOY_VERSION__
+ */
+class TemplatecodeLayoutPathTest extends ProclaimTestCase
+{
+    /**
+     * A site-root path mapped back onto this repository's layout.
+     *
+     * The map is written as the site sees it — `components/com_proclaim/tmpl/x`
+     * and `modules/mod_proclaim/tmpl` — which is `site/tmpl/x` and
+     * `modules/site/mod_proclaim/tmpl` in the package.
+     *
+     * @param   string  $directory  A directory from the map
+     *
+     * @return  string  Absolute path in this repository
+     *
+     * @since __DEPLOY_VERSION__
+     */
+    private static function repositoryPath(string $directory): string
+    {
+        $base = \dirname(__DIR__, 4);
+
+        if (str_starts_with($directory, 'components/com_proclaim/tmpl/')) {
+            return $base . '/site/tmpl/' . basename($directory);
+        }
+
+        if ($directory === 'modules/mod_proclaim/tmpl') {
+            return $base . '/modules/site/mod_proclaim/tmpl';
+        }
+
+        return $base . '/' . $directory;
+    }
+
+    /**
+     * @return  void
+     *
+     * @since __DEPLOY_VERSION__
+     */
+    #[TestDox('Every directory the map writes to is one the package actually ships')]
+    public function testEveryMappedDirectoryIsShipped(): void
+    {
+        $map = CwmtemplatecodeTable::LAYOUT_DIRECTORIES;
+
+        // ⚠️ Not a silent pass over an empty map.
+        $this->assertGreaterThanOrEqual(7, \count($map), 'The layout map is missing entries.');
+
+        $missing = [];
+
+        foreach ($map as $type => $directory) {
+            $path = self::repositoryPath($directory);
+
+            if (!is_dir($path)) {
+                $missing[] = \sprintf('type %d -> %s (looked in %s)', $type, $directory, $path);
+            }
+        }
+
+        $this->assertSame(
+            [],
+            $missing,
+            "These layout directories are written to but not shipped, so the front end will never read them:\n"
+            . implode("\n", $missing)
+        );
+    }
+
+    /**
+     * The specific regression. A capitalised segment resolves on the developer's
+     * machine and silently does not on the host.
+     *
+     * @return  void
+     *
+     * @since __DEPLOY_VERSION__
+     */
+    #[TestDox('No mapped directory carries a capitalised path segment')]
+    public function testNoMappedDirectoryIsCapitalised(): void
+    {
+        $offenders = [];
+
+        foreach (CwmtemplatecodeTable::LAYOUT_DIRECTORIES as $type => $directory) {
+            if ($directory !== strtolower($directory)) {
+                $offenders[] = \sprintf('type %d -> %s', $type, $directory);
+            }
+        }
+
+        $this->assertSame(
+            [],
+            $offenders,
+            "Joomla resolves layouts by the lower-case folder the package ships:\n" . implode("\n", $offenders)
+        );
+    }
+
+    /**
+     * ⚠️ The map existed in three places — store(), delete() and the backup
+     * controller — and all three named the pre-2022 folders. One copy is why
+     * the rename could be missed twice; this asserts the other two are gone
+     * rather than trusting that they were removed.
+     *
+     * @return  void
+     *
+     * @since __DEPLOY_VERSION__
+     */
+    #[TestDox('Nothing outside the table hard-codes a layout directory again')]
+    public function testTheMapIsNotCopied(): void
+    {
+        $base    = \dirname(__DIR__, 4);
+        $checked = 0;
+        $copies  = [];
+
+        foreach (['admin/src', 'site/src', 'api/src'] as $root) {
+            if (!is_dir($base . '/' . $root)) {
+                continue;
+            }
+
+            $it = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($base . '/' . $root));
+
+            foreach ($it as $file) {
+                $path = str_replace('\\', '/', $file->getPathname());
+
+                if (!str_ends_with($path, '.php')) {
+                    continue;
+                }
+
+                $checked++;
+                $source = (string) file_get_contents($path);
+
+                // The table itself is where the map belongs.
+                if (str_ends_with($path, 'Table/CwmtemplatecodeTable.php')) {
+                    continue;
+                }
+
+                // ⚠️ Site layouts only. JPATH_ADMINISTRATOR . '/components/
+                // com_proclaim/tmpl/…' is the admin view tree, which has
+                // nothing to do with where template code is written.
+                if (preg_match('#JPATH_(?:ROOT|SITE)\s*\.\s*[\'"][^\'"]*com_proclaim/tmpl/cwm#i', $source)) {
+                    $copies[] = substr($path, \strlen($base) + 1);
+                }
+            }
+        }
+
+        $this->assertGreaterThan(100, $checked, 'Too few source files scanned; the scan is broken.');
+
+        $this->assertSame(
+            [],
+            $copies,
+            "These files build a layout path of their own instead of using "
+            . "CwmtemplatecodeTable::LAYOUT_DIRECTORIES:\n" . implode("\n", $copies)
+        );
+    }
+}


### PR DESCRIPTION
Fixes #1929.

`CwmtemplatecodeTable` mapped a record's type to a layout folder using the **pre-2022 capitalised** names — `tmpl/Cwmsermons`, `tmpl/Cwmteacher` and the rest. The package stopped shipping those in `50b3cd85e`:

> Renaming tmpl folders as joomla wants them small case (like com_contact). **Found this out because it wouldn't work on Dreamhost.**

On a case-insensitive filesystem both spellings are the same file, so nothing looked wrong on macOS or Windows. On a case-sensitive one — essentially all Linux hosting, including the Dreamhost that prompted the rename — `File::write()` created a second directory the front end never reads. **Editing template code appeared to save and changed nothing on the site**, and a restore rewrote every layout into the same unread place.

## One map instead of three

There were three copies, all carrying the stale spelling: `store()`, `delete()`, and `CwmbackupController::recreateTemplatecodeFiles()`. That is how one rename came to be missed three times over. It is now a single constant on the table; the backup controller and `SermonsTemplateFileField` read it instead of building their own.

## Clearing the strays

`store()` and `delete()` remove the copy an older version left in the capitalised folder.

⚠️ **Guarded on `realpath`, not on the name.** Where the two spellings are the same file, deleting the "stray" would delete the layout just written — which is the case on a default macOS volume.

## The install script

It no longer renames the site tmpl folders. It moved seven legacy folders onto capitalised names that are equally unread, and since **renames run before deletions** and the delete list names the *old* folder, each rename left a directory behind permanently. All seven are already in `$deleteFolders`; I verified each one before removing the rename.

## Guards

| Assertion | |
| --- | --- |
| Every mapped directory exists in the shipped tree | catches drift from the package |
| No mapped directory has a capitalised segment | holds **regardless of the filesystem** the tests run on |
| Nothing outside the table builds a site layout path | stops the map being copied again |

The admin tmpl tree is excluded deliberately — `JPATH_ADMINISTRATOR/components/com_proclaim/tmpl` is the admin view layer, unrelated to where template code is written. My first regex flagged two admin controllers as false positives.

Verified by reintroducing the capitalised path and watching both relevant tests fail, rather than assuming.

## ⚠️ An unregistered test directory

`tests/unit/Admin/Table` had **no suite entry**, so a test placed there would never have run. Registered in `phpunit.xml` and in the `test:unit` list.

2,973 tests green; `composer lint` clean at 0/632.

🤖 Generated with [Claude Code](https://claude.com/claude-code)