### PR TITLE
fix(install): drop the tables before deleting the permissions, not after

### DIFF
--- a/proclaim.script.php
+++ b/proclaim.script.php
@@ -1405,14 +1405,12 @@ class com_proclaimInstallerScript extends InstallerScript
             try {
                 // Same narrowing as the #__assets delete: the seeded values are
                 // `com_proclaim` and `com_proclaim.<entity>`, and a bare prefix
-                // would take another extension's rows with them.
+                // would take another extension's rows with them. orWhere() so
+                // the builder brackets the two halves rather than this code.
                 $query = $this->dbo->getQuery(true)
                     ->delete($this->dbo->quoteName($table))
-                    ->where(
-                        '(' . $this->dbo->quoteName($column) . ' = ' . $this->dbo->quote('com_proclaim')
-                        . ' OR ' . $this->dbo->quoteName($column) . ' LIKE '
-                        . $this->dbo->quote('com_proclaim.%') . ')'
-                    );
+                    ->where($this->dbo->quoteName($column) . ' = ' . $this->dbo->quote('com_proclaim'))
+                    ->orWhere($this->dbo->quoteName($column) . ' LIKE ' . $this->dbo->quote('com_proclaim.%'));
 
                 $this->dbo->setQuery($query)->execute();
             } catch (\Throwable $e) {
@@ -1727,21 +1725,25 @@ class com_proclaimInstallerScript extends InstallerScript
             // `com_proclaim` and `com_proclaim.<section>[.<id>]`; every other
             // asset query in this codebase already uses the dotted form.
             //
-            // The OR is bracketed because where() glues with AND and adds no
-            // brackets of its own, so a bare disjunction here would override
-            // the root.1 guard beside it.
+            // andWhere() rather than a bracketed string: the query builder
+            // groups the disjunction itself, so the SQL is the driver's to
+            // emit rather than ours to assemble. ⚠️ It goes through
+            // extendWhere(), which needs a WHERE to extend — the root.1 guard
+            // has to be the call before it, not after.
             $query = $this->dbo->getQuery(true)
                 ->delete($this->dbo->quoteName('#__assets'))
-                ->where(
-                    '(' . $this->dbo->quoteName('name') . ' = ' . $this->dbo->quote('com_proclaim')
-                    . ' OR ' . $this->dbo->quoteName('name') . ' LIKE '
-                    . $this->dbo->quote('com_proclaim.%') . ')'
-                )
-                // Kept even though the pattern above can no longer reach it.
+                // Kept even though the group below can no longer reach it.
                 // Deleting the ACL root takes every extension's permissions
                 // with it, and that guard should not depend on the predicate
                 // beside it staying narrow.
-                ->where($this->dbo->quoteName('name') . ' != ' . $this->dbo->quote('root.1'));
+                ->where($this->dbo->quoteName('name') . ' != ' . $this->dbo->quote('root.1'))
+                ->andWhere(
+                    [
+                        $this->dbo->quoteName('name') . ' = ' . $this->dbo->quote('com_proclaim'),
+                        $this->dbo->quoteName('name') . ' LIKE ' . $this->dbo->quote('com_proclaim.%'),
+                    ],
+                    'OR'
+                );
             $this->dbo->setQuery($query);
             $this->dbo->execute();
         } catch (\Exception) {

--- a/proclaim.script.php
+++ b/proclaim.script.php
@@ -1667,7 +1667,37 @@ class com_proclaimInstallerScript extends InstallerScript
                 return;
             }
 
