### PR TITLE
fix(install): stop uninstall fatalling half way, and clean up proclaim.script.php

### DIFF
--- a/admin/src/Model/CwmlocationwizardModel.php
+++ b/admin/src/Model/CwmlocationwizardModel.php
@@ -300,6 +300,8 @@ class CwmlocationwizardModel extends BaseDatabaseModel
      *
      * @return  void
      *
+     * @throws  \RuntimeException  When the rules will not encode, rather than
+     *                             storing an empty rules column.
      * @since   10.1.0
      */
     private function applyPermissions(array $permissions): void
@@ -356,10 +358,25 @@ class CwmlocationwizardModel extends BaseDatabaseModel
             }
         }
 
+        // ⚠️ Refuse rather than write what will not encode. json_encode()
+        // returns false, quote(false) is an empty string, and an empty rules
+        // column is not a harmless value here — it drops every permission on
+        // the component asset, which presents later as a 404 nobody links back
+        // to this wizard.
+        try {
+            $encoded = json_encode($rules, JSON_THROW_ON_ERROR);
+        } catch (\JsonException $e) {
+            throw new \RuntimeException(
+                'Refusing to write permissions that could not be encoded: ' . $e->getMessage(),
+                0,
+                $e
+            );
+        }
+
         // Save updated rules
         $query = $db->createQuery()
             ->update($db->quoteName('#__assets'))
-            ->set($db->quoteName('rules') . ' = ' . $db->quote(json_encode($rules)))
+            ->set($db->quoteName('rules') . ' = ' . $db->quote($encoded))
             ->where($db->quoteName('id') . ' = ' . (int) $asset->id);
 
         $db->setQuery($query);

--- a/proclaim.script.php
+++ b/proclaim.script.php
@@ -880,7 +880,7 @@ class com_proclaimInstallerScript extends InstallerScript
                         . ' DROP COLUMN ' . $db->quoteName($column)
                     );
                     $db->execute();
-                } catch (\Exception $e) {
+                } catch (\Exception) {
                     // Ignore — column may have been dropped by concurrent request
                 }
             }
@@ -913,7 +913,7 @@ class com_proclaimInstallerScript extends InstallerScript
                             . ' ADD COLUMN ' . $db->quoteName($column) . ' ' . $definition
                         );
                         $db->execute();
-                    } catch (\Exception $e) {
+                    } catch (\Exception) {
                         // Ignore
                     }
                 }
@@ -997,7 +997,7 @@ class com_proclaimInstallerScript extends InstallerScript
             $columns = $this->dbo->getTableColumns($table);
 
             return array_keys($columns);
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             return [];
         }
     }
@@ -1019,7 +1019,7 @@ class com_proclaimInstallerScript extends InstallerScript
             $tables = $this->dbo->getTableList();
 
             return \in_array($table, $tables, true);
-        } catch (Exception $e) {
+        } catch (Exception) {
             return false;
         }
     }
@@ -1145,7 +1145,7 @@ class com_proclaimInstallerScript extends InstallerScript
 
                 return;
             }
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             // Cleanup only. The unique key carries the lookups either way, so a
             // failure here must not take down an otherwise successful update.
         }
@@ -1321,7 +1321,7 @@ class com_proclaimInstallerScript extends InstallerScript
 
                     return;
                 }
-            } catch (Throwable $e) {
+            } catch (Throwable) {
                 // If something breaks, we will fall through
             }
         }
@@ -1692,12 +1692,12 @@ class com_proclaimInstallerScript extends InstallerScript
                     try {
                         $this->dbo->setQuery($singleQuery);
                         $this->dbo->execute();
-                    } catch (\Exception $e) {
+                    } catch (\Exception) {
                         // Continue dropping remaining tables
                     }
                 }
             }
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             // If anything fails, don't block uninstall
         }
     }
@@ -1717,7 +1717,7 @@ class com_proclaimInstallerScript extends InstallerScript
                 ->where($this->dbo->quoteName('language_extension') . ' = ' . $this->dbo->quote('com_proclaim'));
             $this->dbo->setQuery($query);
             $this->dbo->execute();
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             // Don't block uninstall
         }
     }
@@ -2300,7 +2300,7 @@ class com_proclaimInstallerScript extends InstallerScript
                         ->where($db->quoteName('type') . ' = ' . $db->quote('component'));
                     $db->setQuery($update)->execute();
                 }
-            } catch (\Exception $e) {
+            } catch (\Exception) {
                 // Non-critical — help will fall back to default behavior
             }
         }
@@ -2322,7 +2322,7 @@ class com_proclaimInstallerScript extends InstallerScript
                         'warning'
                     );
                 }
-            } catch (\Exception $e) {
+            } catch (\Exception) {
                 // Silently ignore detection failures during install
             }
         }
