### PR TITLE
docs(release): add the Browse search fix to the 10.6.1 notes

### DIFF
--- a/build/release-notes-10.6.1.md
+++ b/build/release-notes-10.6.1.md
@@ -1,4 +1,4 @@
-A patch release fixing two problems introduced by 10.6.0. If you have installed 10.6.0, this is worth taking.
+A patch release fixing three problems. If you have installed 10.6.0, this is worth taking.
 
 ## The "servers waiting to be migrated" notice would not go away
 
@@ -15,6 +15,14 @@ If you have been looking at that message since updating to 10.6.0 and could not 
 Opening Permissions → Assets showed a loading spinner and left it there. Pressing **Refresh** loaded the table, and it behaved from then on, so the problem only appeared on the first visit after an update or a new login.
 
 Nothing was actually loading. The screen was waiting for information it had never asked for. It now requests it when you open the screen, which is what the spinner was always claiming.
+
+## Browse opened without searching for your message
+
+On a media file, **Browse** is meant to start by searching for the message you are working on, rather than showing you the whole channel. It had stopped doing that and opened on an unfiltered list, so you had to type the title in yourself every time.
+
+This affected the YouTube, Vimeo and Wistia browsers, and the series box in the message wizard alongside them. All four now fill in the title again.
+
+Unlike the two above, this one was not introduced by 10.6.0 — it broke when the underlying Joomla field changed, and had been quietly doing nothing for some time.
 
 ## Requirements
 


### PR DESCRIPTION
#2015 landed after the 10.6.1 notes were written, so they described two fixes and the release ships three.

Adds the Browse prefill fix, and notes the thing that makes it different from the other two: **it was not introduced by 10.6.0.** It broke when Joomla replaced the modal field it read, so it had been quietly doing nothing for some time. An administrator reading "fixes a regression in 10.6.0" three times would reasonably conclude 10.6.0 caused all of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)