### PR TITLE
test(guards): close the two blind spots where a guard reported clean on what it could not see

### DIFF
--- a/tests/unit/Query/WhereClauseContractTest.php
+++ b/tests/unit/Query/WhereClauseContractTest.php
@@ -232,4 +232,100 @@ class WhereClauseContractTest extends TestCase
             . implode("\n", $offenders)
         );
     }
+
+    /**
+     * Conditions handed to where() as a variable, with the reason each is safe.
+     *
+     * ⚠️ Keep this list short. An entry means the OR check above cannot see
+     * that call at all, so its correctness rests on this note rather than on a
+     * test.
+     *
+     * @var array<string, string>
+     * @since __DEPLOY_VERSION__
+     */
+    private const UNVERIFIABLE_WHERE = [
+        'CwmarchiveModel.php:105' => 'One-element array holding a single date comparison; no OR to bracket.',
+        'CwmarchiveModel.php:120' => 'One-element array holding a single date comparison; no OR to bracket.',
+    ];
+
+    /**
+     * ⚠️ The OR check reconstructs SQL from the literal argument at the call
+     * site, so `->where($conditions)` reconstructs to nothing and is skipped —
+     * silently, and reported as clean.
+     *
+     * Found in #1985: with the predicate assembled into a variable first,
+     * removing its brackets still passed. Moved inline, the identical edit
+     * failed at that file and line.
+     *
+     * Flagging the shape rather than teaching the detector to follow variables:
+     * there are two of these, both wanting no OR anyway, so the cost of
+     * refusing the shape is nearly nothing and the rule is easy to state.
+     *
+     * @return  void
+     * @since __DEPLOY_VERSION__
+     */
+    #[TestDox('no where() is handed conditions the OR check cannot read')]
+    public function testNoWhereIsGivenAnUnreadableArgument(): void
+    {
+        $offenders = [];
+        $seen      = 0;
+
+        foreach (self::sourceFiles() as $path) {
+            foreach (explode("\n", (string) file_get_contents($path)) as $n => $line) {
+                if (!preg_match('/->(where|having)\s*\(\s*\$[a-zA-Z_][a-zA-Z0-9_]*\s*\)/', $line)) {
+                    continue;
+                }
+
+                $seen++;
+                $key = basename($path) . ':' . ($n + 1);
+
+                if (isset(self::UNVERIFIABLE_WHERE[$key])) {
+                    continue;
+                }
+
+                $offenders[] = \sprintf('%s  %s', $key, trim($line));
+            }
+        }
+
+        $this->assertGreaterThan(
+            0,
+            $seen,
+            'No where($variable) calls were found at all — the scan is not reading the source.'
+        );
+
+        $this->assertSame(
+            [],
+            $offenders,
+            "where(\$variable) hides the condition from the unbracketed-OR check above, which reads the\n"
+            . "literal argument at the call site. Write the condition inline, or use andWhere()/orWhere()\n"
+            . "so the builder does the bracketing, or add the line to self::UNVERIFIABLE_WHERE with the\n"
+            . 'reason it holds no OR.' . "\n\n" . implode("\n", $offenders)
+        );
+    }
+
+    #[TestDox('the unreadable-argument list only names lines that still look that way')]
+    public function testUnverifiableEntriesAreStillAccurate(): void
+    {
+        foreach (self::UNVERIFIABLE_WHERE as $key => $why) {
+            [$file, $line] = explode(':', $key);
+
+            $match = null;
+
+            foreach (self::sourceFiles() as $path) {
+                if (basename($path) === $file) {
+                    $match = explode("\n", (string) file_get_contents($path))[(int) $line - 1] ?? null;
+
+                    break;
+                }
+            }
+
+            $this->assertNotNull($match, $key . ' is exempted but the file or line is gone.');
+
+            $this->assertMatchesRegularExpression(
+                '/->(where|having)\s*\(\s*\$[a-zA-Z_][a-zA-Z0-9_]*\s*\)/',
+                (string) $match,
+                $key . ' no longer passes a variable to where(), so the exemption is stale. Remove it: ' . $why
+            );
+        }
+    }
 }

