### PR TITLE
refactor(install): act on the IDE warnings that are real, and record why the rest are not

### DIFF
--- a/proclaim.script.php
+++ b/proclaim.script.php
@@ -18,6 +18,7 @@ use CWM\Component\Proclaim\Administrator\Lib\Cwmassets;
 use CWM\Component\Proclaim\Administrator\Lib\CwmscriptureMigration;
 use Joomla\CMS\Event\Cache\AfterPurgeEvent;
 use Joomla\CMS\Event\Model\AfterCleanCacheEvent;
+use Joomla\CMS\Application\CMSApplicationInterface;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Installer\Adapter\ComponentAdapter;
 use Joomla\CMS\Installer\Adapter\FileAdapter;
@@ -671,17 +672,17 @@ class com_proclaimInstallerScript extends InstallerScript
      * @param   string    $name  Task name, as it appears in the log
      * @param   callable  $work  The work to time
      *
-     * @return  mixed  Whatever $work returned
+     * @return  void
      *
      * @since   __DEPLOY_VERSION__
      */
-    private function task(string $name, callable $work): mixed
+    private function task(string $name, callable $work): void
     {
         $started = microtime(true);
         $error   = '';
 
         try {
-            return $work();
+            $work();
         } catch (\Throwable $e) {
             $error = $e->getMessage() !== '' ? $e->getMessage() : $e::class;
 
@@ -694,8 +695,6 @@ class com_proclaimInstallerScript extends InstallerScript
                 ),
                 'warning'
             );
-
-            return null;
         } finally {
             $secs = microtime(true) - $started;
 
@@ -1357,7 +1356,7 @@ class com_proclaimInstallerScript extends InstallerScript
         $this->scriptureConsumer('unregister');
 
         // Show the post-uninstalling page
-        $this->renderPostUninstallation($this->status, $parent);
+        $this->renderPostUninstallation($this->status);
 
         return true;
     }
@@ -1528,13 +1527,13 @@ class com_proclaimInstallerScript extends InstallerScript
      * that combine or cache whole pages, where a stale entry can reference assets
      * that no longer exist.
      *
-     * @param   \Joomla\CMS\Application\CMSApplicationInterface  $app  The application
+     * @param   CMSApplicationInterface  $app  The application
      *
      * @return  void
      *
      * @since   10.5.0
      */
