### PR TITLE
fix(assets): load the asset table on open instead of promising to

### DIFF
--- a/build/media_source/js/asset-fix.es6.js
+++ b/build/media_source/js/asset-fix.es6.js
@@ -71,6 +71,16 @@ class ProclaimAssetFix {
         document.querySelectorAll('[data-proclaim-action]').forEach((btn) => {
             btn.addEventListener('click', (e) => this.handleAction(e));
         });
+
+        // ⚠️ The table has to be loaded here, not just on the Refresh button.
+        // The view fills its rows from the 'checklists' session key, and the
+        // only thing that ever writes that key is this XHR -- so before it has
+        // run once the template falls to its empty branch, which renders a
+        // spinner. Nothing then replaced it: the page promised it was loading
+        // and never was, and pressing Refresh was the only way to see data.
+        if (document.getElementById('asset-status-body')) {
+            this.refreshAssetStatus();
+        }
     }
 
     /**

--- a/tests/js/asset-fix-initial-load.test.js
+++ b/tests/js/asset-fix-initial-load.test.js
@@ -1,0 +1,123 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * The Assets screen renders its status table from the `checklists` session
+ * key, and the only thing that ever writes that key is the `checkAssetsXHR`
+ * request behind the Refresh button. So before Refresh had been pressed once,
+ * the view got an empty array, the template fell to its empty branch — which
+ * renders a **spinner** — and nothing ever replaced it. The page said it was
+ * loading and was not; the data only appeared if you pressed Refresh yourself.
+ *
+ * These exercise the shipped module rather than a copy of its logic, and
+ * assert the request is actually issued, not merely that a method exists.
+ *
+ * @package  Proclaim.Tests
+ * @since    __DEPLOY_VERSION__
+ */
+
+/**
+ * The markup the PHP template emits when it has no cached rows: a spinner,
+ * and the Refresh button.
+ *
+ * @returns {void}
+ */
+function renderEmptyAssetsScreen() {
+    document.body.innerHTML = `
+        <table>
+            <tbody id="asset-status-body">
+                <tr>
+                    <td colspan="7" class="text-center py-4">
+                        <div class="spinner-border spinner-border-sm" role="status">
+                            <span class="visually-hidden">JBS_CMN_LOADING</span>
+                        </div>
+                        <span class="ms-2">JBS_ADM_CHECKING_ASSETS</span>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+        <button type="button" data-proclaim-action="refresh">Refresh</button>
+    `;
+}
+
+/**
+ * Load the module against whatever is currently in the DOM.
+ *
+ * @returns {void}
+ */
+function loadModule() {
+    global.Joomla = {
+        Text: { _: (key) => key },
+        getOptions: () => '',
+        renderMessages: () => {},
+    };
+
+    jest.isolateModules(() => {
+        require('../../build/media_source/js/asset-fix.es6.js');
+    });
+
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+}
+
+describe('Assets screen initial load', () => {
+    beforeEach(() => {
+        jest.resetModules();
+
+        global.fetch = jest.fn(() => Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve({
+                success: true,
+                data: { assets: [] },
+            }),
+        }));
+    });
+
+    afterEach(() => {
+        delete global.fetch;
+        document.body.innerHTML = '';
+    });
+
+    it('requests the asset status without waiting for a Refresh click', async () => {
+        renderEmptyAssetsScreen();
+        loadModule();
+
+        // Let the promise chain started during init settle.
+        await Promise.resolve();
+
+        // Nothing pressed Refresh. If no request went out, the spinner the
+        // template rendered would still be spinning — which is the bug.
+        expect(global.fetch).toHaveBeenCalled();
+    });
+
+    it('replaces the spinner rather than leaving it on screen', async () => {
+        renderEmptyAssetsScreen();
+
+        expect(document.querySelector('#asset-status-body .spinner-border')).not.toBeNull();
+
+        loadModule();
+
+        // Let the fetch resolve and the render run.
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+
+        // The spinner must be replaced by a result. An empty result is still
+        // a result; a spinner left on screen is not.
+        expect(document.querySelector('#asset-status-body .spinner-border')).toBeNull();
+    });
+
+    /**
+     * ⚠️ The guard matters as much as the call. This module is loaded on more
+     * than the Assets screen, and firing the request on a page with no table
+     * would be a pointless round trip on every admin page that includes it.
+     */
+    it('issues no request on a page that has no asset table', async () => {
+        document.body.innerHTML = '<div>Some other admin screen</div>';
+        loadModule();
+
+        await Promise.resolve();
+
+        expect(global.fetch).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
Closes #2008.

Opening the Assets screen showed a spinner that never resolved. Pressing **Refresh** loaded the table, and it worked from then on.

## Root cause

`View\Cwmassets\HtmlView::display()` fills the table from the **session**, not the model:

```php
$this->assets = $session->get('checklists', [], 'CWM');
```

The only thing that ever writes `checklists` is the `checkAssetsXHR` request behind the Refresh button. So on a first visit the array is empty, `admin/tmpl/cwmassets/edit.php` falls to its `else` branch — which renders a **spinner** — and `asset-fix.es6.js` bound the buttons in `bindEvents()` and stopped there.

The page said it was loading, nothing was loading, and it would say so indefinitely. **The spinner was not a slow request; there was no request.**

## The fix

The module issues that first load itself, guarded on the table being present:

```js
if (document.getElementById('asset-status-body')) {
    this.refreshAssetStatus();
}
```

The guard matters as much as the call — this script is loaded on more than the Assets screen, and an unguarded call would be a pointless round trip on every one of them.

**Deliberately left as an XHR** rather than moved into the view. The scan is not cheap, and blocking the page render on it trades one bad experience for another. The goal is to make the spinner honest, not to remove it.

## Testing

New `tests/js/asset-fix-initial-load.test.js` exercises the shipped module in jsdom rather than a copy of its logic:

- a request is issued without anything pressing Refresh
- the spinner is **replaced** — an empty result is still a result
- no request on a page with no asset table (the guard)

⚠️ **Canary-verified, and the first attempt was wrong**: deleting a rough slice broke the file syntactically and failed all three, which proves nothing. Removing exactly the added block — `node --check` clean — fails the two tests that assert the initial load while the guard test still passes. That is the correct split.

Full JS suite: **19 suites, 246 passed, 3 skipped**.

`media/js/` is gitignored and built at package time, so only the source is committed here; `npm run build` was run to confirm the fix reaches `media/js/asset-fix.js` and `.min.js`.

## Worth a separate look

Rendering from a session key means the screen can also show **stale** counts from whenever the XHR last ran, with nothing indicating their age. Loading on open makes that far less likely, but "the view reads a cache the view never populates" is still an odd arrangement, and the session is the wrong place for it. Noted in #2008 rather than fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)