@@ -2665,7 +2665,7 @@ class com_proclaimInstallerScript extends InstallerScript
             $language = Factory::getApplication()->getLanguage();
             $language->load('com_proclaim', JPATH_ADMINISTRATOR . '/components/com_proclaim', 'en-GB', true);
             $language->load('com_proclaim', JPATH_ADMINISTRATOR . '/components/com_proclaim', null, true);
-        } catch (Exception $e) {
+        } catch (Exception) {
             return;
         }
 
@@ -2783,7 +2783,10 @@ class com_proclaimInstallerScript extends InstallerScript
             try {
                 $this->dbo->execute();
             } catch (RuntimeException $e) {
-                Factory::getApplication()->enqueueMessage('Failed to execute Admin Menu removal', 'error');
+                Factory::getApplication()->enqueueMessage(
+                    'Failed to execute Admin Menu removal: ' . $e->getMessage(),
+                    'error'
+                );
             }
 
             // Update Site Menus for BibleStudy to Proclaim
@@ -2894,7 +2897,10 @@ class com_proclaimInstallerScript extends InstallerScript
         try {
             $this->dbo->execute();
         } catch (RuntimeException $e) {
-            Factory::getApplication()->enqueueMessage("Failed to execute $element removal", 'error');
+            Factory::getApplication()->enqueueMessage(
+                "Failed to execute $element removal: " . $e->getMessage(),
+                'error'
+            );
         }
     }
 
@@ -2972,7 +2978,7 @@ class com_proclaimInstallerScript extends InstallerScript
                     ->bind(':filename', $filename);
                 $db->setQuery($query);
                 $records = $db->loadObjectList();
-            } catch (\Exception $e) {
+            } catch (\Exception) {
                 continue;
             }
 
@@ -2994,7 +3000,7 @@ class com_proclaimInstallerScript extends InstallerScript
                         ->bind(':id', $record->id, ParameterType::INTEGER);
                     $db->setQuery($delete)->execute();
                     $removed[] = $filename . ' (record)';
-                } catch (\Exception $e) {
+                } catch (\Exception) {
                     $customised = true;
                 }
             }
@@ -3052,7 +3058,7 @@ class com_proclaimInstallerScript extends InstallerScript
                     ->from($db->quoteName('#__bsms_templates'))
             );
             $templates = $db->loadObjectList();
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             return 0;
         }
 
@@ -3100,7 +3106,7 @@ class com_proclaimInstallerScript extends InstallerScript
                     ->bind(':id', $template->id, ParameterType::INTEGER);
                 $db->setQuery($update)->execute();
                 $changed++;
-            } catch (\Exception $e) {
+            } catch (\Exception) {
                 // A template we cannot rewrite is left as it was.
                 continue;
             }
@@ -3147,7 +3153,7 @@ class com_proclaimInstallerScript extends InstallerScript
                     $db->execute();
                 }
             }
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             // Non-fatal — column may already be gone
         }
     }

--- a/proclaim.script.php
+++ b/proclaim.script.php
@@ -590,8 +590,7 @@ class com_proclaimInstallerScript extends InstallerScript
      * Run a legacy migration, or record why it was skipped.
      *
      * Wraps the version gate and the timing in one place so the report can say
-     * what happened. Before this, an update that did nothing looked exactly like
-     * an update that did everything: a spinner, then silence.
+     * what happened rather than leaving a spinner and silence.
      *
      * A step that throws is recorded and the update carries on. None of these is
      * load-bearing enough to abandon an otherwise successful update over, and a
