### PR TITLE
chore(release): open the 10.6.1 patch cycle

### DIFF
--- a/build/release-notes-10.6.1.md
+++ b/build/release-notes-10.6.1.md
@@ -1,0 +1,21 @@
+A patch release fixing two problems introduced by 10.6.0. If you have installed 10.6.0, this is worth taking.
+
+## The "servers waiting to be migrated" notice would not go away
+
+If Proclaim told you that servers were waiting to be migrated, migrating them did not clear the message. Neither did unpublishing or deleting the servers it was pointing at. The notice appeared on the dashboard, in System Health, and at the end of a restore, and it stayed there.
+
+The count was looking at the wrong thing. When Proclaim finishes migrating a server it retires it, but the record keeps its original type — so the count went on including every server you had already dealt with. It could only ever have reached zero if you deleted the records outright.
+
+It now counts servers that are genuinely still waiting. Migrating them clears the notice, and servers you have trashed or unpublished yourself are no longer counted against you.
+
+If you have been looking at that message since updating to 10.6.0 and could not work out what was left to do: the answer may well be nothing, and this release will say so.
+
+## The Assets screen showed a spinner that never finished
+
+Opening Permissions → Assets showed a loading spinner and left it there. Pressing **Refresh** loaded the table, and it behaved from then on, so the problem only appeared on the first visit after an update or a new login.
+
+Nothing was actually loading. The screen was waiting for information it had never asked for. It now requests it when you open the screen, which is what the spinner was always claiming.
+
+## Requirements
+
+Joomla 5.4 or later, PHP 8.3 or later. Unchanged from 10.6.0.

--- a/build/versions.json
+++ b/build/versions.json
@@ -1,17 +1,17 @@
 {
     "_comment": "Development version tracking - semantic versioning: major.minor.patch",
-    "_updated": "2026-08-28",
+    "_updated": "2026-08-29",
     "current": {
         "version": "10.6.0",
         "description": "Last stable release (from GitHub releases)"
     },
     "next": {
-        "patch": "10.6.1",
+        "patch": "10.6.2",
         "minor": "10.7.0",
         "major": "11.0.0"
     },
     "active_development": {
-        "version": "10.7.0",
+        "version": "10.6.1",
         "description": "Use this for @since tags and migrations"
     },
     "notes": {


### PR DESCRIPTION
Opens the **10.6.1** patch cycle. 10.6.0 shipped two regressions that are worth a patch rather than a wait for 10.7.0 — both already fixed on `development`:

- **#2007** — the "servers waiting to be migrated" notice could not be cleared by migrating them
- **#2008** — the Assets screen showed a spinner that never resolved

## versions.json

| field | change | why |
|---|---|---|
| `active_development` | `10.7.0` → **`10.6.1`** | so the release substitutes `@since __DEPLOY_VERSION__` to the version actually being cut, and names the artifact for it |
| `next.patch` | `10.6.1` → `10.6.2` | the patch slot moves on |
| `next.minor` | `10.7.0` unchanged | where #2009 and #2012 stay |
| `current` | **untouched** | it records what has shipped; release step 8 sets it |

## Release notes

Written for an administrator deciding whether to update, so they lead with the symptom rather than the cause — "the notice that would not go away", "the spinner that never finished". They also say the thing worth saying out loud: if you have been staring at that migration message since 10.6.0 wondering what was left to do, the answer may be nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)