--- a/tests/unit/Repo/InstallScriptImportsTest.php
+++ b/tests/unit/Repo/InstallScriptImportsTest.php
@@ -35,17 +35,18 @@ use PHPUnit\Framework\Attributes\TestDox;
 class InstallScriptImportsTest extends ProclaimTestCase
 {
     /**
-     * Resolvable without an import: PHP's own globals, and classes this file
-     * declares. `parent::` and `self::` are language constructs, not classes.
+     * Language keywords that appear where a class name would.
+     *
+     * ⚠️ Everything else is decided by asking whether the name resolves, not by
+     * listing it here. A hand-kept list of PHP's globals is a list that goes
+     * stale: this one omitted ReflectionObject, and `new ReflectionObject()` —
+     * correct code, since the file has no namespace and the global class
+     * exists — was reported as an offender.
      *
      * @var    string[]
      * @since  __DEPLOY_VERSION__
      */
-    private const GLOBALS = [
-        'Exception', 'RuntimeException', 'Throwable', 'Error', 'JsonException',
-        'stdClass', 'DateTime', 'DateTimeZone', 'SplFileInfo', 'ArrayObject',
-        'JLoader', 'self', 'parent', 'static',
-    ];
+    private const KEYWORDS = ['self', 'parent', 'static'];
 
     /**
      * The script source with comments and string literals removed.
@@ -66,14 +67,22 @@ class InstallScriptImportsTest extends ProclaimTestCase
         $found  = [];
 
         foreach ($tokens as $i => $token) {
-            // A class name in a static call is T_STRING followed by T_DOUBLE_COLON.
             if (!\is_array($token) || $token[0] !== \T_STRING) {
                 continue;
             }
 
+            // Four shapes name a class inside a method body, and all four fail
+            // the same way when the name is not imported: a global class that
+            // does not exist, and an Error at the moment the line runs.
             $next = $tokens[$i + 1] ?? null;
+            $back = $this->previousMeaningful($tokens, $i);
 
-            if (!\is_array($next) || $next[0] !== \T_DOUBLE_COLON) {
+            $isStaticCall = \is_array($next) && $next[0] === \T_DOUBLE_COLON;
+            $isNew        = \is_array($back) && $back[0] === \T_NEW;
+            $isInstanceof = \is_array($back) && $back[0] === \T_INSTANCEOF;
+            $isCatch      = $this->isInsideCatch($tokens, $i);
+
+            if (!$isStaticCall && !$isNew && !$isInstanceof && !$isCatch) {
                 continue;
             }
 
@@ -108,19 +117,28 @@ class InstallScriptImportsTest extends ProclaimTestCase
             $imported[] = $match[2] ?? end($parts);
         }
 
-        $known  = array_merge($imported, self::GLOBALS);
         $usages = $this->staticCallTargets();
 
-        $this->assertNotEmpty($usages, 'No static calls found — the tokeniser is not seeing the file.');
+        $this->assertNotEmpty($usages, 'No class references found — the tokeniser is not seeing the file.');
 
         $offenders = [];
 
         foreach ($usages as $usage) {
-            if (\in_array($usage['name'], $known, true)) {
+            $name = $usage['name'];
+
+            if (\in_array($name, self::KEYWORDS, true) || \in_array($name, $imported, true)) {
                 continue;
             }
 
-            $offenders[] = $usage['name'] . '::  at line ' . $usage['line'];
+            // Unimported is fine when the bare name is a real global — the file
+            // has no namespace, so `new ReflectionObject()` resolves. What is
+            // not fine is a name that resolves to nothing, which is the
+            // DatabaseDriver case: an Error at the moment the line runs.
+            if (class_exists($name) || interface_exists($name) || enum_exists($name)) {
+                continue;
+            }
+
+            $offenders[] = $name . '  at line ' . $usage['line'];
         }
 
         $this->assertSame(
@@ -130,5 +148,153 @@ class InstallScriptImportsTest extends ProclaimTestCase
             . "raises an Error — which catch (\\Exception) does not catch, making it a fatal. Add the use\n"
             . "statement, or prefix the call with a backslash if the global class is genuinely meant."
         );
+    }
+
+    /**
+     * The token before $i that is not whitespace or a comment.
+     *
+     * @param   array  $tokens  token_get_all() output
+     * @param   int    $i       Index to look back from
+     *
+     * @return  mixed
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function previousMeaningful(array $tokens, int $i): mixed
+    {
+        for ($j = $i - 1; $j >= 0; $j--) {
+            if (\is_array($tokens[$j]) && \in_array($tokens[$j][0], [\T_WHITESPACE, \T_COMMENT, \T_DOC_COMMENT], true)) {
+                continue;
+            }
+
+            return $tokens[$j];
+        }
+
+        return null;
+    }
+
+    /**
+     * Whether $i sits inside the parentheses of a `catch`.
+     *
+     * @param   array  $tokens  token_get_all() output
+     * @param   int    $i       Index to test
+     *
+     * @return  bool
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function isInsideCatch(array $tokens, int $i): bool
+    {
+        for ($j = $i - 1; $j >= 0 && $j > $i - 12; $j--) {
+            $t = $tokens[$j];
+
+            if ($t === ')' || $t === '{' || $t === ';') {
+                return false;
+            }
+
+            if (\is_array($t) && $t[0] === \T_CATCH) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * ⚠️ Type hints fail exactly as static calls do and were invisible here.
+     *
+     * The file has no namespace, so `private function f(Foo $x)` with no `use`
+     * resolves to a global `\Foo`, and PHP raises an Error when the method is
+     * called — not when the file is parsed, so `php -l` passes and the class
+     * loads. #1981 added such a hint and its import had to be checked by hand
+     * precisely because this test could not see it.
+     *
+     * Reflection rather than tokens: it reports the name PHP actually resolved
+     * to, so an unimported hint arrives as the bare name and simply fails to
+     * exist. Nothing has to be parsed or guessed.
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    #[TestDox('Every class named in a signature or property type resolves')]
+    public function testEverySignatureTypeResolves(): void
+    {
+        if (!class_exists('com_proclaimInstallerScript', false)) {
+            require_once \dirname(__DIR__, 3) . '/proclaim.script.php';
+        }
+
+        $class = new \ReflectionClass('com_proclaimInstallerScript');
+        $names = [];
+
+        foreach ($class->getMethods() as $method) {
+            if ($method->getDeclaringClass()->getName() !== $class->getName()) {
+                continue;
+            }
+
+            foreach ($method->getParameters() as $parameter) {
+                $names += $this->typeNames($parameter->getType(), $method->getName() . '()');
+            }
+
+            $names += $this->typeNames($method->getReturnType(), $method->getName() . '() return');
+        }
+
+        foreach ($class->getProperties() as $property) {
+            if ($property->getDeclaringClass()->getName() !== $class->getName()) {
+                continue;
+            }
+
+            $names += $this->typeNames($property->getType(), '$' . $property->getName());
+        }
+
+        $this->assertNotEmpty($names, 'No declared types were found — this test would pass on nothing.');
+
+        $offenders = [];
+
+        foreach ($names as $name => $where) {
+            if (class_exists($name) || interface_exists($name) || enum_exists($name)) {
+                continue;
+            }
+
+            $offenders[] = $name . '  (' . $where . ')';
+        }
+
+        $this->assertSame(
+            [],
+            $offenders,
+            "proclaim.script.php has no namespace, so a type hint whose class is not imported resolves\n"
+            . "to a global one that does not exist. PHP raises an Error when the method is called, which\n"
+            . 'php -l cannot see. Add the use statement.'
+        );
+    }
+
+    /**
+     * Class names in a declared type, keyed by name.
+     *
+     * @param   ?\ReflectionType  $type   The declared type, if any
+     * @param   string            $where  Where it was declared, for the message
+     *
+     * @return  array<string, string>
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function typeNames(?\ReflectionType $type, string $where): array
+    {
+        if ($type === null) {
+            return [];
+        }
+
+        // Union and intersection types hold several named types; a single one
+        // arrives as a ReflectionNamedType on its own.
+        $parts = $type instanceof \ReflectionNamedType ? [$type] : $type->getTypes();
+        $found = [];
+
+        foreach ($parts as $part) {
+            if ($part instanceof \ReflectionNamedType && !$part->isBuiltin()) {
+                $found[$part->getName()] = $where;
+            }
+        }
+
+        return $found;
     }
 }


### PR DESCRIPTION
Closes #1984. Closes #1986.

Both are the same species — a contract test that passes because the shape it checks never reaches it. Today produced three of those; the third was a guard of mine that was simply wrong (#1989). Worth closing together.

## #1984 — `InstallScriptImportsTest` saw static calls only

It matched `T_STRING` followed by `T_DOUBLE_COLON`, so `X::y()` was covered and nothing else. **A type hint fails identically**: the file has no namespace, an unimported hint resolves to a global class that doesn't exist, and PHP raises an `Error` when the method is *called* — not when the file is parsed. `php -l` passes, the class loads. #1981 added exactly such a hint and I had to check its import by hand.

Now covers:

| Shape | How |
|---|---|
| `X::y()` | token (unchanged) |
| `new X` | token |
| `instanceof X` | token |
| `catch (X)` | token |
| parameter / return / property types | **reflection** |

Reflection rather than parsing for types: it reports the name PHP *actually resolved to*, so an unimported one arrives as the bare name and fails to exist. Nothing has to be guessed.

### ⚠️ Widening it immediately produced a false positive

`new ReflectionObject($adapter)` — which is correct code. The file has no namespace and the global class exists; my hand-kept list of PHP globals had simply never needed that name.

So I replaced the list with the question it was approximating: **does this name resolve to anything?** A list of globals is a list that goes stale. Existence isn't. It still catches the `DatabaseDriver` case exactly, because no global `\DatabaseDriver` exists.

## #1986 — `WhereClauseContractTest` reads the call site literally

`->where($conditions)` reconstructs to nothing, so it's skipped — silently, and reported as clean. Found in #1985: with the predicate in a variable, **removing its brackets still passed**; inline, the same edit failed at that line.

The shape is now **refused** rather than the detector taught to follow variables. Two call sites exist (`CwmarchiveModel:105,120`), both single-condition arrays wanting no OR, so refusing it costs nothing and the rule states in a sentence. Both are listed with the reason they're safe, and a second test fails if either line stops looking that way — so the exemption can't go stale unnoticed.

## Canaries — every shape, at the right line

| Canary | Result |
|---|---|
| remove `DatabaseDriver` import | fails: `DatabaseDriver at line 1688` |
| remove `CMSApplicationInterface` import (type hint) | fails: signature type doesn't resolve |
| `new NotAnImportedClass(` | fails: `at line 1338` |
| `catch (NotAnImportedError $e)` | fails: `at line 2894` |
| unbracketed OR hidden in a variable | fails: `RestrictedMediaCheck.php:196 ->where($restricted);` |

All pass again when restored. That last one is the exact shape that slipped through during #1985.

## Verification

- `composer test:unit` — **2975 tests, 7126 assertions green**
- `composer test:integration` — **524 tests, 4165 assertions green**
- `composer lint` / `lint:comments` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)