@@ -716,11 +715,10 @@ class com_proclaimInstallerScript extends InstallerScript
     /**
      * Whether a migration first shipped in `$version` still has work to do here.
      *
-     * ⚠️ A migration that ran on the update that introduced it does not need to
-     * run again, but nothing recorded that it had. With no gate, a 10.5.7 site
-     * re-ran every migration written since 10.0 — nine of them, each walking
-     * whole tables to discover there was nothing to do. That is what made
-     * updates take minutes on a site with real content.
+     * ⚠️ Nothing records that a migration already ran on the update that
+     * introduced it. Without this gate every migration written since 10.0
+     * replays on every update, each walking whole tables to find nothing to do
+     * — minutes of it on a site with real content.
      *
      * ⚠️ An unknown source version returns true. Skipping a migration that was
      * needed loses data; running one that was not costs time.
@@ -2923,13 +2921,15 @@ class com_proclaimInstallerScript extends InstallerScript
     /**
      * Remove the stray template layouts that shipped by accident.
      *
-     * `default_easy.php` was committed in 2019 and carried along by folder
-     * renames; `default_fluidsermonlist.php` and `default_fluidsermondetail.php`
-     * were never reachable because no templatecode record ever named them. The
-     * install SQL also seeded an `easy` templatecode row whose stored PHP still
-     * calls `JHtml`, removed in Joomla 4 — and both `CwmtemplatecodeTable::store()`
-     * and the backup restore rewrite the layout file from that row, so saving the
-     * record or restoring a backup replaced a working layout with fatal code.
+     * `default_easy.php`, `default_fluidsermonlist.php` and
+     * `default_fluidsermondetail.php` are named by no templatecode record, so
+     * nothing can reach them.
+     *
+     * ⚠️ Deleting the files is not enough. The install SQL seeds an `easy`
+     * templatecode row whose stored PHP calls `JHtml`, gone since Joomla 4, and
+     * both `CwmtemplatecodeTable::store()` and the backup restore rewrite the
+     * layout file from that row — so saving the record or restoring a backup
+     * puts the fatal code back.
      *
      * A record whose code no longer carries the `JHtml` signature has been edited
      * by the site and is left alone, along with the file it owns.

--- a/proclaim.script.php
+++ b/proclaim.script.php
@@ -3155,30 +3155,21 @@ class com_proclaimInstallerScript extends InstallerScript
      * Drop legacy/orphaned Proclaim tables that the current codebase no
      * longer references.
      *
-     * Some of these have been targeted by old migration files
-     * (10.1.0-20260228, 10.1.0-20260301), but Joomla skips already-applied
-     * migrations on upgrades that jump multiple versions, so sites that
-     * went straight from 10.0 → 10.2/10.3 still carry the rows. Others
-     * (e.g. `jbsbackup_timeset`) are pre-10.0 leftovers never covered by
-     * any migration.
+     * Done here rather than in migration SQL because Joomla skips
+     * already-applied migrations on upgrades that jump versions, so a site
+     * that went straight from 10.0 to 10.2/10.3 still carries rows the 10.1.0
+     * files were meant to remove. Others, `jbsbackup_timeset` among them,
+     * predate 10.0 and no migration ever covered them.
      *
-     * Each candidate has been verified against the live codebase: not
-     * referenced in admin/, site/, libraries/, plugins/, or modules/.
-     * `#__bsms_version` is intentionally NOT in this list — it is read by the
-     * v7→v10 upgrade detector.
+     * A table earns a place here by being unreferenced across admin/, site/,
+     * libraries/, plugins/ and modules/ — but unreferenced is not sufficient:
      *
-     * ⚠️ `#__bsms_styles` was described here as the active template-styles
-     * store. It never was on any site this code installs: the install schema
-     * has never created it, only the uninstall SQL names it, and its last two
-     * readers — an exporter branch and a helper with no callers — are gone.
-     * Custom CSS lives in params instead, `#__bsms_admin` site-wide and
-     * `#__bsms_templates` per template, and has since 10.5.8.
+     * ⚠️ `#__bsms_version` is read by the v7→v10 upgrade detector.
      *
-     * ⚠️ It is still deliberately absent from the list below. No migration ever
-     * moved its rows into those params, so a site upgraded from 7.x may hold
-     * the only copy of its stylesheets there. Dropping the table would destroy
-     * them. Retiring the code that read it is safe; dropping the table needs a
-     * migration first.
+     * ⚠️ `#__bsms_styles` is deliberately absent. Nothing reads it any more,
+     * yet no migration ever moved its rows into the params that replaced it,
+     * so a site upgraded from 7.x may hold the only copy of its stylesheets
+     * there. Dropping it needs a migration first.
      *
      * @return  void
      *

--- a/proclaim.script.php
+++ b/proclaim.script.php
@@ -107,11 +107,12 @@ class com_proclaimInstallerScript extends InstallerScript
     protected DatabaseInterface|null $dbo;
 
     /**
-     * Minimum PHP version required to install the extension
+     * Log category for the install record.
      *
-     * @var    string
-     * @since  3.6
+     * @since  10.5.9
      */
+    private const INSTALL_LOG = 'com_proclaim.install';
+
     /**
      * The version this update is coming from, read before Joomla overwrites it.
      *
@@ -122,13 +123,6 @@ class com_proclaimInstallerScript extends InstallerScript
      * @var    string
      * @since  10.5.9
      */
-    /**
-     * Log category for the install record.
-     *
-     * @since  10.5.9
-     */
-    private const INSTALL_LOG = 'com_proclaim.install';
-
     private string $fromVersion = '';
 
     /**
@@ -171,6 +165,12 @@ class com_proclaimInstallerScript extends InstallerScript
      */
     private float $startedAt = 0.0;
 