-            // Remove component assets
+            // ⚠️ Tables first, asset rows second, and the order is the whole
+            // point. Either half can fail, but only one order fails
+            // recoverably: dropped tables with stale #__assets rows left behind
+            // is drift Cwmassets already knows how to sweep, while deleted
+            // asset rows with the tables still present is a site whose
+            // permissions are gone and whose content is still there.
+            //
+            // It ran the other way round until a missing DatabaseDriver import
+            // made the second half throw, and an uninstall destroyed the
+            // permissions without dropping a single table.
+            $sqlFile = JPATH_ADMINISTRATOR . '/components/com_proclaim/sql/uninstall.mysql.utf8.sql';
+            $buffer  = is_file($sqlFile) ? file_get_contents($sqlFile) : false;
+
+            if ($buffer !== false) {
+                foreach (DatabaseDriver::splitSql($buffer) as $singleQuery) {
+                    $singleQuery = trim($singleQuery);
+
+                    if ($singleQuery !== '' && $singleQuery[0] !== '#') {
+                        try {
+                            $this->dbo->setQuery($singleQuery);
+                            $this->dbo->execute();
+                        } catch (\Exception) {
+                            // Continue dropping remaining tables
+                        }
+                    }
+                }
+            }
+
+            // Remove component assets. Reached whether or not the uninstall SQL
+            // was there to run, which the early returns this replaced did not
+            // do — a missing file used to skip the asset cleanup entirely.
             $query = $this->dbo->getQuery(true)
                 ->select($this->dbo->quoteName('id'))
                 ->from($this->dbo->quoteName('#__assets'))
@@ -1690,34 +1720,6 @@ class com_proclaimInstallerScript extends InstallerScript
                 ->where($this->dbo->quoteName('name') . ' != ' . $this->dbo->quote('root.1'));
             $this->dbo->setQuery($query);
             $this->dbo->execute();
-
-            // Run the uninstall SQL
-            $sqlFile = JPATH_ADMINISTRATOR . '/components/com_proclaim/sql/uninstall.mysql.utf8.sql';
-
-            if (!file_exists($sqlFile)) {
-                return;
-            }
-
-            $buffer = file_get_contents($sqlFile);
-
-            if ($buffer === false) {
-                return;
-            }
-
-            $queries = DatabaseDriver::splitSql($buffer);
-
-            foreach ($queries as $singleQuery) {
-                $singleQuery = trim($singleQuery);
-
-                if ($singleQuery !== '' && $singleQuery[0] !== '#') {
-                    try {
-                        $this->dbo->setQuery($singleQuery);
-                        $this->dbo->execute();
-                    } catch (\Exception) {
-                        // Continue dropping remaining tables
-                    }
-                }
-            }
         } catch (\Exception) {
             // If anything fails, don't block uninstall
         }

