### PR TITLE
docs(health): cut the docblocks to what the code does

### DIFF
--- a/admin/layouts/health/report.php
+++ b/admin/layouts/health/report.php
@@ -3,15 +3,11 @@
 /**
  * The System Health report.
  *
- * A layout rather than a view template: the report is rendered inside the
- * Administration screen's first tab, which is an edit form, so it has to be a
- * fragment something else owns rather than a page of its own.
+ * A layout, not a view template: it renders inside the Administration
+ * screen's first tab, which is an edit form.
  *
- * Built as a flush list group inside a `cwmadmin-panel`, the shape the Image
- * Migration Pipeline and the thumbnail tools on this same screen already use.
- * A list rather than a table because the data is not tabular -- a status, a
- * name, a sentence and sometimes a button -- and because the panel has to stay
- * readable as checks are added to it, so every row costs vertical space.
+ * A flush list group in a `cwmadmin-panel`, matching the other tools on that
+ * tab. A list rather than a table because the data is not tabular.
  *
  * @package    Proclaim.Admin
  * @copyright  (C) 2026 CWM Team All rights reserved
@@ -70,8 +66,7 @@ $taskLink = static fn(string $task, string $check): string => Route::_(
         <?php foreach ([HealthStatus::Warning, HealthStatus::Notice, HealthStatus::Unknown, HealthStatus::Ok] as $status) :
             $count = (int) ($summary[$status->value] ?? 0);
 
-            // A chip reading "0 Worth knowing" is noise -- it reports the
-            // absence of something nobody asked about.
+            // A chip reading "0 Worth knowing" is noise.
             if ($count === 0) :
                 continue;
             endif;
@@ -96,20 +91,13 @@ $taskLink = static fn(string $task, string $check): string => Route::_(
                 ?>
                 <li class="list-group-item bg-transparent px-0 py-2">
                     <div class="d-flex align-items-start gap-2 flex-wrap">
-                        <?php // Badge and text in an inner flex that cannot wrap, so only
-                              // the buttons drop to a second line when space runs out. Let
-                              // the outer row wrap between them and a long title pushed the
-                              // badge onto its own line, leaving some titles indented and
-                              // some against the edge down the same list.
-                              //
-                              // `min-width: 0` on both is the flexbox default-min-content
-                              // escape: without it the text refuses to shrink below its
-                              // longest word and forces the wrap it is trying to avoid. ?>
+                        <?php // ⚠️ Inner flex must not wrap, so only the buttons drop to a
+                              // second line and every title starts at the same edge.
+                              // `min-width: 0` lets the text shrink below its longest
+                              // word; without it the row wraps anyway. ?>
                         <div class="d-flex align-items-start gap-2 flex-grow-1" style="min-width: 0;">
-                            <?php // The fixed width is on the cell, not the badge: stretching
-                                  // the badge itself left a wide block of flat colour on the
-                                  // short labels. This aligns the titles down the column and
-                                  // lets each badge size to its own word. ?>
+                            <?php // Width on the cell, not the badge, so titles align while
+                                  // each badge sizes to its own word. ?>
                             <span class="flex-shrink-0" style="min-width: 8.5em;">
                                 <span class="badge bg-<?php echo $result->status->contextClass(); ?>">
                                     <?php echo Text::_($result->status->labelKey()); ?>
@@ -136,8 +124,8 @@ $taskLink = static fn(string $task, string $check): string => Route::_(
                                 </a>
                             <?php endif; ?>
 
-                            <?php // An active check renders a button rather than a result: opening
-                                  // this screen must never be what spends a platform's API quota. ?>
+                            <?php // ⚠️ An active check offers a button, never a result: opening
+                                  // this screen must not spend a platform's API quota. ?>
                             <?php if (!$check->isPassive()) : ?>
                                 <a class="btn btn-sm btn-secondary"
                                    href="<?php echo $taskLink('test', $check->getId()); ?>"

--- a/admin/src/Controller/CwmhealthController.php
+++ b/admin/src/Controller/CwmhealthController.php
@@ -32,11 +32,8 @@ use Joomla\CMS\Session\Session;
 class CwmhealthController extends BaseController
 {
     /**
-     * Where every task returns to.
-     *
-     * The report is a panel on the Administration screen rather than a view of
-     * its own, so `task=` is right here: `view=cwmadmin` renders the settings
-     * form without the controller having set it up.
+     * Where every task returns to. ⚠️ `task=`, not `view=`: the settings form
+     * is set up by the controller.
      *
      * @var    string
      * @since  __DEPLOY_VERSION__
@@ -44,11 +41,10 @@ class CwmhealthController extends BaseController
     private const RETURN_VIEW = 'index.php?option=com_proclaim&task=cwmadmin.edit&id=1';
 
     /**
-     * Run one check on request, including the ones too expensive to run on load.
+     * Run one check on request.
      *
-     * ⚠️ The only path that evaluates a non-passive check. Nothing else in the
-     * component may call it, because everything else runs without someone
-     * having asked.
+     * ⚠️ The only path that may evaluate a non-passive check; everything else
+     * runs without someone having asked.
      *
      * @return  void
      *
@@ -94,9 +90,8 @@ class CwmhealthController extends BaseController
         $this->assertToken();
         $this->assertAdmin();
 
-        // Re-run rather than trusting a fingerprint from the request: what is
-        // stored has to be the finding as it is now, or a stale value could
-        // silence a state that never existed.
+        // ⚠️ Re-run rather than trust a fingerprint from the request, which
+        // could silence a state that never existed.
         $result = HealthRegistry::runOne($this->input->getCmd('check', ''));
 
         if ($result === null || $result->fingerprint === '') {
@@ -108,9 +103,8 @@ class CwmhealthController extends BaseController
         try {
             HealthQuietStore::quieten($result);
         } catch (\RuntimeException $e) {
-            // The store refuses to write over a params column it could not
-            // read, rather than trading the site's settings for a cleared
-            // banner. Say so instead of reporting a success that did nothing.
+            // The store refuses to write over unreadable params; say so
+            // rather than report a success that did nothing.
             $this->setRedirect(Route::_(self::RETURN_VIEW, false), Text::_('JBS_HEALTH_QUIET_SAVE_FAILED'), 'error');
 
             return;
@@ -144,12 +138,10 @@ class CwmhealthController extends BaseController
     }
 
     /**
-     * Refuse a request that did not come from a Proclaim screen.
+     * Refuse a request without a valid token.
      *
-     * Every task here is reached from a link on the report, so the token
-     * arrives in the query string. `checkToken()` alone looks only at POST and
-     * would reject all three -- the POST form is still accepted so a future
-     * button does not have to remember this.
+     * ⚠️ These tasks are reached from links, so the token is in the query
+     * string; `checkToken()` alone checks POST only. POST is still accepted.
      *
      * @return  void
      *

--- a/admin/src/Health/Check/ImageMigrationCheck.php
+++ b/admin/src/Health/Check/ImageMigrationCheck.php
@@ -24,11 +24,9 @@ use CWM\Component\Proclaim\Administrator\Helper\CwmImageMigration;
 use Joomla\CMS\Language\Text;
 
 /**
- * Studies, teachers and series whose images still sit in the old layout.
- *
- * Not a fault on its own -- the old paths keep resolving -- but the images
- * stay outside the structured `images/biblestudy/{type}/{alias}-{id}/` folders
- * until they are moved, which is what every later image feature assumes.
+ * Records whose images still sit outside the structured
+ * `images/biblestudy/{type}/{alias}-{id}/` folders. Not a fault: the old
+ * paths keep resolving.
  *
  * @since  __DEPLOY_VERSION__
  */