+    /**
+     * Minimum PHP version required to install the extension
+     *
+     * @var    string
+     * @since  3.6
+     */
     protected $minimumPhp = '8.3.0';
 
     /**
@@ -2924,16 +2924,6 @@ class com_proclaimInstallerScript extends InstallerScript
     }
 
     /**
-     * Migrate studyimage param values to thumbnailm column
-     *
-     * Messages that only have a studyimage (stock image) but no thumbnailm
-     * need the value preserved since the studyimage field is being removed.
-     *
-     * @return void
-     *
-     * @since 10.1.0
-     */
-    /**
      * Remove the stray template layouts that shipped by accident.
      *
      * `default_easy.php` was committed in 2019 and carried along by folder
@@ -3069,7 +3059,11 @@ class com_proclaimInstallerScript extends InstallerScript
         }
 
         foreach ($templates as $template) {
-            $params = json_decode((string) $template->params, true);
+            try {
+                $params = json_decode((string) $template->params, true, 512, JSON_THROW_ON_ERROR);
+            } catch (\JsonException) {
+                continue;
+            }
 
             if (!\is_array($params)) {
                 continue;
@@ -3343,6 +3337,16 @@ class com_proclaimInstallerScript extends InstallerScript
         }
     }
 
+    /**
+     * Migrate studyimage param values to thumbnailm column
+     *
+     * Messages that only have a studyimage (stock image) but no thumbnailm
+     * need the value preserved since the studyimage field is being removed.
+     *
+     * @return void
+     *
+     * @since 10.1.0
+     */
     private function migrateStudyImageParams(): void
     {
         $db    = Factory::getContainer()->get(DatabaseInterface::class);
@@ -3394,7 +3398,15 @@ class com_proclaimInstallerScript extends InstallerScript
 
             // Update thumbnailm and remove studyimage from params
             unset($params['studyimage']);
-            $newParams = json_encode($params);
+
+            try {
+                $newParams = json_encode($params, JSON_THROW_ON_ERROR);
+            } catch (\JsonException) {
+                // Without the flag this returned false, which quoted to an empty
+                // string and wrote it over the row's entire params blob. Skip the
+                // row instead, matching the decode above.
+                continue;
+            }
 
             $update = $db->getQuery(true)
                 ->update($db->qn('#__bsms_studies'))
@@ -3501,9 +3513,18 @@ class com_proclaimInstallerScript extends InstallerScript
                     ],
                 ];
 
+                try {
+                    $encoded = json_encode($links, JSON_THROW_ON_ERROR);
+                } catch (\JsonException) {
+                    // Legacy rows can hold bytes that will not encode. Leaving the
+                    // link where it is beats counting the row as migrated and
+                    // storing an empty string.
+                    continue;
+                }
+
                 $update = $db->getQuery(true)
                     ->update($db->quoteName('#__bsms_podcast'))
-                    ->set($db->quoteName('platform_links') . ' = ' . $db->quote(json_encode($links)))
+                    ->set($db->quoteName('platform_links') . ' = ' . $db->quote($encoded))
                     ->where($db->quoteName('id') . ' = ' . (int) $row->id);
                 $db->setQuery($update);
                 $db->execute();

--- a/proclaim.script.php
+++ b/proclaim.script.php
@@ -1422,6 +1422,7 @@ class com_proclaimInstallerScript extends InstallerScript
      *
      * @return  void
      *
+     * @throws Exception
      * @since   10.5.1
      */
     private function withoutCacheHousekeepingNoise(callable $operation): void
@@ -1494,6 +1495,7 @@ class com_proclaimInstallerScript extends InstallerScript
      *
      * @return  void
      *
+     * @throws Exception
      * @since   10.5.0
      */
     private function clearCaches(): void
@@ -3253,6 +3255,7 @@ class com_proclaimInstallerScript extends InstallerScript
      *
      * @return  void
      *
+     * @throws Exception
      * @since   10.1.0
      */
     private function ensurePrimaryKeys(): void
@@ -3345,6 +3348,7 @@ class com_proclaimInstallerScript extends InstallerScript
      *
      * @return void
      *
+     * @throws Exception
      * @since 10.1.0
      */
     private function migrateStudyImageParams(): void
@@ -3436,6 +3440,7 @@ class com_proclaimInstallerScript extends InstallerScript
      *
      * @return  void
      *
+     * @throws Exception
      * @since   10.1.0
      */
     private function migratePodcastAlternateLinks(): void
@@ -3555,6 +3560,7 @@ class com_proclaimInstallerScript extends InstallerScript
      *
      * @return void
      *
+     * @throws Exception
      * @since 10.1.0
      */
     private function migratePodcastImageField(): void
@@ -3598,6 +3604,7 @@ class com_proclaimInstallerScript extends InstallerScript
      *
      * @return void
      *
+     * @throws Exception
      * @since 10.1.0
      */
     private function migratePodcastLinkToMenuItem(): void
@@ -3735,6 +3742,7 @@ class com_proclaimInstallerScript extends InstallerScript
      *
      * @return  void
      *
+     * @throws Exception
      * @since  10.3.0
      */
     private function migrateScriptureParamsToPlugin(): void

--- a/proclaim.script.php
+++ b/proclaim.script.php
@@ -27,6 +27,7 @@ use Joomla\CMS\Installer\InstallerScript;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Log\Log;
 use Joomla\CMS\Session\Session;
+use Joomla\Database\DatabaseDriver;
 use Joomla\Database\DatabaseInterface;
 use Joomla\Database\ParameterType;
 use Joomla\Filesystem\File;