--- a/proclaim.script.php
+++ b/proclaim.script.php
@@ -1403,9 +1403,16 @@ class com_proclaimInstallerScript extends InstallerScript
     {
         foreach (['#__action_log_config' => 'type_alias', '#__action_logs_extensions' => 'extension'] as $table => $column) {
             try {
+                // Same narrowing as the #__assets delete: the seeded values are
+                // `com_proclaim` and `com_proclaim.<entity>`, and a bare prefix
+                // would take another extension's rows with them.
                 $query = $this->dbo->getQuery(true)
                     ->delete($this->dbo->quoteName($table))
-                    ->where($this->dbo->quoteName($column) . ' LIKE ' . $this->dbo->quote('com_proclaim%'));
+                    ->where(
+                        '(' . $this->dbo->quoteName($column) . ' = ' . $this->dbo->quote('com_proclaim')
+                        . ' OR ' . $this->dbo->quoteName($column) . ' LIKE '
+                        . $this->dbo->quote('com_proclaim.%') . ')'
+                    );
 
                 $this->dbo->setQuery($query)->execute();
             } catch (\Throwable $e) {
@@ -1714,9 +1721,26 @@ class com_proclaimInstallerScript extends InstallerScript
                 $this->dbo->execute();
             }
 
+            // ⚠️ `com_proclaim%` would also match another extension that merely
+            // starts with our name — com_proclaimtools and the like — and this
+            // is an uninstall, so the match is a DELETE. Ours are exactly
+            // `com_proclaim` and `com_proclaim.<section>[.<id>]`; every other
+            // asset query in this codebase already uses the dotted form.
+            //
+            // The OR is bracketed because where() glues with AND and adds no
+            // brackets of its own, so a bare disjunction here would override
+            // the root.1 guard beside it.
             $query = $this->dbo->getQuery(true)
                 ->delete($this->dbo->quoteName('#__assets'))
-                ->where($this->dbo->quoteName('name') . ' LIKE ' . $this->dbo->quote('com_proclaim%'))
+                ->where(
+                    '(' . $this->dbo->quoteName('name') . ' = ' . $this->dbo->quote('com_proclaim')
+                    . ' OR ' . $this->dbo->quoteName('name') . ' LIKE '
+                    . $this->dbo->quote('com_proclaim.%') . ')'
+                )
+                // Kept even though the pattern above can no longer reach it.
+                // Deleting the ACL root takes every extension's permissions
+                // with it, and that guard should not depend on the predicate
+                // beside it staying narrow.
                 ->where($this->dbo->quoteName('name') . ' != ' . $this->dbo->quote('root.1'));
             $this->dbo->setQuery($query);
             $this->dbo->execute();

--- a/tests/unit/Repo/UninstallOrderTest.php
+++ b/tests/unit/Repo/UninstallOrderTest.php
@@ -1,0 +1,134 @@
+<?php
+
+/**
+ * Part of Proclaim Package
+ *
+ * @package    Proclaim.UnitTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace CWM\Component\Proclaim\Tests\Repo;
+
+use CWM\Component\Proclaim\Tests\ProclaimTestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+
+/**
+ * The order the uninstall destroys things in, which decides how bad a failure is.
+ *
+ * `dropTablesIfRequested()` does two destructive things: it drops Proclaim's
+ * tables, and it deletes Proclaim's `#__assets` rows. Both can fail. Only one
+ * order fails recoverably:
+ *
+ *   tables first  -> dropped tables, stale asset rows. Drift `Cwmassets`
+ *                    already sweeps, and nothing of the site's is lost.
+ *   assets first  -> deleted permissions, tables still full of content. The
+ *                    records survive with nothing governing access to them.
+ *
+ * It ran assets-first until #1980. A `DatabaseDriver` import removed a month
+ * before the call that needed it made the second half raise an `Error` — which
+ * the method's own `catch (\Exception)` does not catch — so an uninstall with
+ * drop_tables enabled destroyed the permissions and dropped no tables at all.
+ * That went unnoticed from 2026-03-23 to 2026-08-27.
+ *
+ * ⚠️ Asserted at source level rather than by running it. Exercising this needs
+ * a database it is allowed to destroy, and the integration suite runs against a
+ * live dev database — see #1983 for the disposable-site harness. The property
+ * worth defending meanwhile is that the order is written down deliberately,
+ * which is the same bar `HealthContractTest` sets for its ACL guard.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class UninstallOrderTest extends ProclaimTestCase
+{
+    /**
+     * The body of `dropTablesIfRequested()`.
+     *
+     * @return  string
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private static function method(): string
+    {
+        $source = (string) file_get_contents(\dirname(__DIR__, 3) . '/proclaim.script.php');
+        $start  = strpos($source, 'private function dropTablesIfRequested(): void');
+
+        self::assertNotFalse($start, 'dropTablesIfRequested() could not be found.');
+
+        $end = strpos($source, "\n    }\n", $start);
+
+        self::assertNotFalse($end, 'Could not find the end of dropTablesIfRequested().');
+
+        return substr($source, $start, $end - $start);
+    }
+
+    #[TestDox('the uninstall drops the tables before it deletes the permission rows')]
+    public function testTablesAreDroppedBeforeAssetsAreDeleted(): void
+    {
+        $body = self::method();
+
+        $dropSql     = strpos($body, 'splitSql');
+        $deleteAsset = strpos($body, "quote('com_proclaim%')");
+
+        $this->assertNotFalse($dropSql, 'The uninstall SQL is no longer run here.');
+        $this->assertNotFalse($deleteAsset, 'The #__assets cleanup is no longer done here.');
+
+        $this->assertLessThan(
+            $deleteAsset,
+            $dropSql,
+            "dropTablesIfRequested() deletes Proclaim's #__assets rows before it drops the tables.\n"
+            . "A failure between the two then leaves a site whose content is intact and whose\n"
+            . "permissions are gone, which is not recoverable from here. The other order leaves\n"
+            . 'stale asset rows, which Cwmassets already sweeps. Drop the tables first.'
+        );
+    }
+
+    /**
+     * ⚠️ The early returns this replaced skipped the asset cleanup entirely
+     * when the SQL file was absent. Now the tables run first, an early return
+     * between the two halves would silently reintroduce that.
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    #[TestDox('nothing returns between dropping the tables and clearing the permission rows')]
+    public function testNoEarlyReturnBetweenTheTwoHalves(): void
+    {
+        $body    = self::method();
+        $between = substr(
+            $body,
+            (int) strpos($body, 'splitSql'),
+            (int) strpos($body, "quote('com_proclaim%')") - (int) strpos($body, 'splitSql')
+        );
+
+        $this->assertStringNotContainsString(
+            'return;',
+            $between,
+            "A return between dropping the tables and deleting the #__assets rows leaves the rows\n"
+            . 'behind on a path that meant to remove them. Let the block fall through instead.'
+        );
+    }
+
+    #[TestDox('the uninstall still refuses unless the administrator asked for it')]
+    public function testDroppingIsGatedOnTheStoredSetting(): void
+    {
+        $body = self::method();
+
+        $this->assertStringContainsString(
+            "quoteName('drop_tables')",
+            $body,
+            'dropTablesIfRequested() no longer reads the drop_tables setting.'
+        );
+
+        $gate = strpos($body, '$dropTables < 1');
+
+        $this->assertNotFalse($gate, 'The drop_tables gate is gone; an uninstall would always drop.');
+
+        $this->assertLessThan(
+            (int) strpos($body, 'splitSql'),
+            $gate,
+            'The drop_tables gate has to be read before anything is destroyed.'
+        );
+    }
+}

--- a/tests/unit/Repo/UninstallOrderTest.php
+++ b/tests/unit/Repo/UninstallOrderTest.php
@@ -68,7 +68,9 @@ class UninstallOrderTest extends ProclaimTestCase
         $body = self::method();
 
         $dropSql     = strpos($body, 'splitSql');
-        $deleteAsset = strpos($body, "quote('com_proclaim%')");
+        // Anchored on the delete itself rather than its predicate, so
+        // narrowing the predicate does not silently unanchor this test.
+        $deleteAsset = strpos($body, '->delete($this->dbo->quoteName(\'#__assets\'))');
 
         $this->assertNotFalse($dropSql, 'The uninstall SQL is no longer run here.');
         $this->assertNotFalse($deleteAsset, 'The #__assets cleanup is no longer done here.');
@@ -99,7 +101,8 @@ class UninstallOrderTest extends ProclaimTestCase
         $between = substr(
             $body,
             (int) strpos($body, 'splitSql'),
-            (int) strpos($body, "quote('com_proclaim%')") - (int) strpos($body, 'splitSql')
+            (int) strpos($body, '->delete($this->dbo->quoteName(\'#__assets\'))')
+            - (int) strpos($body, 'splitSql')
         );
 
         $this->assertStringNotContainsString(
@@ -129,6 +132,44 @@ class UninstallOrderTest extends ProclaimTestCase
             (int) strpos($body, 'splitSql'),
             $gate,
             'The drop_tables gate has to be read before anything is destroyed.'
+        );
+    }
+
+    /**
+     * ⚠️ A bare `com_proclaim%` also matches any extension whose name merely
+     * starts with ours — com_proclaimtools and the like. In an uninstall that
+     * match is a DELETE, against `#__assets` and against Joomla's action-log
+     * tables, so it takes another extension's permissions and log config with
+     * it. Our own names are exactly `com_proclaim` and `com_proclaim.<x>`, and
+     * every asset query outside this file already uses the dotted form.
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    #[TestDox('the uninstall never matches rows on a bare com_proclaim prefix')]
+    public function testDeletesDoNotUseABarePrefix(): void
+    {
+        $source = (string) file_get_contents(\dirname(__DIR__, 3) . '/proclaim.script.php');
+
+        $this->assertStringNotContainsString(
+            "quote('com_proclaim%')",
+            $source,
+            "A bare `com_proclaim%` matches any extension sharing the prefix, and here that match is\n"
+            . "a DELETE on an uninstall. Use `= 'com_proclaim' OR LIKE 'com_proclaim.%'`, bracketed,\n"
+            . 'as the rest of the codebase does.'
+        );
+    }
+
+    #[TestDox('the ACL root is still excluded from the asset delete')]
+    public function testRootAssetIsExcluded(): void
+    {
+        $this->assertStringContainsString(
+            "quote('root.1')",
+            self::method(),
+            'The root.1 exclusion is gone. Deleting the ACL root takes every extension\'s '
+            . 'permissions with it, and that guard should not depend on the predicate beside it '
+            . 'staying narrow.'
         );
     }
 }


### PR DESCRIPTION
Part of #1983 — and the part that turned out not to be a test.

## The most valuable item on that issue was a bug

I filed #1983 asking for coverage of the uninstall path. Reading it to decide what a test should assert surfaced this:

`dropTablesIfRequested()` does two destructive things, and either can fail. **Only one order fails recoverably.**

| Order | On failure between the halves |
|---|---|
| tables first | dropped tables, stale `#__assets` rows — drift `Cwmassets` already sweeps, nothing of the site's is lost |
| **assets first** *(what shipped)* | deleted permissions, tables still full of content — the records survive with nothing governing access to them |

It ran assets-first. **That is why the `DatabaseDriver` fatal fixed in #1980 was data loss rather than an inconvenience** — the import had been removed a month before the call that needed it, the call raised an `Error` that `catch (\Exception)` does not catch, and an uninstall with `drop_tables` enabled destroyed the permissions and dropped no tables at all.

## The reorder is safe, checked rather than assumed

- the asset deletes touch **only `#__assets`** — no `#__bsms_*` reads
- the `drop_tables` setting is read from `#__bsms_admin` **before either half**, so it is unaffected

⚠️ The two early `return`s in the SQL half had to go with it. They returned when the file was missing or unreadable — which, once that half runs *first*, would have skipped the asset cleanup entirely. The block falls through instead, so asset rows are cleared whether or not there was SQL to run. `UninstallOrderTest` pins that too.

## Why source level, and what stays open

Exercising this needs a database it is allowed to destroy, and `composer test:integration` runs against a **live dev database** (`j5_dev`). A test that creates and drops schemas in that suite is one typo away from real data, so it does not belong there.

The genuine end-to-end test belongs on the disposable site (`composer test:install` / `cwm-reset-testsite` / the `role=test` site) and is its own piece of work. **#1983 stays open for it** — this PR does not close it.

Meanwhile the property worth defending is that the order is written down deliberately, which is the bar `HealthContractTest` already sets for its ACL guard.

`UninstallOrderTest` asserts three things:
1. the SQL drop precedes the `#__assets` delete
2. nothing `return`s between the two halves
3. the `drop_tables` gate is still read, and still read before anything is destroyed

## Verification

- `composer test:unit` — **2970 tests, 7098 assertions green**
- `composer test:integration` — **522 tests, 4160 assertions green**
- `composer lint` / `lint:comments` clean
- Canary-verified: restoring the old order fails with *"deletes Proclaim's #__assets rows before it drops the tables"*

🤖 Generated with [Claude Code](https://claude.com/claude-code)