-    private function warnAboutExternalCaches($app): void
+    private function warnAboutExternalCaches(CMSApplicationInterface $app): void
     {
         $known = [
             'jchoptimize'    => 'JCH Optimize',
@@ -1863,14 +1862,13 @@ class com_proclaimInstallerScript extends InstallerScript
     /**
      * Render Post Uninstalling
      *
-     * @param   object            $status  Object of things to uninstall
-     * @param   InstallerAdapter  $parent  The class calling this method
+     * @param   stdClass  $status  Object of things to uninstall
      *
      * @return void
      *
      * @since 1.7.0
      */
-    private function renderPostUninstallation($status, $parent): void
+    private function renderPostUninstallation(stdClass $status): void
     {
         $rows = 0;
         echo '<h2>' . Text::_('JBS_INS_UNINSTALL') . '</h2>
@@ -2093,10 +2091,10 @@ class com_proclaimInstallerScript extends InstallerScript
         $this->task('Language files', fn () => $this->copyLanguageFiles());
 
         // Show the post-installation page
-        $this->task('Post-install page', fn () => $this->renderPostInstallation($this->status, $parent));
+        $this->task('Post-install page', fn () => $this->renderPostInstallation($this->status));
 
         //Remove old com_biblestudy menu items on the admin side
-        $this->task('Legacy menu removal', fn () => $this->removeBibleStudyVersion($parent));
+        $this->task('Legacy menu removal', fn () => $this->removeBibleStudyVersion());
 
         // Declare our dependency on lib_cwmscripture so its uninstall guard and
         // shared-table cleanup can see us
@@ -2653,13 +2651,12 @@ class com_proclaimInstallerScript extends InstallerScript
     /**
      * Renders the post-installation message
      *
-     * @param   object            $status  Object of things to install
-     * @param   InstallerAdapter  $parent  The class calling this method
+     * @param   stdClass  $status  Object of things to install
      *
      * @return void
      * @since  1.7.0
      */
-    private function renderPostInstallation($status, $parent): void
+    private function renderPostInstallation(stdClass $status): void
     {
         try {
             $language = Factory::getApplication()->getLanguage();
@@ -2746,13 +2743,11 @@ class com_proclaimInstallerScript extends InstallerScript
     /**
      * Remove leftovers due to upgrading from an older Proclaim version.
      *
-     * @param   InstallerAdapter  $parent  The class calling this method
-     *
      * @return void
      * @throws Exception
      * @since 10.0.0
      */
-    private function removeBibleStudyVersion(InstallerAdapter $parent): void
+    private function removeBibleStudyVersion(): void
     {
         $biblestudyID = $this->getExtensionId('component', 'com_biblestudy');
 
@@ -3569,7 +3564,7 @@ class com_proclaimInstallerScript extends InstallerScript
                 ->where('(' . $db->quoteName('podcastimage') . ' IS NULL OR '
                     . $db->quoteName('podcastimage') . ' = ' . $db->quote('') . ')');
             $db->setQuery($query);
-            $affected = $db->execute();
+            $db->execute();
 
             $count = $db->getAffectedRows();
 

--- a/tests/unit/Admin/Lib/PostflightTaskTest.php
+++ b/tests/unit/Admin/Lib/PostflightTaskTest.php
@@ -71,7 +71,7 @@ class PostflightTaskTest extends ProclaimTestCase
     #[TestDox('A failing task does not roll back an install that already happened')]
     public function testTaskDoesNotAbortTheInstall(): void
     {
-        $body = self::methodBody('private function task(string $name, callable $work): mixed');
+        $body = self::methodBody('private function task(string $name, callable $work): void');
 
         $this->assertStringContainsString(
             'catch (\Throwable',
@@ -91,7 +91,7 @@ class PostflightTaskTest extends ProclaimTestCase
     #[TestDox('A failing task is reported, logged and left visible to the release gate')]
     public function testTaskFailureIsNotSilent(): void
     {
-        $body = self::methodBody('private function task(string $name, callable $work): mixed');
+        $body = self::methodBody('private function task(string $name, callable $work): void');
 
         $this->assertStringContainsString(
             'enqueueMessage',
@@ -139,7 +139,7 @@ class PostflightTaskTest extends ProclaimTestCase
     #[TestDox('Every timed task is recorded and logged')]
     public function testTaskRecordsAndLogs(): void
     {
-        $body = self::methodBody('private function task(string $name, callable $work): mixed');
+        $body = self::methodBody('private function task(string $name, callable $work): void');
 
         $this->assertStringContainsString(
             '$this->taskLog[]',
@@ -156,7 +156,7 @@ class PostflightTaskTest extends ProclaimTestCase
     #[TestDox('The migration steps and the postflight tasks stay separate')]
     public function testTaskLogIsNotTheStepLog(): void
     {
-        $body = self::methodBody('private function task(string $name, callable $work): mixed');
+        $body = self::methodBody('private function task(string $name, callable $work): void');
 
         $this->assertStringNotContainsString(
             '$this->stepLog',


### PR DESCRIPTION
Follow-on to #1980. Working through PhpStorm's remaining inspections on `proclaim.script.php`, five were worth taking and four were worth refusing — the refusals are in the commit body so nobody re-runs these inspections and "fixes" them.

## Taken

| Finding | Why it was real |
|---|---|
| `$affected = $db->execute()` | Never read, and sitting directly above the `$count = $db->getAffectedRows()` that is the actual source of the migration count. Verified nothing runs between the two, so the reported count was already right. |
| `$parent` unused ×3 | `renderPostInstallation`, `renderPostUninstallation`, `removeBibleStudyVersion`. Removed from signature and call site. |
| `$status`, `$app` untyped | Typed on the private methods; the docblocks already named the types. |
| `task(): mixed` | `return $work();` passed through a value none of its 14 call sites reads. `step()` beside it is already `void`. |

⚠️ On the parameter removals: **PHP silently ignores a surplus argument** to a user-defined function, so a missed call site would not have failed `php -l` or any test — that is the same failure mode as the two dead arguments removed in #1980. Each of the three was checked for matching arity by hand.

The `CMSApplicationInterface` import is load-bearing: a type hint whose class is not imported is a fatal at call time, and `InstallScriptImportsTest` (added in #1980) only checks static-call targets, not hints.

## Refused

- **~35 "Expression result is not used"** on `$db->setQuery()` / `$db->execute()`. PhpStorm's fix is literally *"Delete `$db->execute();`"*, which would stop the queries running.
- **~70 "Qualifier is unnecessary"** on `\count`, `\sprintf`. Those slashes are PHP CS Fixer's `native_function_invocation` rule — following the IDE fights `composer lint` on every commit.
- **`Factory::getCache()` deprecation.** `com_cache::purge()` still calls `Factory::getCache('')` in core on the versions we target. `clearCaches()`'s docblock exists because a mis-cleared cache once left a live site serving 404s for every bundled script; not the place to get ahead of core.
- **`uninstall($parent)` left untyped.** `postflight()` is typed and works, but Joomla calls these dynamically with no interface guaranteeing the argument type, and `uninstall` is the path #1980 found had been fatal for five months.

## Verification

- `composer test:unit` — **2999 tests, 6874 assertions green**
- `composer lint` / `lint:comments` clean
- The suite caught the one real regression: `PostflightTaskTest` locates `task()` by its declaration line, so the four locator strings moved with the signature. Assertions unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)