### PR TITLE
chore(tests): drop a throwaway spec that reached development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,11 @@ com_proclaim/media/css/site/
 
 # Playwright E2E
 tests/e2e/.auth/
+
+# Throwaway Playwright specs used to drive a screen once and read the result.
+# One reached development because `git add -A` ran while a `rm` had not
+# (#1967) -- ignoring the prefix means the next one cannot.
+tests/e2e/**/_tmp-*.spec.js
 playwright-report/
 test-results/
 

--- a/tests/e2e/admin/_tmp-panel2.spec.js
+++ b/tests/e2e/admin/_tmp-panel2.spec.js
@@ -1,9 +1,0 @@
-const { test } = require('@playwright/test');
-test('panel with image checks', async ({ page }) => {
-    await page.setViewportSize({ width: 1500, height: 1900 });
-    await page.goto('/administrator/index.php?option=com_proclaim&task=cwmadmin.edit&id=1');
-    const panel = page.locator('.card').filter({ hasText: 'System Health' }).first();
-    await panel.waitFor({ timeout: 20000 });
-    await panel.scrollIntoViewIfNeeded();
-    await panel.screenshot({ path: '/tmp/health-panel2.png' });
-});


### PR DESCRIPTION
`tests/e2e/admin/_tmp-panel2.spec.js` was a scratch Playwright spec I used to drive the Administration screen once and screenshot the result. It should have been deleted before committing and was not — `git add -A` picked it up and it merged with #1967.

It is inert (it screenshots to `/tmp`) but it tests nothing and would run on every e2e pass.

Also ignores the `_tmp-` prefix rather than just deleting the file. The scratch spec has to live under `tests/e2e` to be picked up by the project at all, so it is always one forgotten `rm` away from being committed again — deleting this one does not stop the next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)