### PR TITLE
fix(site): delete the landing page's unused list query and the tainted state feeding it

### DIFF
--- a/site/src/Model/CwmlandingpageModel.php
+++ b/site/src/Model/CwmlandingpageModel.php
@@ -17,12 +17,8 @@ namespace CWM\Component\Proclaim\Site\Model;
 // phpcs:enable PSR1.Files.SideEffects
 
 use CWM\Component\Proclaim\Administrator\Helper\Cwmparams;
-use Joomla\CMS\Date\Date;
 use Joomla\CMS\Factory;
 use Joomla\CMS\MVC\Model\ListModel;
-use Joomla\Database\DatabaseQuery;
-use Joomla\Database\ParameterType;
-use Joomla\Registry\Registry;
 
 /**
  * Model class for LandingPage
@@ -74,9 +70,6 @@ class CwmlandingpageModel extends ListModel
      */
     protected function populateState($ordering = null, $direction = null): void
     {
-        $order = $this->getUserStateFromRequest($this->context . '.filter.order', 'filter_orders');
-        $this->setState('filter.order', $order);
-
         // Load the parameters.
         $template = Cwmparams::getTemplateparams();
         $admin    = Cwmparams::getAdmin();
@@ -104,105 +97,5 @@ class CwmlandingpageModel extends ListModel
         $this->setState('filter.show_archived', $showArchived);
 
         parent::populateState('s.studydate', 'DESC');
-    }
-
-    /**
-     * Method to get a JDatabaseQuery object for retrieving the data set from a database.
-     *
-     * @return  DatabaseQuery  A DatabaseQuery object to retrieve the data set.
-     *
-     * @throws \Exception
-     * @since   11.1
-     */
-    protected function getListQuery(): DatabaseQuery
-    {
-        $db              = $this->getDatabase();
-        $query           = $db->createQuery();
-        $template_params = Cwmparams::getTemplateparams();
-        $t_params        = $template_params->params;
-
-        // Load the parameters. Merge Global and Menu Item params into new object
-        $app = Factory::getApplication();
-        /** @var Registry $params */
-        $params = $app->getParams();
-        $this->setState('params', $params);
-        $menuparams = new Registry();
-        $menu       = $app->getMenu()->getActive();
-
-        if ($menu) {
-            $menuparams->loadString($menu->params);
-        }
-
-        $query->select($db->quoteName('s.id'));
-        $query->from($db->quoteName('#__bsms_studies', 's'));
-        $query->select(
-            $db->quoteName(['t.id', 't.teachername', 't.title', 't.language'], ['tid', 'teachertitle', null, null])
-        );
-        $query->join('LEFT', $db->quoteName('#__bsms_study_teachers', 'stj') . ' ON '
-            . $db->quoteName('stj.study_id') . ' = ' . $db->quoteName('s.id')
-            . ' AND ' . $db->quoteName('stj.ordering') . ' = 0');
-        $query->join('LEFT', $db->quoteName('#__bsms_teachers', 't') . ' ON '
-            . $db->quoteName('t.id') . ' = ' . $db->quoteName('stj.teacher_id'));
-        $query->select(
-            $db->quoteName(
-                ['se.id', 'se.series_text', 'se.description', 'se.series_thumbnail'],
-                ['sid', null, 'sdescription', null]
-            )
-        );
-        $query->join('LEFT', $db->quoteName('#__bsms_series', 'se') . ' ON ' . $db->quoteName('s.series_id') . ' = ' . $db->quoteName('se.id'));
-        $query->select($db->quoteName(['m.id', 'm.message_type'], ['mid', null]));
-        $query->join('LEFT', $db->quoteName('#__bsms_message_type', 'm') . ' ON ' . $db->quoteName('s.messagetype') . ' = ' . $db->quoteName('m.id'));
-        $query->select('GROUP_CONCAT(DISTINCT ' . $db->quoteName('st.topic_id') . ')');
-        $query->join('LEFT', $db->quoteName('#__bsms_studytopics', 'st') . ' ON ' . $db->quoteName('s.id') . ' = ' . $db->quoteName('st.study_id'));
-        $query->select(
-            'GROUP_CONCAT(DISTINCT ' . $db->quoteName('tp.id') . '), ' .
-            'GROUP_CONCAT(DISTINCT ' . $db->quoteName('tp.topic_text') . ') as topics_text, ' .
-            'GROUP_CONCAT(DISTINCT ' . $db->quoteName('tp.params') . ')'
-        );
-        $query->join('LEFT', $db->quoteName('#__bsms_topics', 'tp') . ' ON ' . $db->quoteName('tp.id') . ' = ' . $db->quoteName('st.topic_id'));
-        $query->select($db->quoteName(['l.id', 'l.location_text'], ['lid', null]));
-        $query->join('LEFT', $db->quoteName('#__bsms_locations', 'l') . ' ON ' . $db->quoteName('s.location_id') . ' = ' . $db->quoteName('l.id'));
-
-        $rightnow = (new Date())->toSql();
-
-        // Filter by published state based on show_archived parameter
-        $showArchived = $this->getState('filter.show_archived', '0');
-        switch ($showArchived) {
-            case '1': // Archived only
-                $archived = 2;
-                $query->where($db->quoteName('s.published') . ' = :published')
-                    ->bind(':published', $archived, ParameterType::INTEGER);
-                break;
-            case '2': // Both published and archived
-                $query->whereIn($db->quoteName('s.published'), [1, 2]);
-                break;
-            default: // Published only (backward compatible)
-                $published = 1;
-                $query->where($db->quoteName('s.published') . ' = :published')
-                    ->bind(':published', $published, ParameterType::INTEGER);
-                break;
-        }
-
-        $query->where($db->quoteName('s.studydate') . ' <= :rightnow')
-            ->bind(':rightnow', $rightnow, ParameterType::STRING);
-
-        // Order by order filter
-        $orderparam = $params->get('default_order');
-
-        if (empty($orderparam)) {
-            $orderparam = $t_params->get('default_order', '1');
-        }
-
-        $order = ($orderparam == 2) ? 'ASC' : 'DESC';
-
-        $orderstate = $this->getState('filter.order');
-
-        if (!empty($orderstate)) {
-            $order = $orderstate;
-        }
-
-        $query->order($db->quoteName('studydate') . ' ' . $db->escape($order));
-
-        return $query;
     }
 }


