### PR TITLE
fix(js): take the CSRF token from script options, not from the DOM

### DIFF
--- a/build/media_source/js/asset-fix.es6.js
+++ b/build/media_source/js/asset-fix.es6.js
@@ -313,11 +313,13 @@ class ProclaimAssetFix {
         url.searchParams.set('task', `cwmassets.${task}`);
         url.searchParams.set('format', 'json');
 
-        // Add CSRF token
-        const tokenInput = document.querySelector('input[name^="csrf.token"]')
-                          || document.querySelector('input[name][value="1"]');
-        if (tokenInput) {
-            url.searchParams.set(tokenInput.name, '1');
+        // The token's field name is a random hash, so it can only come from
+        // script options. Reading it off the DOM meant matching on value="1",
+        // which is whichever input happens to come first.
+        const token = Joomla.getOptions('csrf.token');
+
+        if (token) {
+            url.searchParams.set(token, '1');
         }
 
         // Add additional params

--- a/build/media_source/js/backup-restore.es6.js
+++ b/build/media_source/js/backup-restore.es6.js
@@ -24,7 +24,6 @@
             this.liveRegion = null;
             this.triggerElement = null;
             this.isCancelled = false;
-            this.token = Joomla.getOptions('csrf.token') || document.querySelector(`input[name^="${Joomla.getOptions('csrf.token', '')}"]`)?.name || '';
         }
 
         /**


### PR DESCRIPTION
Fixes #1977.

### `asset-fix.js`

```js
const tokenInput = document.querySelector('input[name^="csrf.token"]')
                  || document.querySelector('input[name][value="1"]');
```

The first selector **cannot match** — Joomla names the token field with a random 32-character hash, so nothing is ever called `csrf.token`. Every request fell through to the second, which takes the *first* input in the document with value `"1"`.

That works on the Assets screen only because the page happens to have exactly one input. Anywhere else, or the moment anyone adds a checkbox or hidden field above line 209, the request would carry some other field's name as the token and come back `JINVALID_TOKEN` — from a change that had nothing to do with tokens.

Twenty-five other places in this codebase already use `Joomla.getOptions('csrf.token')`. This was the only one that did not, and the script already declares `core` as a dependency, so the accessor is available.

### `backup-restore.js`

Same shape, in a **dead assignment**:

```js
this.token = Joomla.getOptions('csrf.token')
  || document.querySelector(`input[name^="${Joomla.getOptions('csrf.token', '')}"]`)?.name || '';
```

⚠️ The fallback interpolates the *empty default* into the selector, so it becomes `input[name^=""]` — which matches the first named input on the page and takes its name as the token.

`this.token` is never read anywhere in the file, so it is removed rather than repaired.

**`getToken()` is deliberately left alone.** It looks the input up by the token name and returns its **value** for the `X-CSRF-Token` header, which is what that header wants. Different job, correct as written — and this file is on the backup/restore path, so it is not a place to tidy speculatively.

### Testing

- `npm run lint:js` — clean at `--max-warnings=0`
- `npm test` — 17 suites, 235 passed
- `npm run build:js` — rebuilt; confirmed the built output uses `getOptions` and the dead selector is gone
- `composer lint` 0 of 658, `lint:comments` clean

Built JS is not committed — `/media/js/` is gitignored and produced at package time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)