### PR TITLE
chore: open the 10.6.1 release cycle

### DIFF
--- a/build/pkg_proclaim.xml
+++ b/build/pkg_proclaim.xml
@@ -2,7 +2,7 @@
 <extension type="package" method="upgrade">
     <packagename>proclaim</packagename>
     <name>PKG_PROCLAIM</name>
-    <version>10.6.0</version>
+    <version>10.6.1</version>
     <creationDate>2026-08-29</creationDate>
     <author>CWM Team</author>
     <authorEmail>info@christianwebministries.org</authorEmail>

--- a/modules/admin/mod_proclaimicon/mod_proclaimicon.xml
+++ b/modules/admin/mod_proclaimicon/mod_proclaimicon.xml
@@ -7,7 +7,7 @@
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
     <authorEmail>info@christianwebministries.org</authorEmail>
     <authorUrl>www.christianwebministries.org</authorUrl>
-    <version>10.6.0</version>
+    <version>10.6.1</version>
     <description>MOD_PROCLAIMICON_XML_DESCRIPTION</description>
     <namespace path="src">CWM\Module\Proclaimicon</namespace>
     <files>

--- a/modules/site/mod_proclaim/mod_proclaim.xml
+++ b/modules/site/mod_proclaim/mod_proclaim.xml
@@ -5,7 +5,7 @@
     <authorEmail>info@christianwebministries.org</authorEmail>
     <authorUrl>www.christianwebministries.org</authorUrl>
     <copyright>(C) 2026 Proclaim All rights reserved.</copyright>
-    <version>10.6.0</version>
+    <version>10.6.1</version>
     <creationDate>2026-08-29</creationDate>
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
     <description>MOD_PROCLAIM_DESCRIPTION</description>

--- a/modules/site/mod_proclaim_podcast/mod_proclaim_podcast.xml
+++ b/modules/site/mod_proclaim_podcast/mod_proclaim_podcast.xml
@@ -7,7 +7,7 @@
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
     <authorEmail>info@christianwebministries.org</authorEmail>
     <authorUrl>www.christianwebministries.org</authorUrl>
-    <version>10.6.0</version>
+    <version>10.6.1</version>
     <description>MOD_PROCLAIM_PODCAST_XML_DESCRIPTION</description>
     <namespace path="src">CWM\Module\ProclaimPodcast</namespace>
     <files>

--- a/modules/site/mod_proclaim_youtube/mod_proclaim_youtube.xml
+++ b/modules/site/mod_proclaim_youtube/mod_proclaim_youtube.xml
@@ -5,7 +5,7 @@
     <authorEmail>info@christianwebministries.org</authorEmail>
     <authorUrl>www.christianwebministries.org</authorUrl>
     <copyright>(C) 2026 CWM Team All rights reserved</copyright>
-    <version>10.6.0</version>
+    <version>10.6.1</version>
     <creationDate>2026-08-29</creationDate>
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
     <description>MOD_PROCLAIM_YOUTUBE_DESCRIPTION</description>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "com_proclaim",
