### PR TITLE
docs: run the IDE inspector on changed files before opening a PR

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,32 @@ This project follows **PSR-12** coding standards. All code must pass PHP CS Fixe
 - PHP CS Fixer config: `.php-cs-fixer.dist.php`
 - Run `composer lint:fix` before committing
 
+### Before opening a PR: run the IDE inspector on changed files
+
+`php -l` and a green test suite do **not** catch an unresolved class or method.
+The file parses; the symbol is only resolved when the line runs. If that line is
+on a path the suites do not exercise — an installer, a restore, a scheduled
+task — it ships and fails in production.
+
+Run PhpStorm's inspection on each changed PHP file (`get_file_problems`, or
+Code → Inspect Code) and read the result before pushing.
+
+⚠️ **Include warnings.** "Undefined class" and "Method not found" are severity
+**WARNING**, not ERROR. Checking errors only returns an empty list and looks
+like a clean file.
+
+Two examples, both of which passed `php -l` and the full suite:
+
+| Symptom | Where |
+|---|---|
+| `Undefined class 'Factory'` | `HealthRegistry` used `Factory` and `DatabaseInterface` with neither imported |
+| `Method 'getDatabase' not found` | `CwmbackupController` has no such method; it extends `BaseController` without the database-aware trait |
+
+⚠️ Do **not** act on its "Qualifier is unnecessary" warnings for `\count`,
+`\sprintf` and similar. Those leading slashes are PHP CS Fixer's
+`native_function_invocation` rule — following the IDE there fights
+`composer lint` on every commit.
+
 ### Naming Conventions
 
 - Class naming: `Cwm` prefix (e.g., `CwmparamsModel`, `CwmteacherTable`)


### PR DESCRIPTION
Makes the pre-merge IDE check part of the documented process, after it caught undefined-symbol fatals in **two consecutive PRs**.

## Why it earns a place

`php -l` and a green suite do not catch an unresolved class or method. The file parses; the symbol resolves only when the line runs. If that line sits on a path the suites don't exercise — an installer, a restore, a scheduled task — **it ships**.

| Symptom | Where | Would have |
|---|---|---|
| `Undefined class 'Factory'` | `HealthRegistry` used `Factory` and `DatabaseInterface`, importing neither (#1997) | fatalled on every Administration render |
| `Method 'getDatabase' not found` | `CwmbackupController` extends `BaseController` without the database-aware trait (#1998) | fatalled the first time a restore finished |

Both passed `php -l`. Both passed the full suite — the second because `mediaStatus()` is only reached from `finalizeImportXHR()`, which needs a live restore session.

## ⚠️ The trap the instruction calls out

Both were severity **WARNING**, not ERROR. An errors-only inspection returns an empty list and reads as a clean file. The rule says to include warnings for exactly that reason.

## And the advice to ignore

"Qualifier is unnecessary" on `\count`, `\sprintf` and friends — those leading slashes are PHP CS Fixer's `native_function_invocation` rule. Following the IDE there fights `composer lint` on every commit. Recorded so nobody spends an afternoon discovering it twice.

Docs only — no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)