@@ -95,8 +93,7 @@ final class ImageMigrationCheck implements HealthCheckInterface
             $this->getId(),
             HealthStatus::Notice,
             Text::plural('JBS_HEALTH_IMAGE_MIGRATION_N', $counts['total']),
-            // Per type, so migrating one kind of record and not another still
-            // reads as a change rather than staying quiet on a stale total.
+            // Per type, so migrating one kind of record resurfaces the notice.
             $counts['studies'] . ':' . $counts['teachers'] . ':' . $counts['series'],
             'index.php?option=com_proclaim&task=cwmadmin.edit&id=1#imagetools',
             Text::_('JBS_HEALTH_IMAGE_TOOLS_ACTION')

--- a/admin/src/Health/Check/ImageWebPCheck.php
+++ b/admin/src/Health/Check/ImageWebPCheck.php
@@ -24,11 +24,8 @@ use CWM\Component\Proclaim\Administrator\Helper\CwmImageMigration;
 use Joomla\CMS\Language\Text;
 
 /**
- * Images with no WebP sibling built beside them.
- *
- * Nothing is broken without one -- the original still serves -- so this is a
- * notice. It is the derivative that has not been generated yet, not a missing
- * original.
+ * Images with no WebP sibling built beside them. Nothing is broken without
+ * one: the original still serves.
  *
  * @since  __DEPLOY_VERSION__
  */

