### PR TITLE
chore: open the 10.6.0 cycle, folding 10.5.11 into it

### DIFF
--- a/build/pkg_proclaim.xml
+++ b/build/pkg_proclaim.xml
@@ -2,8 +2,8 @@
 <extension type="package" method="upgrade">
     <packagename>proclaim</packagename>
     <name>PKG_PROCLAIM</name>
-    <version>10.5.11</version>
-    <creationDate>2026-08-19</creationDate>
+    <version>10.6.0</version>
+    <creationDate>2026-08-26</creationDate>
     <author>CWM Team</author>
     <authorEmail>info@christianwebministries.org</authorEmail>
     <authorUrl>www.christianwebministries.org</authorUrl>

--- a/build/versions.json
+++ b/build/versions.json
@@ -11,7 +11,7 @@
         "major": "11.0.0"
     },
     "active_development": {
-        "version": "10.5.11",
+        "version": "10.6.0",
         "description": "Use this for @since tags and migrations"
     },
     "notes": {

--- a/modules/admin/mod_proclaimicon/mod_proclaimicon.xml
+++ b/modules/admin/mod_proclaimicon/mod_proclaimicon.xml
@@ -2,12 +2,12 @@
 <extension type="module" client="administrator" method="upgrade">
     <name>mod_proclaimicon</name>
     <author>CWM Team</author>
-    <creationDate>2026-08-19</creationDate>
+    <creationDate>2026-08-26</creationDate>
     <copyright>(C) 2026 Proclaim All rights reserved.</copyright>
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
     <authorEmail>info@christianwebministries.org</authorEmail>
     <authorUrl>www.christianwebministries.org</authorUrl>
-    <version>10.5.11</version>
+    <version>10.6.0</version>
     <description>MOD_PROCLAIMICON_XML_DESCRIPTION</description>
     <namespace path="src">CWM\Module\Proclaimicon</namespace>
     <files>

--- a/modules/site/mod_proclaim/mod_proclaim.xml
+++ b/modules/site/mod_proclaim/mod_proclaim.xml
@@ -5,8 +5,8 @@
     <authorEmail>info@christianwebministries.org</authorEmail>
     <authorUrl>www.christianwebministries.org</authorUrl>
     <copyright>(C) 2026 Proclaim All rights reserved.</copyright>
-    <version>10.5.11</version>
-    <creationDate>2026-08-19</creationDate>
+    <version>10.6.0</version>
+    <creationDate>2026-08-26</creationDate>
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
     <description>MOD_PROCLAIM_DESCRIPTION</description>
     <namespace path="src">CWM\Module\Proclaim</namespace>

--- a/modules/site/mod_proclaim_podcast/mod_proclaim_podcast.xml
+++ b/modules/site/mod_proclaim_podcast/mod_proclaim_podcast.xml
@@ -2,12 +2,12 @@
 <extension type="module" client="site" method="upgrade">
     <name>mod_proclaim_podcast</name>
     <author>CWM Team</author>
-    <creationDate>2026-08-19</creationDate>
+    <creationDate>2026-08-26</creationDate>
     <copyright>(C) 2026 Christian Web Ministries All rights reserved.</copyright>
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
     <authorEmail>info@christianwebministries.org</authorEmail>
     <authorUrl>www.christianwebministries.org</authorUrl>
-    <version>10.5.11</version>
+    <version>10.6.0</version>
     <description>MOD_PROCLAIM_PODCAST_XML_DESCRIPTION</description>
     <namespace path="src">CWM\Module\ProclaimPodcast</namespace>
     <files>

--- a/modules/site/mod_proclaim_youtube/mod_proclaim_youtube.xml
+++ b/modules/site/mod_proclaim_youtube/mod_proclaim_youtube.xml
@@ -5,8 +5,8 @@
     <authorEmail>info@christianwebministries.org</authorEmail>
     <authorUrl>www.christianwebministries.org</authorUrl>
     <copyright>(C) 2026 CWM Team All rights reserved</copyright>
-    <version>10.5.11</version>
-    <creationDate>2026-08-19</creationDate>
+    <version>10.6.0</version>
+    <creationDate>2026-08-26</creationDate>
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
     <description>MOD_PROCLAIM_YOUTUBE_DESCRIPTION</description>
     <namespace path="src">CWM\Module\ProclaimYoutube</namespace>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "com_proclaim",
-  "version": "10.5.11",
+  "version": "10.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "com_proclaim",
-      "version": "10.5.11",
+      "version": "10.6.0",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@fancyapps/ui": "^6.1.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com_proclaim",
-  "version": "10.5.11",
+  "version": "10.6.0",
   "description": "CWM Proclaim - A Joomla! Extension for Church Media Management",
   "license": "GPL-2.0-or-later",
   "repository": {

--- a/plugins/finder/proclaim/proclaim.xml
+++ b/plugins/finder/proclaim/proclaim.xml
@@ -2,12 +2,12 @@
 <extension type="plugin" group="finder" method="upgrade">
     <name>plg_finder_proclaim</name>
     <author>CWM Team</author>
-    <creationDate>2026-08-19</creationDate>
+    <creationDate>2026-08-26</creationDate>
     <copyright>(C) 2026 Proclaim All rights reserved.</copyright>
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
     <authorEmail>info@christianwebministries.org</authorEmail>
     <authorUrl>www.christianwebministries.org</authorUrl>
-    <version>10.5.11</version>
+    <version>10.6.0</version>
     <description>PLG_FINDER_PROCLAIM_XML_DESCRIPTION</description>
     <namespace path="src">CWM\Plugin\Finder\Proclaim</namespace>
     <files>

--- a/plugins/schemaorg/proclaim/proclaim.xml
+++ b/plugins/schemaorg/proclaim/proclaim.xml
@@ -2,12 +2,12 @@
 <extension type="plugin" group="schemaorg" method="upgrade">
     <name>plg_schemaorg_proclaim</name>
     <author>CWM Team</author>
-    <creationDate>2026-08-19</creationDate>
+    <creationDate>2026-08-26</creationDate>
     <copyright>(C) 2026 CWM Team All rights reserved</copyright>
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
     <authorEmail>info@christianwebministries.org</authorEmail>
     <authorUrl>www.christianwebministries.org</authorUrl>
-    <version>10.5.11</version>
+    <version>10.6.0</version>
     <description>PLG_SCHEMAORG_PROCLAIM_XML_DESCRIPTION</description>
     <namespace path="src">CWM\Plugin\Schemaorg\Proclaim</namespace>
     <files>

--- a/plugins/system/proclaim/proclaim.xml
+++ b/plugins/system/proclaim/proclaim.xml
@@ -2,12 +2,12 @@
 <extension type="plugin" group="system" method="upgrade">
     <name>plg_system_proclaim</name>
     <author>CWM Team</author>
-    <creationDate>2026-08-19</creationDate>
+    <creationDate>2026-08-26</creationDate>
     <copyright>(C) 2026 Proclaim All rights reserved.</copyright>
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
     <authorEmail>info@christianwebministries.org</authorEmail>
     <authorUrl>www.christianwebministries.org</authorUrl>
-    <version>10.5.11</version>
+    <version>10.6.0</version>
     <description>PLG_SYSTEM_PROCLAIM_DESCRIPTION</description>
     <namespace path="src">CWM\Plugin\System\Proclaim</namespace>
     <files>

--- a/plugins/task/proclaim/proclaim.xml
+++ b/plugins/task/proclaim/proclaim.xml
@@ -2,12 +2,12 @@
 <extension type="plugin" group="task" method="upgrade">
 	<name>plg_task_proclaim</name>
 	<author>CWM Team</author>
-	<creationDate>2026-08-19</creationDate>
+	<creationDate>2026-08-26</creationDate>
 	<copyright>(C) 2026 Proclaim All rights reserved.</copyright>
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<authorEmail>info@christianwebministries.org</authorEmail>
 	<authorUrl>www.christianwebministries.org</authorUrl>
-	<version>10.5.11</version>
+	<version>10.6.0</version>
 	<description>PLG_TASK_PROCLAIM_XML_DESCRIPTION</description>
 	<namespace path="src">CWM\Plugin\Task\Proclaim</namespace>
 	<files>

--- a/plugins/webservices/proclaim/proclaim.xml
+++ b/plugins/webservices/proclaim/proclaim.xml
@@ -2,12 +2,12 @@
 <extension type="plugin" group="webservices" method="upgrade">
     <name>plg_webservices_proclaim</name>
     <author>CWM Team</author>
-    <creationDate>2026-08-19</creationDate>
+    <creationDate>2026-08-26</creationDate>
     <copyright>(C) 2026 CWM Team All rights reserved</copyright>
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
     <authorEmail>support@christianwebministries.org</authorEmail>
     <authorUrl>https://www.christianwebministries.org</authorUrl>
-    <version>10.5.11</version>
+    <version>10.6.0</version>
     <description>PLG_WEBSERVICES_PROCLAIM_DESCRIPTION</description>
     <namespace path="src">CWM\Plugin\WebServices\Proclaim</namespace>
     <files>

--- a/proclaim.script.php
+++ b/proclaim.script.php
@@ -2230,7 +2230,11 @@ class com_proclaimInstallerScript extends InstallerScript
 
             // The 'easy' starter template and the two orphaned fluid layouts,
             // which were swept into the package rather than authored as layouts.
-            $this->step('Stray layouts', '10.5.11', function () {
+            // Gated on 10.6.0, the version this actually ships in. 10.5.11 was
+            // developed but never released — its work went out as 10.6.0 — so a
+            // gate naming it would be describing a version no site can be on.
+            // Behaviourally the same either way: nothing is between the two.
+            $this->step('Stray layouts', '10.6.0', function () {
                 return $this->removeStrayTemplateLayouts();
             });
 

--- a/proclaim.xml
+++ b/proclaim.xml
@@ -6,8 +6,8 @@
     <authorEmail>info@christianwebministries.org</authorEmail>
     <authorUrl>www.christianwebministries.org</authorUrl>
     <copyright>(C) 2026 Proclaim All rights reserved.</copyright>
-    <version>10.5.11</version>
-    <creationDate>2026-08-19</creationDate>
+    <version>10.6.0</version>
+    <creationDate>2026-08-26</creationDate>
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
     <description>JBS_INS_XML_DESCRIPTION</description>
     <namespace path="src">CWM\Component\Proclaim</namespace>


### PR DESCRIPTION
10.5.11 was developed but is not being released. Everything on that milestone — the importer rescue (#1955), the language guards (#1951, #1960), the restore notice (#1959) and the templatecode path fix (#1961) — ships as **10.6.0** instead.

## Done on GitHub already

- The **32 items** on `v10.5.11` retargeted to `v10.6.0`
- `v10.5.11` **closed**, described as folded in
- #1926, #1930, #1953 attached to `v10.6.0`
- #1933 (CI tooling) and #1944 (dependency bot) left unmilestoned — neither ships

`v10.6.0` now stands at **5 open / 32 closed**.

## In this PR

`cwm-bump` moved 11 manifests, `package.json`/`package-lock.json` and `active_development` to 10.6.0. That last one matters beyond bookkeeping: `@since __DEPLOY_VERSION__` resolves from it, so anything written before the bump would have been stamped with a version that never ships.

**One gate corrected.** The `Stray layouts` postflight step was gated on `10.5.11` — a version no site can ever be on. It is gated on `10.6.0` now, matching what the other steps do (they name the version they shipped in). No behavioural change: nothing exists between the two, so `upgradingFromBefore()` admits exactly the same installs.

## Checked, not assumed

- **No SQL update file** was written for 10.5.11, so there is nothing to rename or consolidate.
- **`next.patch` is still `10.5.11`** and deliberately left. It is correct relative to `current` (10.5.10), and `VersionTracker` recomputes it at release. Its only reader is `sync-wiki-version.sh`, as a fallback for when `active_development` equals the released version — not the case here.

2,973 tests green; `composer lint` clean at 0/632.

🤖 Generated with [Claude Code](https://claude.com/claude-code)