@@ -111,7 +112,7 @@ class com_proclaimInstallerScript extends InstallerScript
      *
      * @since  10.5.9
      */
-    private const INSTALL_LOG = 'com_proclaim.install';
+    private const string INSTALL_LOG = 'com_proclaim.install';
 
     /**
      * The version this update is coming from, read before Joomla overwrites it.
@@ -3463,7 +3464,7 @@ class com_proclaimInstallerScript extends InstallerScript
             $xmlFile          = JPATH_ADMINISTRATOR . '/components/com_proclaim/forms/podcast-platforms.xml';
 
             if (file_exists($xmlFile)) {
-                $xml = simplexml_load_file($xmlFile);
+                $xml = simplexml_load_string(file_get_contents($xmlFile));
 
                 if ($xml !== false) {
                     foreach ($xml->platform as $p) {

--- a/proclaim.script.php
+++ b/proclaim.script.php
@@ -650,11 +650,9 @@ class com_proclaimInstallerScript extends InstallerScript
     /**
      * Time a piece of postflight, and record where the time went.
      *
-     * Postflight's unconditional work — installing the sub-extensions, copying
-     * language files, clearing caches — was never measured, so an update that
-     * felt slow could only be guessed at. The migrations were instrumented
-     * first and turned out to be free, which left the larger part of an update
-     * unaccounted for.
+     * Covers postflight's unconditional work — installing the sub-extensions,
+     * copying language files, clearing caches — which is where an update's time
+     * actually goes, the migrations themselves having turned out to be free.
      *
      * ⚠️ A throw is recorded and the update carries on. Joomla treats a
      * RuntimeException out of postflight as grounds to abort and roll the
@@ -1469,13 +1467,10 @@ class com_proclaimInstallerScript extends InstallerScript
      * caches, and nothing tells an optimisation plugin that the files it combined
      * have been replaced.
      *
-     * That gap is not theoretical. On a live site running JCH Optimize, updating
-     * the scripture library deleted the combined JS bundles while the cached HTML
-     * kept referencing them by filename. Every bundled script — including the
-     * Bible version switcher — returned a 404 HTML error page, so the switcher
-     * rendered and did nothing. No error was visible anywhere; the markup was
-     * correct and the JavaScript simply never arrived. Clearing both caches fixed
-     * it.
+     * That gap is not theoretical. An optimisation plugin can go on serving
+     * cached HTML that names combined bundles the update has already replaced,
+     * so every bundled script returns a 404 and the feature it powers renders
+     * correctly and does nothing — with no error anywhere to say so.
      *
      * What we can do:
      *

--- a/proclaim.script.php
+++ b/proclaim.script.php
@@ -788,7 +788,7 @@ class com_proclaimInstallerScript extends InstallerScript
                 $libBase = JPATH_LIBRARIES . $libSuffix;
 
                 if (is_dir($libBase) && !class_exists('CWM\\Library\\Scripture\\Helper\\ScriptureHelper', false)) {
-                    \JLoader::registerNamespace('CWM\\Library\\Scripture', $libBase, false, false, 'psr4');
+                    \JLoader::registerNamespace('CWM\\Library\\Scripture', $libBase);
 
                     break;
                 }
@@ -2770,7 +2770,7 @@ class com_proclaimInstallerScript extends InstallerScript
             $this->deleteFiles   = ['/language/en-GB/en-GB.com_biblestudy.ini'];
 
             // Call parent removeFiles with the required argument
-            $this->removeFiles($parent);
+            $this->removeFiles();
 
             // Clean up Admin Menus from old install
             $query = $this->dbo->getQuery(true)

--- a/tests/unit/Admin/Helper/JsonThrowContractTest.php
+++ b/tests/unit/Admin/Helper/JsonThrowContractTest.php
@@ -47,6 +47,18 @@ class JsonThrowContractTest extends ProclaimTestCase
     private const ROOTS = ['admin/src', 'site/src', 'api/src'];
 
     /**
+     * Individual files of ours that live outside those trees.
+     *
+     * ⚠️ The install script is the reason this exists. It sat outside every
+     * root, so nothing held it to the contract and three bare calls collected
+     * there — two of which wrote `''` over a row it was migrating, because
+     * `json_encode()` returns false and `quote(false)` is an empty string.
+     *
+     * @var  string[]
+     */
+    private const FILES = ['proclaim.script.php'];
+
+    /**
      * Calls that deliberately omit the flag, each with the reason it is safe.
      *
      * A `json_encode()` cannot fail on a value that PHP just handed us from a
@@ -72,6 +84,8 @@ class JsonThrowContractTest extends ProclaimTestCase
         $root  = \dirname(__DIR__, 4);
         $found = [];
 
+        $paths = [];
+
         foreach (self::ROOTS as $rel) {
             $dir = $root . '/' . $rel;
 
@@ -87,48 +101,58 @@ class JsonThrowContractTest extends ProclaimTestCase
                     continue;
                 }
 
-                $tokens = token_get_all((string) file_get_contents($path));
-                $count  = \count($tokens);
+                $paths[] = $path;
+            }
+        }
 
-                for ($i = 0; $i < $count; $i++) {
-                    $token = $tokens[$i];
+        foreach (self::FILES as $rel) {
+            if (is_file($root . '/' . $rel)) {
+                $paths[] = $root . '/' . $rel;
+            }
+        }
 
-                    if (
-                        !\is_array($token)
-                        || $token[0] !== \T_STRING
-                        || !\in_array($token[1], ['json_decode', 'json_encode'], true)
-                    ) {
-                        continue;
-                    }
+        foreach ($paths as $path) {
+            $tokens = token_get_all((string) file_get_contents($path));
+            $count  = \count($tokens);
 
-                    $depth   = 0;
-                    $args    = '';
-                    $started = false;
+            for ($i = 0; $i < $count; $i++) {
+                $token = $tokens[$i];
 
-                    for ($j = $i + 1; $j < $count; $j++) {
-                        $text = \is_array($tokens[$j]) ? $tokens[$j][1] : $tokens[$j];
-
-                        if ($text === '(') {
-                            $depth++;
-                            $started = true;
-                        } elseif ($text === ')') {
-                            $depth--;
-
-                            if ($depth === 0) {
-                                break;
-                            }
-                        } elseif ($started) {
-                            $args .= $text;
-                        }
-                    }
-
-                    $found[] = [
-                        'file' => str_replace($root . '/', '', $path),
-                        'line' => $token[2],
-                        'fn'   => $token[1],
-                        'args' => $args,
-                    ];
+                if (
+                    !\is_array($token)
+                    || $token[0] !== \T_STRING
+                    || !\in_array($token[1], ['json_decode', 'json_encode'], true)
+                ) {
+                    continue;
                 }
+
+                $depth   = 0;
+                $args    = '';
+                $started = false;
+
+                for ($j = $i + 1; $j < $count; $j++) {
+                    $text = \is_array($tokens[$j]) ? $tokens[$j][1] : $tokens[$j];
+
+                    if ($text === '(') {
+                        $depth++;
+                        $started = true;
+                    } elseif ($text === ')') {
+                        $depth--;
+
+                        if ($depth === 0) {
+                            break;
+                        }
+                    } elseif ($started) {
+                        $args .= $text;
+                    }
+                }
+
+                $found[] = [
+                    'file' => str_replace($root . '/', '', $path),
+                    'line' => $token[2],
+                    'fn'   => $token[1],
+                    'args' => $args,
+                ];
             }
         }
 
@@ -175,17 +199,26 @@ class JsonThrowContractTest extends ProclaimTestCase
                 continue;
             }
 
-            // "Stored" means the result is assigned onto an object property or
-            // written to disk. A json_encode() feeding a cache key, an echoed
-            // AJAX body or a data- attribute cannot corrupt anything durable,
-            // and guarding those would be noise rather than safety.
-            $line = file($root . '/' . $call['file'])[$call['line'] - 1] ?? '';
+            // "Stored" means the result reaches something durable: an object
+            // property, a file, or a database write. A json_encode() feeding a
+            // cache key, an echoed AJAX body or a data- attribute cannot corrupt
+            // anything durable, and guarding those would be noise rather than
+            // safety.
+            //
+            // ⚠️ The database arm is not decoration. `json_encode()` returns
+            // false, `quote(false)` is `''`, and the row is written anyway — so
+            // the damage is a blanked column on a record the code believed it had
+            // migrated. Two calls in the install script had exactly that shape.
+            $lines = file($root . '/' . $call['file']);
+            $line  = $lines[$call['line'] - 1] ?? '';
 
             if (
                 preg_match(
                     '/(\$this->[a-zA-Z_]+|\$[a-zA-Z_]+->[a-zA-Z_]+)\s*=\s*json_encode|file_put_contents\s*\([^,]+,\s*json_encode/',
                     $line
                 )
+                || preg_match('/->(quote|q)\s*\(\s*json_encode/', $line)
+                || $this->encodedLocalIsPersisted($lines, $call['line'], $line)
             ) {
                 $offenders[] = $call['file'] . ':' . $call['line'];
             }
@@ -236,4 +269,37 @@ class JsonThrowContractTest extends ProclaimTestCase
             'Expected many calls to carry the flag — if this drops, the argument extraction has broken'
         );
     }
+
+    /**
+     * Whether a local `$x = json_encode(...)` is quoted into a query below it.
+     *
+     * The regex arms above only see one line, so they miss the commonest shape
+     * of all: encode into a local, then hand that local to `quote()` a few lines
+     * down as part of an UPDATE. Looks ahead a short way for that variable
+     * reaching a quote or a set().
+     *
+     * @param   string[]  $lines   Every line of the file
+     * @param   int       $number  1-indexed line the call sits on
+     * @param   string    $line    That line's text
+     *
+     * @return  bool
+     */
+    private function encodedLocalIsPersisted(array $lines, int $number, string $line): bool
+    {
+        if (!preg_match('/(\$[a-zA-Z_][a-zA-Z0-9_]*)\s*=\s*json_encode/', $line, $m)) {
+            return false;
+        }
+
+        $variable = preg_quote($m[1], '/');
+        $end      = min(\count($lines), $number + 15);
+
+        for ($i = $number; $i < $end; $i++) {
+            if (preg_match('/->(quote|q|set|bind)\s*\([^)]*' . $variable . '\b/', $lines[$i])) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
 }

--- a/tests/unit/Repo/InstallScriptImportsTest.php
+++ b/tests/unit/Repo/InstallScriptImportsTest.php
@@ -1,0 +1,134 @@
+<?php
+
+/**
+ * Part of Proclaim Package
+ *
+ * @package    Proclaim.UnitTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace CWM\Component\Proclaim\Tests\Repo;
+
+use CWM\Component\Proclaim\Tests\ProclaimTestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+
+/**
+ * Every class the install script names must resolve to an import.
+ *
+ * ⚠️ The script has no namespace, so an unimported `Foo::bar()` resolves to a
+ * global `\Foo` and PHP raises an **Error** — which `catch (\Exception $e)` does
+ * not catch. The failure is a fatal, not a caught one.
+ *
+ * This is not hypothetical. `DatabaseDriver::splitSql()` was written into
+ * dropTablesIfRequested() a month after a refactor removed the import, and sat
+ * there from 2026-03-23. That path runs on uninstall when the administrator has
+ * opted into dropping tables, and it deletes the `#__assets` rows *before*
+ * reaching the fatal — so an uninstall destroyed the ACL rows, then died without
+ * dropping a single table.
+ *
+ * Nothing caught it for five months: it only runs on uninstall, only with
+ * drop_tables set, and the install script is not exercised by the unit suite.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class InstallScriptImportsTest extends ProclaimTestCase
+{
+    /**
+     * Resolvable without an import: PHP's own globals, and classes this file
+     * declares. `parent::` and `self::` are language constructs, not classes.
+     *
+     * @var    string[]
+     * @since  __DEPLOY_VERSION__
+     */
+    private const GLOBALS = [
+        'Exception', 'RuntimeException', 'Throwable', 'Error', 'JsonException',
+        'stdClass', 'DateTime', 'DateTimeZone', 'SplFileInfo', 'ArrayObject',
+        'JLoader', 'self', 'parent', 'static',
+    ];
+
+    /**
+     * The script source with comments and string literals removed.
+     *
+     * Tokenised rather than pattern-matched: the docblocks in this file name
+     * classes constantly (`CwmtemplatecodeTable::store()`, `FileStorage::…`),
+     * and one branch tests for the literal string `'JHtml::addIncludePath'`.
+     * A regex over raw text reports all of those and is worse than no test.
+     *
+     * @return  array<int, array{name: string, line: int}>  Static-call targets
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function staticCallTargets(): array
+    {
+        $source = (string) file_get_contents(\dirname(__DIR__, 3) . '/proclaim.script.php');
+        $tokens = token_get_all($source);
+        $found  = [];
+
+        foreach ($tokens as $i => $token) {
+            // A class name in a static call is T_STRING followed by T_DOUBLE_COLON.
+            if (!\is_array($token) || $token[0] !== \T_STRING) {
+                continue;
+            }
+
+            $next = $tokens[$i + 1] ?? null;
+
+            if (!\is_array($next) || $next[0] !== \T_DOUBLE_COLON) {
+                continue;
+            }
+
+            // A leading backslash makes it explicitly global and always valid.
+            $prev = $tokens[$i - 1] ?? null;
+
+            if (\is_array($prev) && $prev[0] === \T_NS_SEPARATOR) {
+                continue;
+            }
+
+            if ($prev === '\\') {
+                continue;
+            }
+
+            $found[] = ['name' => $token[1], 'line' => $token[2]];
+        }
+
+        return $found;
+    }
+
+    #[TestDox('Every class named in a static call in the install script is imported')]
+    public function testEveryStaticCallTargetIsImported(): void
+    {
+        $source = (string) file_get_contents(\dirname(__DIR__, 3) . '/proclaim.script.php');
+
+        preg_match_all('/^use\s+([\w\\\\]+?)(?:\s+as\s+(\w+))?;/m', $source, $matches, \PREG_SET_ORDER);
+
+        $imported = [];
+
+        foreach ($matches as $match) {
+            $parts      = explode('\\', $match[1]);
+            $imported[] = $match[2] ?? end($parts);
+        }
+
+        $known  = array_merge($imported, self::GLOBALS);
+        $usages = $this->staticCallTargets();
+
+        $this->assertNotEmpty($usages, 'No static calls found — the tokeniser is not seeing the file.');
+
+        $offenders = [];
+
+        foreach ($usages as $usage) {
+            if (\in_array($usage['name'], $known, true)) {
+                continue;
+            }
+
+            $offenders[] = $usage['name'] . '::  at line ' . $usage['line'];
+        }
+
+        $this->assertSame(
+            [],
+            $offenders,
+            "proclaim.script.php has no namespace, so an unimported class resolves to the global one and PHP\n"
+            . "raises an Error — which catch (\\Exception) does not catch, making it a fatal. Add the use\n"
+            . "statement, or prefix the call with a backslash if the global class is genuinely meant."
+        );
+    }
+}


### PR DESCRIPTION
Started as a PHPDoc cleanup in `proclaim.script.php` and turned up two data-loss bugs on the way.

## Docblocks that had come off their members

Three docblocks each sat immediately above **another** docblock, so the lower one captured the declaration and the real subject was left bare:

| Docblock | Documents | Was sitting |
|---|---|---|
| Minimum PHP version | `$minimumPhp` | 65 lines above it |
| The version this update is coming from | `$fromVersion` | two lines above it |
| Migrate studyimage param values | `migrateStudyImageParams()` | 420 lines above it |

`INSTALL_LOG` had silently absorbed the `$fromVersion` block. Each is reattached to its own declaration with no wording changed. A sweep the other way now reports **0 orphaned docblocks and 0 undocumented members**.

## A failed encode was blanking the row it was migrating

`json_encode()` returns `false` on failure, and `$db->quote(false)` is an empty string — so a row that would not encode was written as `''` and still counted as migrated:

- `migrateStudyImageParams()` — overwrote a message's **entire params blob**
- `migratePodcastAlternateLinks()` — same shape against `platform_links`

Legacy rows holding non-UTF-8 bytes are exactly what these migrations run against, so this is reachable rather than theoretical. Both now skip the row, matching the `catch (\JsonException) { continue; }` already sitting a few lines above, and `step()` reports the step rather than aborting the rest of postflight. A third bare `json_decode()` in the same file got the flag too.

## The guard could not have caught either of them

`JsonThrowContractTest` walked `admin/src`, `site/src` and `api/src`, so a repo-root file was outside every root — this adds a `FILES` list, and it immediately caught a bare `json_decode()` a grep of mine had missed.

The encode arm had the larger gap. It called a value "stored" only when assigned to an object property or passed to `file_put_contents`, but the durable write in a Joomla component is usually neither — it is an `UPDATE`. Both shapes that matter were invisible:

```php
$db->quote(json_encode($links))              // inline in the query
$x = json_encode($p);  ... $db->q($x)        // local, quoted below
```

Widening it surfaced a **live one** in `CwmlocationwizardModel::applyPermissions()`: the location wizard encoded its rules straight into `$db->quote()` when writing `#__assets`. A failed encode there does not store a malformed value, it stores `''` — which drops every permission on the component asset and presents later as a 404 with nothing pointing back at the wizard. It now refuses the write and throws `RuntimeException`, which `CwmlocationwizardController` already catches, so it surfaces as a refused save rather than a white screen.

Both new arms are verified by canary: reverting either call site fails the test at that line, restoring it passes.

## `@throws` tags

PhpStorm flags eight methods for missing `@throws`, and the same eight carry an "Unhandled Exception" warning on the line causing it — in every case a `Factory::getApplication()` or `enqueueMessage()` reached while building a message. Tags added above `@since`, matching `preflight`/`postflight`. Both inspections now report clean on the file.

Deliberately **not** acted on: the "Qualifier is unnecessary" warnings on `\count`, `\sprintf` and friends. Those leading slashes are PHP CS Fixer's `native_function_invocation` rule, so following the IDE there would fight the linter on every commit.

## Docblock size

Measured before cutting: 74 docblocks, 898 lines, 22% of the file, median 10, six at 24+.

Only **two** of those six were genuinely oversized, and both for the same reason — narrating an incident rather than describing the code. `clearCaches()` spent seven lines on a specific live site running JCH Optimize; the mechanism is worth keeping, the site is not. `task()` opened by explaining that postflight had never been measured before. Both now say what the code does in three lines.

The other four stay. `reconcileAnalyticsAggregateIndex()` and `dropRedundantStudyTopicIndex()` each explain why the work is in PHP rather than migration SQL — no `DROP INDEX IF EXISTS`, and DDL wrapped in `SET`/`PREPARE` becoming unparseable to `ChangeItem`, which then scores it `-1` and never runs it. `withoutCacheHousekeepingNoise()` explains why the warning it suppresses cannot be caught. Deleting any of them would make a future "simplification" look safe, and it is not.

## Verification

- `composer test:unit` — **2998 tests, 6872 assertions, green**
- `composer lint` / `composer lint:comments` — clean
- Orphaned docblocks 0, undocumented members 0
- Both new contract-test arms canary-verified

Independent of #1979; either can merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)