--- a/admin/src/Health/Check/LegacyServersCheck.php
+++ b/admin/src/Health/Check/LegacyServersCheck.php
@@ -93,15 +93,10 @@ final class LegacyServersCheck implements HealthCheckInterface
         return new HealthResult(
             $this->getId(),
             HealthStatus::Warning,
-            // Text::plural(), not "server(s)" -- the dashboard banner describing
-            // this same finding pluralises properly, and the two sit minutes
-            // apart in the same workflow. The `_N` belongs to the key: plural()
-            // appends only the suffix, so the keys are ..._PENDING_N_1 and
-            // ..._PENDING_N_MORE.
+            // ⚠️ The `_N` belongs to the key passed in: plural() appends only
+            // the suffix, so the keys are ..._PENDING_N_1 and ..._N_MORE.
             Text::plural('JBS_HEALTH_LEGACY_SERVERS_PENDING_N', $pending['servers'], $pending['media']),
-            // Both counts, so migrating some of them -- or a restore adding
-            // more -- brings the notice back rather than leaving it quiet at a
-            // number that no longer describes the site.
+            // Both counts, so migrating some of them resurfaces the notice.
             $pending['servers'] . ':' . $pending['media'],
             'index.php?option=com_proclaim&view=cwmservers',
             Text::_('JBS_HEALTH_LEGACY_SERVERS_ACTION')

--- a/admin/src/Health/Check/MaxInputVarsCheck.php
+++ b/admin/src/Health/Check/MaxInputVarsCheck.php
@@ -27,24 +27,18 @@ use Joomla\Database\DatabaseInterface;
 /**
  * Whether the permissions grid still fits inside PHP's `max_input_vars`.
  *
- * ⚠️ This is the failure mode a health check exists for: PHP discards the
- * inputs past the limit without an error, so the save appears to succeed and
- * changes nothing. `CwmpermissionsModel` already renders one section per
- * request for exactly this reason, which brought the count down by a factor of
- * seventeen -- but the grid is one field per action per user group, so a site
- * with enough groups walks back into it.
+ * ⚠️ PHP discards inputs past the limit without an error, so the save appears
+ * to succeed and changes nothing. The grid is one field per action per user
+ * group, so enough groups breach it.
  *
  * @since  __DEPLOY_VERSION__
  */
 final class MaxInputVarsCheck implements HealthCheckInterface
 {
     /**
-     * Non-grid inputs the permissions form posts -- the section, the token,
-     * the task and Joomla's standard hidden fields.
-     *
-     * Deliberately generous. Being a little pessimistic about the overhead
-     * costs a notice on a site that would just have squeaked through; being
-     * optimistic costs a silent save failure.
+     * Non-grid inputs the permissions form posts. Deliberately generous:
+     * over-estimating costs a spurious notice, under-estimating costs a
+     * silent save failure.
      *
      * @var    int
      * @since  __DEPLOY_VERSION__
@@ -109,10 +103,8 @@ final class MaxInputVarsCheck implements HealthCheckInterface
         $limit = (int) \ini_get('max_input_vars');
 
         if ($limit <= 0) {
-            // The directive is compiled out or unreadable, so there is no
-            // number to compare against. Saying nothing is better than
-            // guessing at PHP's 1000 default and reporting a limit the host
-            // may not have.
+            // No number to compare against; guessing at PHP's 1000 default
+            // would report a limit the host may not have.
             return new HealthResult(
                 $this->getId(),
                 HealthStatus::Unknown,

--- a/admin/src/Health/Check/MissingImagesCheck.php
+++ b/admin/src/Health/Check/MissingImagesCheck.php
@@ -26,11 +26,8 @@ use Joomla\CMS\Language\Text;
 /**
  * Records whose image path points at a file that is not on disk.
  *
- * ⚠️ A strict subset of the records awaiting migration: the scan walks those
- * and asks whether each source file exists. Migration cannot move a file that
- * is not there, so these are the ones that will fail rather than merely wait
- * -- which is why this reports a warning where the migration check reports a
- * notice.
+ * ⚠️ A strict subset of the records awaiting migration. Migration cannot move
+ * a file that is not there, so these fail rather than wait.
  *
  * @since  __DEPLOY_VERSION__
  */

--- a/admin/src/Health/Check/PluginEnabledCheck.php
+++ b/admin/src/Health/Check/PluginEnabledCheck.php
@@ -25,18 +25,11 @@ use Joomla\CMS\Language\Text;
 use Joomla\Database\DatabaseInterface;
 
 /**
- * Whether a plugin Proclaim depends on is installed and enabled.
+ * Whether a plugin Proclaim depends on is installed and enabled. Disabling
+ * one breaks a feature with nothing on screen to say why.
  *
- * Disabling one of these breaks a feature silently -- turning off
- * `plg_content_scripturelinks` leaves the admin scripture tab dead with
- * nothing on screen to say why, because the tab reaches it through
- * `com_ajax`.
- *
- * ⚠️ The state is read from `#__extensions` rather than through
- * `PluginHelper::isEnabled()`. `PluginHelper` answers from the plugins loaded
- * for the running application, so it cannot tell "disabled" from "not
- * installed", and it is not usable from a task with no site context. The two
- * cases need different advice, so the check has to distinguish them.
+ * ⚠️ Read from `#__extensions`, not `PluginHelper::isEnabled()`, which answers
+ * only for the running application and cannot tell disabled from missing.
  *
  * @since  __DEPLOY_VERSION__
  */

--- a/admin/src/Health/Check/ServerConnectionCheck.php
+++ b/admin/src/Health/Check/ServerConnectionCheck.php
@@ -25,13 +25,10 @@ use CWM\Component\Proclaim\Administrator\Helper\Cwmparams;
 use Joomla\CMS\Language\Text;
 
 /**
- * Whether one media server can actually reach its platform.
+ * Whether one media server can reach its platform.
  *
- * ⚠️ The only check in the registry that is not passive, and the reason
- * `isPassive()` exists at all. Running it makes an outbound API call and, on
- * YouTube, spends quota -- so a health page that ran it on load would burn
- * quota by being opened, which is worst at exactly the moment someone opens
- * the page because something looks wrong.
+ * ⚠️ Not passive. Running it makes an outbound API call and, on YouTube,
+ * spends quota, so only an explicit request may run it.
  *
  * @since  __DEPLOY_VERSION__
  */
@@ -100,10 +97,8 @@ final class ServerConnectionCheck implements HealthCheckInterface
      */
     public function run(): HealthResult
     {
-        // GDPR mode is switched on to stop data leaving the server. A status
-        // page that made outbound calls anyway would be the exact surprise
-        // that setting is meant to prevent, so the test refuses rather than
-        // quietly ignoring it.
+        // ⚠️ GDPR mode exists to stop data leaving the server, so the test
+        // refuses rather than quietly ignoring it.
         if ($this->gdprMode()) {
             return new HealthResult(
                 $this->getId(),
@@ -157,9 +152,7 @@ final class ServerConnectionCheck implements HealthCheckInterface
         try {
             return (bool) Cwmparams::getAdmin()->params->get('gdpr_mode', '0');
         } catch (\Throwable) {
-            // Unreadable params are treated as GDPR mode off, matching every
-            // other reader of this setting. The button is still an explicit
-            // action by an administrator, not something that fires on its own.
+            // Unreadable params read as off, matching every other reader.
             return false;
         }
     }

--- a/admin/src/Health/HealthCheckInterface.php
+++ b/admin/src/Health/HealthCheckInterface.php
@@ -17,22 +17,20 @@ namespace CWM\Component\Proclaim\Administrator\Health;
 // phpcs:enable PSR1.Files.SideEffects
 
 /**
- * One thing the System Health view can report on.
+ * One thing the System Health report can check.
  *
- * ⚠️ A check answers about the site, never about the caller. It must not read
- * the identity, the session or the request, because the same check runs from
- * an admin page render, from a restore finishing, and from a scheduled task
- * with no user at all. Authorisation belongs to whatever displays the result.
+ * ⚠️ A check answers about the site, never the caller: no identity, session or
+ * request. Authorisation belongs to whatever displays the result.
  *
  * @since  __DEPLOY_VERSION__
  */
 interface HealthCheckInterface
 {
     /**
-     * Stable identifier, `group.slug`, used as the quieting key.
+     * Stable `group.slug` identifier.
      *
-     * ⚠️ It is stored in the database once a notice is quietened, so renaming
-     * one silently un-quietens every site that had.
+     * ⚠️ Stored as the quieting key, so renaming one un-quietens every site
+     * that had cleared it.
      *
      * @return  string
      *
@@ -41,7 +39,7 @@ interface HealthCheckInterface
     public function getId(): string;
 
     /**
-     * The section of the report this check appears under.
+     * The report section this check appears under.
      *
      * @return  HealthGroup
      *
@@ -50,7 +48,7 @@ interface HealthCheckInterface
     public function getGroup(): HealthGroup;
 
     /**
-     * Translated name of the check, shown whatever it reports.
+     * Translated name of the check.
      *
      * @return  string
      *
@@ -59,12 +57,10 @@ interface HealthCheckInterface
     public function getTitle(): string;
 
     /**
-     * Whether running this check is free of side effects and safe unprompted.
+     * Whether `run()` is free to call unprompted.
      *
-     * ⚠️ False means `run()` reaches the network, spends an API quota, or
-     * otherwise costs something. Those are evaluated only when a person asks
-     * for them by name -- never on a page render, and never from the scheduled
-     * re-check, which has no one to consent on its behalf.
+     * ⚠️ False means it reaches the network or spends quota, so only an
+     * explicit request may run it.
      *
      * @return  bool
      *

--- a/admin/src/Health/HealthGroup.php
+++ b/admin/src/Health/HealthGroup.php
@@ -17,12 +17,8 @@ namespace CWM\Component\Proclaim\Administrator\Health;
 // phpcs:enable PSR1.Files.SideEffects
 
 /**
- * The section of the health report a check belongs to.
- *
- * The full taxonomy is declared here even though the first release fills only
- * four of the nine sections. A later check picks its group from this list
- * instead of inventing a heading, which is what keeps the report readable as
- * it grows.
+ * The section of the health report a check belongs to. A new check picks from
+ * this list rather than inventing a heading.
  *
  * @since  __DEPLOY_VERSION__
  */

--- a/admin/src/Health/HealthQuietStore.php
+++ b/admin/src/Health/HealthQuietStore.php
@@ -22,19 +22,14 @@ use Joomla\Database\DatabaseInterface;
 use Joomla\Registry\Registry;
 
 /**
- * Which dashboard notices have been quietened, and against what finding.
+ * Check id to the fingerprint it was quietened against, in `#__bsms_admin`
+ * params under `health_quiet`. A fingerprint that no longer matches means the
+ * finding changed and the notice is live again.
  *
- * Stored as a single JSON object under `health_quiet` in the `#__bsms_admin`
- * params, mapping a check id to the fingerprint that was current when it was
- * quietened. A stored fingerprint that no longer matches means the finding
- * changed, so the notice is live again -- nothing has to expire it.
+ * ⚠️ Affects the dashboard only; the report renders every check regardless.
  *
- * ⚠️ Quietening only affects the dashboard. The System Health view renders
- * every check whatever this says, which is what makes clearing a banner safe.
- *
- * The map is kept as an encoded string rather than a nested Registry node
- * because check ids contain dots (`content.legacy-servers`), and Registry
- * treats a dot as a path separator.
+ * ⚠️ Encoded as a JSON string, not a Registry node: check ids contain dots and
+ * Registry reads a dot as a path separator.
  *
  * @since  __DEPLOY_VERSION__
  */
@@ -49,10 +44,8 @@ final class HealthQuietStore
     public const PARAM_KEY = 'health_quiet';
 
     /**
-     * Whether this result should be hidden from the dashboard.
-     *
-     * A passing result is never "quiet" -- it has no fingerprint, so there is
-     * nothing to compare and nothing to suppress.
+     * Whether this result is hidden from the dashboard. A result with no
+     * fingerprint never is.
      *
      * @param   HealthResult  $result  The result to test.
      *
@@ -121,8 +114,8 @@ final class HealthQuietStore
      */
     public static function read(): array
     {
-        // An unreadable row means nothing is quietened, which errs towards
-        // showing notices rather than hiding them.
+        // Unreadable params mean nothing is quietened, erring towards showing
+        // notices rather than hiding them.
         $raw = (string) (self::readParams()?->get(self::PARAM_KEY, '') ?? '');
 
         if ($raw === '') {
@@ -132,10 +125,8 @@ final class HealthQuietStore
         try {
             $decoded = json_decode($raw, true, 512, JSON_THROW_ON_ERROR);
         } catch (\JsonException $e) {
-            // A blob we cannot read is treated as nothing quietened, which
-            // errs towards showing notices rather than hiding them. Logged
-            // because the alternative reading -- everything silently
-            // un-quietened -- looks like the feature stopped working.
+            // Logged: silently un-quietening everything reads as the feature
+            // having stopped working.
             Log::add(
                 'Proclaim health quieting state was unreadable and has been ignored: ' . $e->getMessage(),
                 Log::WARNING,
@@ -169,10 +160,8 @@ final class HealthQuietStore
     {
         $params = self::readParams();
 
-        // ⚠️ Refuse rather than overwrite. Writing here means re-serialising
-        // the whole params column, so proceeding from the empty fallback would
-        // trade every stored setting for a cosmetic preference. Quietening a
-        // banner is not worth that; repairing the row is a separate job.
+        // ⚠️ A write re-serialises the whole params column, so writing from
+        // the empty fallback would discard every stored setting.
         if ($params === null) {
             throw new \RuntimeException('Proclaim admin params are unreadable, so quieting state cannot be saved.');
         }
@@ -189,11 +178,10 @@ final class HealthQuietStore
     }
 
     /**
-     * The admin params row, read fresh, or null when it cannot be parsed.
+     * The admin params row, or null when it cannot be parsed.
      *
-     * Not taken from `Cwmparams::getAdmin()`: that caches the row for the
-     * request, so a write followed by a read in the same request would return
-     * the pre-write state.
+     * ⚠️ Read fresh, not via `Cwmparams::getAdmin()`, which caches for the
+     * request and would return the pre-write state after a write.
      *
      * @return  ?Registry
      *
@@ -211,13 +199,9 @@ final class HealthQuietStore
         try {
             return new Registry($db->loadResult() ?: '{}');
         } catch (\RuntimeException $e) {
-            // ⚠️ Registry does not shrug this off. A truncated write leaves a
-            // string that still starts with `{`, and Json::stringToObject()
-            // throws for exactly that -- the case Cwmparams::getAdmin() and
-            // setCompParams() both already guard. This runs on every admin's
-            // dashboard, so an unguarded throw would turn a half-written row
-            // into a dead screen.
-            //
+            // ⚠️ Registry throws on a truncated blob that still starts with
+            // `{`. This is read on every admin's dashboard, so an unguarded
+            // throw would turn a half-written row into a dead screen.
             Log::add(
                 'Proclaim admin params were unreadable while checking health quieting: ' . $e->getMessage(),
                 Log::WARNING,

--- a/admin/src/Health/HealthRegistry.php
+++ b/admin/src/Health/HealthRegistry.php
@@ -28,12 +28,8 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Log\Log;
 
 /**
- * Every check the System Health view knows about.
- *
- * The registry is the one place that decides what runs unprompted. Callers ask
- * for `runPassive()` and get an answer for every check, with the active ones
- * reported as `Unknown` rather than skipped -- a check missing from the report
- * looks like a check that passed.
+ * Every check the System Health report knows about, and the only place that
+ * decides what runs unprompted.
  *
  * @since  __DEPLOY_VERSION__
  */
@@ -42,9 +38,8 @@ final class HealthRegistry
     /**
      * Build the list of checks.
      *
-     * ⚠️ Not cached. Some checks are per-record -- one connection test per
-     * media server -- so the list itself reflects the current site, and a
-     * server added since the last page load has to appear.
+     * ⚠️ Not cached: some are per-record, so a server added since the last
+     * page load has to appear.
      *
      * @return  HealthCheckInterface[]
      *
@@ -56,11 +51,8 @@ final class HealthRegistry
             new MaxInputVarsCheck(),
             new PluginEnabledCheck('content', 'scripturelinks', 'JBS_HEALTH_PLUGIN_SCRIPTURELINKS'),
             new LegacyServersCheck(),
-            // ⚠️ Together these three walk every study, teacher and series
-            // row and stat the files they name — around 50ms on a library of
-            // 1,000 records. Cheap enough to run on a page render, but the
-            // next filesystem check worth adding should be measured rather
-            // than assumed.
+            // ⚠️ These three stat every study, teacher and series image —
+            // ~50ms per 1,000 records. Measure the next filesystem check too.
             new ImageMigrationCheck(),
             new MissingImagesCheck(),
             new ImageWebPCheck(),
@@ -78,13 +70,10 @@ final class HealthRegistry
     }
 
     /**
-     * Run everything that is safe to run without being asked.
+     * Run everything safe to run unprompted; report the rest as `Unknown`.
      *
-     * `$checks` exists so the guarantee below can be tested against a check
-     * that records whether it was run. Which checks are registered depends on
-     * the site's data -- a site with no API-backed server has no active check
-     * at all -- and a test that silently exercises nothing is how this
-     * guarantee would quietly stop holding.
+     * `$checks` is a seam for tests: which checks exist depends on site data,
+     * so a test using the registry can exercise nothing and still pass.
      *
      * @param   ?HealthCheckInterface[]  $checks  The checks to run, or null for the registry.
      *
@@ -110,10 +99,8 @@ final class HealthRegistry
     }
 
     /**
-     * Run one check by id, active or not.
-     *
-     * Only reached from an explicit request to test something, which is the
-     * consent an active check needs.
+     * Run one check by id, active or not. ⚠️ Only reachable from an explicit
+     * request, which is the consent an active check needs.
      *
      * @param   string  $id  The check id.
      *
@@ -148,10 +135,8 @@ final class HealthRegistry
     }
 
     /**
-     * Run a check, turning a thrown error into a reportable result.
-     *
-     * A check that fatals must not take the health page down with it -- the
-     * page is what someone opens when the site is already misbehaving.
+     * Run a check, turning a throw into a reportable result. ⚠️ A check that
+     * fatals must not take the report down with it.
      *
      * @param   HealthCheckInterface  $check  The check to run.
      *
@@ -190,9 +175,6 @@ final class HealthRegistry
         try {
             return CWMAddon::getConnectionTestableServers();
         } catch (\Throwable) {
-            // A missing or unreadable servers table is itself something other
-            // checks report on. Returning nothing here keeps the rest of the
-            // report available instead of failing the whole page.
             return [];
         }
     }

--- a/admin/src/Health/HealthResult.php
+++ b/admin/src/Health/HealthResult.php
@@ -17,16 +17,13 @@ namespace CWM\Component\Proclaim\Administrator\Health;
 // phpcs:enable PSR1.Files.SideEffects
 
 /**
- * What one check reports about one thing.
+ * What one check reports.
  *
- * The fingerprint is the shape of the finding rather than the fact of it --
- * "10 legacy servers, 2008 media rows", not "there is a problem". Quietening a
- * dashboard notice stores this string, and the notice stays quiet only while
- * the check keeps producing it. An eleventh legacy server changes the
- * fingerprint and the notice comes back on its own.
+ * The fingerprint is the shape of the finding ("10 servers, 2008 media"), not
+ * the fact of it. A quietened notice returns as soon as it changes.
  *
- * A passing check has no fingerprint. There is nothing to quieten, and storing
- * one would mean a later failure could be silenced by a state that was fine.
+ * ⚠️ A passing result has no fingerprint: there is nothing to quieten, and
+ * storing one would let a later failure be silenced by a state that was fine.
  *
  * @since  __DEPLOY_VERSION__
  */
@@ -55,11 +52,8 @@ final readonly class HealthResult
     }
 
     /**
-     * Whether this result is something the dashboard should raise.
-     *
-     * `Unknown` is deliberately not a nag. An active check that has never been
-     * run has not found anything, and a dashboard banner saying so would fire
-     * on every site that never pressed the button.
+     * Whether the dashboard should raise this. ⚠️ `Unknown` is not a nag: an
+     * untested active check has not found anything.
      *
      * @return  bool
      *

--- a/admin/src/Health/HealthStatus.php
+++ b/admin/src/Health/HealthStatus.php
@@ -17,11 +17,8 @@ namespace CWM\Component\Proclaim\Administrator\Health;
 // phpcs:enable PSR1.Files.SideEffects
 
 /**
- * The state a health check reports.
- *
- * `Unknown` is a real answer rather than a missing one: an active check has
- * not been run, so nothing is known about it. Reporting that as `Ok` would
- * claim a passing result nobody measured.
+ * The state a health check reports. `Unknown` is a real answer: nothing was
+ * measured, which is not the same as passing.
  *
  * @since  __DEPLOY_VERSION__
  */

--- a/admin/src/Model/CwmhealthModel.php
+++ b/admin/src/Model/CwmhealthModel.php
@@ -31,12 +31,10 @@ use Joomla\CMS\MVC\Model\BaseDatabaseModel;
 class CwmhealthModel extends BaseDatabaseModel
 {
     /**
-     * Every check, with its current result, grouped by section.
+     * Every check with its current result, grouped by section.
      *
-     * Active checks are included and reported as not tested. The view is the
-     * permanent record, so a check it declines to run still has to be listed
-     * -- a report that omitted them would read as a clean bill of health it
-     * never established.
+     * ⚠️ Active checks are listed as not tested rather than omitted; a missing
+     * check reads as a passing one.
      *
      * @return  array<string, array<int, array{check: HealthCheckInterface, result: HealthResult, quiet: bool}>>
      *
@@ -61,8 +59,7 @@ class CwmhealthModel extends BaseDatabaseModel
             ];
         }
 
-        // Declaration order of HealthGroup, so the report reads the same way
-        // every time regardless of which checks happen to exist.
+        // HealthGroup declaration order, so the report reads the same every time.
         $ordered = [];
 
         foreach (HealthGroup::cases() as $group) {

--- a/tests/e2e/admin/health.spec.js
+++ b/tests/e2e/admin/health.spec.js
@@ -71,16 +71,26 @@ test.describe('System Health', () => {
 
         await clear.first().click();
 
-        await page.goto(CPANEL);
-        await expect(page.locator('a[href*="task=cwmhealth.quieten"]')).toHaveCount(0);
+        try {
+            await page.goto(CPANEL);
+            await expect(page.locator('a[href*="task=cwmhealth.quieten"]')).toHaveCount(0);
 
-        // Cleared on the dashboard, still on the record.
-        await page.goto(ADMIN);
-        const restore = panel(page).locator('a[href*="task=cwmhealth.restore"]').first();
-        await expect(restore).toBeVisible({ timeout: 20000 });
+            // Cleared on the dashboard, still on the record.
+            await page.goto(ADMIN);
+            await expect(panel(page).locator('a[href*="task=cwmhealth.restore"]').first())
+                .toBeVisible({ timeout: 20000 });
+        } finally {
+            // ⚠️ Restore even when the assertions above fail. Quietening
+            // persists in the database, so a failed run otherwise leaves the
+            // banner cleared and the *next* run fails on its own guard
+            // instead, reporting a state problem as a code problem.
+            await page.goto(ADMIN);
+            const restore = panel(page).locator('a[href*="task=cwmhealth.restore"]').first();
 
-        // Put the site back the way it was found.
-        await restore.click();
+            if (await restore.count()) {
+                await restore.click();
+            }
+        }
 
         await page.goto(CPANEL);
         await expect(page.locator('a[href*="task=cwmhealth.quieten"]').first()).toBeVisible();


### PR DESCRIPTION
Follow-up to the System Health work on #1949. No behaviour change in the component; one real fix in the e2e spec.

### What changed

The sixteen System Health files carried **275 lines of discretionary prose** — docblocks defending design choices, restating the interface contract in each implementation, and teaching the domain above methods whose names already said it. Now 182, a net 100 lines removed.

The measure, because percentage-of-comment-lines is misleading (mandatory `@return`/`@since` inflate it, and a five-method interface reads as 75% comments while being perfectly correct): **prose lines beyond one summary per documented member**. That count is now 32.

### The invariants stayed — and got sharper

All 32 remaining are two-line ⚠️ notes a maintainer could otherwise break:

- an active check must never run unprompted, because it spends API quota
- `where()` applies its glue to everything added after it
- `Registry` throws on a truncated params blob

Counting the marker across the changed files, ⚠️ went from **13 to 27**. The trim did not thin the warnings out; it turned defensive prose into flagged invariants, which is the shape that survives a future edit.

That matters because a mechanical comment strip on this repo previously produced ~60% false positives. This was measured per member rather than pattern-matched, and `lint:comments` passed throughout — though that only enforces citations, so density was judged by hand.

### The one behavioural fix

`tests/e2e/admin/health.spec.js` now restores in a `finally`.

Quietening persists in the database, so a failed assertion left the banner cleared and the **next** run failed on its own guard instead — reporting a state problem as a code problem. That happened while trimming this, which is how it was found.

### Testing

- `composer test:unit` — 2996 tests, 6803 assertions
- `composer lint` — 0 of 652
- `composer lint:comments` — clean
- Comment-only changes verified by filtering the diff to non-comment changed lines; the sole exception is the e2e `finally`

🤖 Generated with [Claude Code](https://claude.com/claude-code)