### PR DESCRIPTION
Found while looking at `CwmlandingpageModel` for a return-type question. The method that raised it turned out not to be called at all.

## It is dead code

`CwmlandingpageModel::getListQuery()` is never reached. The view asks the model for `state` and nothing else, then takes its data from `Cwmlanding::getLandingData()`. All three routes into `getListQuery()` — `getItems()`, `getTotal()`, `getPagination()` — are used by neither the view nor the template, and the model isn't referenced from modules, plugins, api or admin.

## It was carrying two defects

**1. An `ORDER BY` built from unfiltered request input.**

`getUserStateFromRequest($key, 'filter_orders')` — the fourth parameter is the filter type and it **defaults to `'none'`**. The value then went through `$db->escape()` into `ORDER BY`, and `escape()` is for *string* context; the value isn't quoted there, so it's a no-op:

```
payload        DESC,(SELECT IF(1=1,SLEEP(0),1))
after escape   DESC,(SELECT IF(1=1,SLEEP(0),1))
generated SQL  ORDER BY `studydate` DESC,(SELECT IF(1=1,SLEEP(0),1))
```

The three sibling site models read the same kind of value through `$input->get()`, whose filter **defaults to CMD** — which reduces that payload to `DESCSELECTIF11SLEEP01`. This model was the only one taking it unfiltered.

⚠️ **Not a live vulnerability** — only unreachable code kept it from being one. Stating that plainly rather than dressing it up.

**2. `GROUP_CONCAT` with no `GROUP BY`**, which collapses the result to one row. Against this database: **536** published studies, **1** row returned, **536** with `GROUP BY s.id`.

## Deleting rather than repairing

Repairing means maintaining a query nothing runs. The parent's `getListQuery()` returns an empty query, so a caller arriving later gets an empty result rather than a fatal. 209 → 103 lines.

The `filter_orders` state goes with it — nothing else read `filter.order`.

## Verified against the rendered page, not just the tests

The dev site is symlinked, so the change is live:

```
HTTP 200   122,457 bytes   <title>Landing</title>
190 list items · 12 featured cards · 115 sermon links
0 fatals · 0 notices
```

- `composer test:unit` — **2975 tests, 7126 assertions green**
- `composer test:integration` — **524 tests, 4165 assertions green**

## Checked and deliberately not changed

14 other sites do `->order($db->escape($orderCol) . ' ' . $db->escape($orderDirn))`. They are safe: core's `ListModel::populateState()` whitelists `list.ordering` against `$this->filter_fields` and `list.direction` against `['ASC','DESC','']`, and the two site models take theirs through CMD-filtered `$input->get()`. The idiom is fragile — it's safe only because of upstream validation — but there's no current risk, so it belongs with the query-builder sweep in #1988 rather than here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)