-  "version": "10.6.0",
+  "version": "10.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "com_proclaim",
-      "version": "10.6.0",
+      "version": "10.6.1",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@fancyapps/ui": "^6.1.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com_proclaim",
-  "version": "10.6.0",
+  "version": "10.6.1",
   "description": "CWM Proclaim - A Joomla! Extension for Church Media Management",
   "license": "GPL-2.0-or-later",
   "repository": {

--- a/plugins/finder/proclaim/proclaim.xml
+++ b/plugins/finder/proclaim/proclaim.xml
@@ -7,7 +7,7 @@
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
     <authorEmail>info@christianwebministries.org</authorEmail>
     <authorUrl>www.christianwebministries.org</authorUrl>
-    <version>10.6.0</version>
+    <version>10.6.1</version>
     <description>PLG_FINDER_PROCLAIM_XML_DESCRIPTION</description>
     <namespace path="src">CWM\Plugin\Finder\Proclaim</namespace>
     <files>

--- a/plugins/schemaorg/proclaim/proclaim.xml
+++ b/plugins/schemaorg/proclaim/proclaim.xml
@@ -7,7 +7,7 @@
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
     <authorEmail>info@christianwebministries.org</authorEmail>
     <authorUrl>www.christianwebministries.org</authorUrl>
-    <version>10.6.0</version>
+    <version>10.6.1</version>
     <description>PLG_SCHEMAORG_PROCLAIM_XML_DESCRIPTION</description>
     <namespace path="src">CWM\Plugin\Schemaorg\Proclaim</namespace>
     <files>

--- a/plugins/system/proclaim/proclaim.xml
+++ b/plugins/system/proclaim/proclaim.xml
@@ -7,7 +7,7 @@
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
     <authorEmail>info@christianwebministries.org</authorEmail>
     <authorUrl>www.christianwebministries.org</authorUrl>
-    <version>10.6.0</version>
+    <version>10.6.1</version>
     <description>PLG_SYSTEM_PROCLAIM_DESCRIPTION</description>
     <namespace path="src">CWM\Plugin\System\Proclaim</namespace>
     <files>

--- a/plugins/task/proclaim/proclaim.xml
+++ b/plugins/task/proclaim/proclaim.xml
@@ -7,7 +7,7 @@
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<authorEmail>info@christianwebministries.org</authorEmail>
 	<authorUrl>www.christianwebministries.org</authorUrl>
-	<version>10.6.0</version>
+	<version>10.6.1</version>
 	<description>PLG_TASK_PROCLAIM_XML_DESCRIPTION</description>
 	<namespace path="src">CWM\Plugin\Task\Proclaim</namespace>
 	<files>

--- a/plugins/webservices/proclaim/proclaim.xml
+++ b/plugins/webservices/proclaim/proclaim.xml
@@ -7,7 +7,7 @@
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
     <authorEmail>support@christianwebministries.org</authorEmail>
     <authorUrl>https://www.christianwebministries.org</authorUrl>
-    <version>10.6.0</version>
+    <version>10.6.1</version>
     <description>PLG_WEBSERVICES_PROCLAIM_DESCRIPTION</description>
     <namespace path="src">CWM\Plugin\WebServices\Proclaim</namespace>
     <files>

--- a/proclaim.xml
+++ b/proclaim.xml
@@ -6,7 +6,7 @@
     <authorEmail>info@christianwebministries.org</authorEmail>
     <authorUrl>www.christianwebministries.org</authorUrl>
     <copyright>(C) 2026 Proclaim All rights reserved.</copyright>
-    <version>10.6.0</version>
+    <version>10.6.1</version>
     <creationDate>2026-08-29</creationDate>
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
     <description>JBS_INS_XML_DESCRIPTION</description>


### PR DESCRIPTION
Moves the 11 manifests off 10.6.0 so the release gate can run.

## Why this is a separate commit

`build/test-upgrade.sh` refuses when the package manifest and the version being released disagree — the #1916 guard. It fired on the first 10.6.1 gate run:

```
ERROR: build/pkg_proclaim.xml declares 10.6.0, but this run claims to test
       an upgrade to 10.6.1.

       The manifests still carry the last released version, so the
       'upgrade' would install 10.6.0 over 10.6.0 and prove nothing.
```

Which is correct, and is the guard doing its job.

⚠️ It has to be its own commit, **before** the release: `cwm-release` runs the gate *before* its own bump step, deliberately — it verifies the commit being released, not the commit that results from bumping it. So the bump happens first and separately; the release's own bump then finds the manifests already correct and is a no-op.

`versions.json` is untouched — #2013 already set `active_development` to 10.6.1, which is where `cwm-bump` reads the target from.

Generated by `composer version -- -v 10.6.1`: 11 manifests plus `package.json` / `package-lock.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)