### PR TITLE
fix(media): read the modal title from the input Joomla renders

### DIFF
--- a/build/media_source/js/addon-vimeo-browser.es6.js
+++ b/build/media_source/js/addon-vimeo-browser.es6.js
@@ -290,7 +290,13 @@
             this.init();
 
             // Auto-search from study title (same pattern as YouTube)
-            const studyTitleField = document.getElementById('jform_study_id_name');
+            // ⚠️ Joomla 5's ModalSelectField puts the readable title in the input
+            // carrying the field's own id (class js-input-title) and the numeric
+            // value in `<id>_id`. The `<id>_name` read here before is the Joomla
+            // 3/4 modal_article convention and no longer exists, so this silently
+            // found nothing and the search box opened empty.
+            const studyTitleField = (document.querySelector('#jform_study_id.js-input-title')
+                || document.getElementById('jform_study_id'));
             if (studyTitleField && studyTitleField.value) {
                 const studyTitle = studyTitleField.value;
                 if (studyTitle.toLowerCase().indexOf('select') === -1) {

--- a/build/media_source/js/addon-wistia-browser.es6.js
+++ b/build/media_source/js/addon-wistia-browser.es6.js
@@ -286,7 +286,13 @@
             this.init();
 
             // Auto-search from study title
-            const studyTitleField = document.getElementById('jform_study_id_name');
+            // ⚠️ Joomla 5's ModalSelectField puts the readable title in the input
+            // carrying the field's own id (class js-input-title) and the numeric
+            // value in `<id>_id`. The `<id>_name` read here before is the Joomla
+            // 3/4 modal_article convention and no longer exists, so this silently
+            // found nothing and the search box opened empty.
+            const studyTitleField = (document.querySelector('#jform_study_id.js-input-title')
+                || document.getElementById('jform_study_id'));
             if (studyTitleField && studyTitleField.value) {
                 const studyTitle = studyTitleField.value;
                 if (studyTitle.toLowerCase().indexOf('select') === -1) {

--- a/build/media_source/js/addon-youtube-browser.es6.js
+++ b/build/media_source/js/addon-youtube-browser.es6.js
@@ -261,7 +261,13 @@
             this.init();
 
             // Get study title for auto-search
-            const studyTitleField = document.getElementById('jform_study_id_name');
+            // ⚠️ Joomla 5's ModalSelectField puts the readable title in the input
+            // carrying the field's own id (class js-input-title) and the numeric
+            // value in `<id>_id`. The `<id>_name` read here before is the Joomla
+            // 3/4 modal_article convention and no longer exists, so this silently
+            // found nothing and the search box opened empty.
+            const studyTitleField = (document.querySelector('#jform_study_id.js-input-title')
+                || document.getElementById('jform_study_id'));
             if (studyTitleField && studyTitleField.value) {
                 const studyTitle = studyTitleField.value;
                 // Skip if it's the placeholder text

--- a/build/media_source/js/message-wizard.es6.js
+++ b/build/media_source/js/message-wizard.es6.js
@@ -205,7 +205,12 @@ document.addEventListener('DOMContentLoaded', () => {
         html += '<dd class="col-sm-9">' + escHtml(teacherNames.join(', ') || '—') + '</dd>';
 
         // Series — get text from the modal field display
-        const seriesDisplay = document.getElementById('jform_series_id_name');
+        // ⚠️ Joomla 5's ModalSelectField puts the readable title in the input
+        // carrying the field's own id (class js-input-title) and the numeric value
+        // in `<id>_id`. The `<id>_name` read here before is the Joomla 3/4
+        // modal_article convention and no longer exists.
+        const seriesDisplay = (document.querySelector('#jform_series_id.js-input-title')
+                || document.getElementById('jform_series_id'));
         const seriesText = seriesDisplay ? seriesDisplay.value.trim() : '';
         html += '<dt class="col-sm-3">' + (t('JBS_CMN_SERIES', 'Series')) + '</dt>';
         html += '<dd class="col-sm-9">' + escHtml(seriesText || '—') + '</dd>';

--- a/tests/js/addon-youtube-browser.test.js
+++ b/tests/js/addon-youtube-browser.test.js
@@ -9,7 +9,14 @@ describe('addon-youtube-browser.es6.js', () => {
             // Set up DOM
             document.body.innerHTML = `
                 <input name="jform[server_id]" value="123" />
-                <input id="jform_study_id_name" value="" />
+                <!-- What Joomla 5 ModalSelectField actually renders: the readable
+                     title on the field id, the value on the id suffixed _id. The
+                     _name element that stood here is the Joomla 3/4 convention and
+                     never appears on a real page - a fixture matching the code
+                     rather than the CMS, which is how the empty-search bug
+                     survived. See tests/js/modal-title-prefill.test.js -->
+                <input class="js-input-title" id="jform_study_id" value="" />
+                <input type="hidden" id="jform_study_id_id" value="" />
                 <input name="jform[params][filename]" value="" />
             `;
 

--- a/tests/js/modal-title-prefill.test.js
+++ b/tests/js/modal-title-prefill.test.js
@@ -1,0 +1,127 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * The media browsers prefill their search box with the message title, so
+ * opening Browse on a sermon searches for that sermon rather than showing the
+ * whole channel. It stopped working because they read the wrong element.
+ *
+ * Joomla 5's `ModalSelectField` renders the readable title in the input
+ * carrying the field's own id, with class `js-input-title`, and puts the
+ * numeric value in `<id>_id`:
+ *
+ *   <input class="form-control js-input-title" id="jform_study_id" readonly>
+ *   <input type="hidden" id="jform_study_id_id" class="modal-value js-input-value">
+ *
+ * The browsers read `jform_study_id_name` — the Joomla 3/4 `modal_article`
+ * convention, which has not existed since the field was replaced. There is no
+ * such element, `getElementById` returned null, the guard treated that as "no
+ * title available", and the box opened empty with nothing reported.
+ *
+ * ⚠️ These build the fixture from core's own layout markup rather than from
+ * what the code happens to look for. A fixture written to match the code is how
+ * this survived: the existing suite asserts against an
+ * `<input id="jform_study_id_name">` that Joomla never renders.
+ *
+ * @package  Proclaim.Tests
+ * @since    __DEPLOY_VERSION__
+ */
+
+/**
+ * The markup Joomla 5 emits for a ModalSelectField, per
+ * layouts/joomla/form/field/modal-select.php.
+ *
+ * @param {string} fieldId The field id, e.g. 'jform_study_id'.
+ * @param {string} title   The readable title it is showing.
+ * @returns {string} The markup.
+ */
+function modalSelectMarkup(fieldId, title) {
+    return `
+        <div class="input-group">
+            <input class="form-control js-input-title" type="text"
+                   value="${title}" readonly id="${fieldId}" name="${fieldId}">
+            <input type="hidden" id="${fieldId}_id" class="modal-value js-input-value" value="7">
+        </div>
+    `;
+}
+
+describe('Media browsers prefill the search box from the message title', () => {
+    beforeEach(() => {
+        jest.resetModules();
+
+        global.Joomla = {
+            Text: { _: (key) => key },
+            getOptions: () => '',
+            renderMessages: () => {},
+        };
+
+        window.cwmAlert = jest.fn(() => Promise.resolve());
+        global.fetch = jest.fn(() => Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve({ success: true, data: {} }),
+        }));
+    });
+
+    afterEach(() => {
+        document.body.innerHTML = '';
+        delete window.Proclaim;
+        delete global.fetch;
+    });
+
+    // ⚠️ The three modules do not agree on the property name — Wistia calls it
+    // searchName where the others call it searchQuery. Parameterised rather
+    // than normalised, because asserting a name the module does not use would
+    // fail for a reason unrelated to the bug under test.
+    describe.each([
+        ['YoutubeBrowser', 'addon-youtube-browser', 'searchQuery'],
+        ['VimeoBrowser', 'addon-vimeo-browser', 'searchQuery'],
+        ['WistiaBrowser', 'addon-wistia-browser', 'searchName'],
+    ])('%s', (globalName, moduleName, queryProp) => {
+        /**
+         * Load a browser module against the current DOM.
+         *
+         * @returns {object|undefined} The browser object, if it registered one.
+         */
+        function loadBrowser() {
+            jest.isolateModules(() => {
+                require(`../../build/media_source/js/${moduleName}.es6.js`);
+            });
+
+            return (window.Proclaim || {})[globalName];
+        }
+
+        it('reads the title from the element Joomla actually renders', async () => {
+            document.body.innerHTML = `
+                <input name="jform[server_id]" value="123">
+                ${modalSelectMarkup('jform_study_id', 'The Prodigal Son')}
+                <input name="jform[params][filename]" value="">
+            `;
+
+            const browser = loadBrowser();
+
+            if (!browser || typeof browser.open !== 'function') {
+                throw new Error(`${globalName} did not register an open() — the fixture is wrong, not the code.`);
+            }
+
+            browser.serverId = 123;
+            await browser.open();
+
+            expect(browser[queryProp]).toBe('The Prodigal Son');
+        });
+
+        it('does not prefill from the placeholder text', async () => {
+            document.body.innerHTML = `
+                <input name="jform[server_id]" value="123">
+                ${modalSelectMarkup('jform_study_id', 'Select a Message')}
+                <input name="jform[params][filename]" value="">
+            `;
+
+            const browser = loadBrowser();
+            browser.serverId = 123;
+            await browser.open();
+
+            expect(browser[queryProp]).not.toBe('Select a Message');
+        });
+    });
+});


### PR DESCRIPTION
Closes #2015.

**Browse** opened with an empty search box. It should prefill with the message title so the search finds that sermon rather than the whole channel.

## Root cause

The prefill read `jform_study_id_name` — **an element that does not exist**.

Joomla 5's `ModalSelectField` (which `Modal_Study` and `Modal_Series` both extend) renders, per `layouts/joomla/form/field/modal-select.php`:

```html
<input class="form-control js-input-title" id="jform_study_id" readonly>
<input type="hidden" id="jform_study_id_id" class="modal-value js-input-value">
```

Title on the field's own id; value on `<id>_id`. The `<id>_name` form is the Joomla 3/4 `modal_article` convention, gone since the field was replaced. `getElementById` returned `null`, the guard read it as "no title available", and the box opened empty with nothing logged.

## Four readers, same mistake

| File | Was | Now |
|---|---|---|
| `addon-youtube-browser.es6.js` | `jform_study_id_name` | `#jform_study_id.js-input-title` |
| `addon-vimeo-browser.es6.js` | `jform_study_id_name` | ″ |
| `addon-wistia-browser.es6.js` | `jform_study_id_name` | ″ |
| `message-wizard.es6.js` | `jform_series_id_name` | `#jform_series_id.js-input-title` |

⚠️ `mediafile-edit.es6.js` uses `jform_server_id_name` and is **deliberately left alone** — it *creates* that element itself rather than reading one Joomla rendered. Different case, correct as it stands.

## ⚠️ Why nothing caught this

The existing test built its fixture from what the code looked for:

```js
<input id="jform_study_id_name" value="" />
```

Markup Joomla never emits. **The fixture agreed with the bug**, so the suite was green while the feature was broken on every real page. That fixture is corrected here, and the new `tests/js/modal-title-prefill.test.js` builds its DOM from core's own modal-select layout instead — the fixture now comes from the CMS, not from the code under test.

## Testing

New tests cover all three browsers: the title is picked up, and the "Select a Message" placeholder is still not used as a query.

**Canary-verified per module**: restoring the old id in one browser fails exactly that browser's assertion and leaves the other two passing — so each module is genuinely covered rather than one standing in for three.

Wistia calls the property `searchName` where the others call it `searchQuery`. The test parameterises that rather than normalising it, since asserting a name a module does not use would fail for a reason unrelated to the bug.

Full JS suite: **20 suites, 252 passed, 3 skipped**. `npm run build` confirms the fix reaches `media/js/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)