### PR TITLE
fix(assets): measure drift against the section a record is parented to

### DIFF
--- a/admin/src/Lib/Cwmassets.php
+++ b/admin/src/Lib/Cwmassets.php
@@ -924,15 +924,29 @@ class Cwmassets
             array_map(static fn ($v) => $db->quote($v), self::EMPTY_RULE_VARIANTS)
         );
 
+        // ⚠️ Item-scoped on both halves. Empty rules are normal on a section
+        // row — it simply has no override — so only an item row with empty
+        // rules is cleanup material. And an item belongs under its section, so
+        // the acceptable parents are com_proclaim plus every section row.
+        $acceptable = [$parentId];
+
+        foreach (self::declaredSections() as $section) {
+            $sectionId = self::sectionId($section);
+
+            if ($sectionId > 0) {
+                $acceptable[] = $sectionId;
+            }
+        }
+
         try {
             $query = $db->createQuery()
                 ->select('COUNT(*)')
                 ->from($db->quoteName('#__assets'))
-                ->where($db->quoteName('name') . ' LIKE ' . $db->quote('com_proclaim.%'))
-                ->where($db->quoteName('name') . ' <> ' . $db->quote('com_proclaim'))
+                ->where($db->quoteName('name') . ' LIKE ' . $db->quote('com_proclaim.%.%'))
                 ->where(
                     '(' . $db->quoteName('rules') . ' IN (' . $emptyQuoted . ')'
-                    . ' OR ' . $db->quoteName('parent_id') . ' <> ' . (int) $parentId . ')'
+                    . ' OR ' . $db->quoteName('parent_id')
+                    . ' NOT IN (' . implode(',', array_map('intval', $acceptable)) . '))'
                 );
             $db->setQuery($query);
 
@@ -1029,10 +1043,13 @@ class Cwmassets
 
         // Now delete the asset rows themselves.
         try {
+            // ⚠️ Item rows only. A section asset (com_proclaim.<section>) has
+            // empty rules whenever no override is set — the ordinary state —
+            // and it is load-bearing, because every item asset is parented to
+            // it. Items carry a third segment, which is what separates them.
             $query = $db->createQuery()
                 ->delete($db->quoteName('#__assets'))
-                ->where($db->quoteName('name') . ' LIKE ' . $db->quote('com_proclaim.%'))
-                ->where($db->quoteName('name') . ' <> ' . $db->quote('com_proclaim'))
+                ->where($db->quoteName('name') . ' LIKE ' . $db->quote('com_proclaim.%.%'))
                 ->where($db->quoteName('rules') . ' IN (' . $emptyQuoted . ')');
             $db->setQuery($query);
             $db->execute();
@@ -1074,17 +1091,49 @@ class Cwmassets
             return 0;
         }
 
+        // ⚠️ One statement per section, because each item belongs under the
+        // parent its own Table::_getAssetParentId() would give it. A single
+        // blanket update onto com_proclaim would move correctly parented items
+        // out of the section whose rules are meant to reach them.
+        $moved = 0;
+
         try {
+            foreach (self::getAssetObjects() as $info) {
+                $section       = $info['assetname'];
+                $sectionParent = self::sectionParentId($section);
+
+                if ($sectionParent < 1) {
+                    continue;
+                }
+
+                $query = $db->createQuery()
+                    ->update($db->quoteName('#__assets'))
+                    ->set($db->quoteName('parent_id') . ' = ' . (int) $sectionParent)
+                    ->where($db->quoteName('name') . ' LIKE ' . $db->quote('com_proclaim.' . $section . '.%'))
+                    ->where($db->quoteName('parent_id') . ' <> ' . (int) $sectionParent);
+                $db->setQuery($query);
+                $db->execute();
+                $moved += (int) $db->getAffectedRows();
+            }
+
+            // Section rows belong directly under com_proclaim.
             $query = $db->createQuery()
                 ->update($db->quoteName('#__assets'))
                 ->set($db->quoteName('parent_id') . ' = ' . (int) $parentId)
                 ->where($db->quoteName('name') . ' LIKE ' . $db->quote('com_proclaim.%'))
-                ->where($db->quoteName('name') . ' <> ' . $db->quote('com_proclaim'))
+                ->where($db->quoteName('name') . ' NOT LIKE ' . $db->quote('com_proclaim.%.%'))
                 ->where($db->quoteName('parent_id') . ' <> ' . (int) $parentId);
             $db->setQuery($query);
             $db->execute();
+            $moved += (int) $db->getAffectedRows();
 
-            return (int) $db->getAffectedRows();
+            // ⚠️ These are raw parent_id writes, which leave lft/rgt pointing at
+            // the old position. That is only safe because fixAllAssets() calls
+            // Asset::rebuild() whenever this returns non-zero — the count below
+            // is what triggers it. Anything calling this directly must rebuild
+            // too, or Access::getAssetRules()'s lft/rgt walk will not see the
+            // new ancestry.
+            return $moved;
         } catch (\Exception $e) {
             Log::add(
                 'Reparent surviving assets error: ' . $e->getMessage(),
@@ -1265,12 +1314,21 @@ class Cwmassets
         // as an ancestor -- an asset row that exists but is silently
         // broken, without a full Asset::rebuild() to catch it.
         // moveByReference() performs a proper nested-set node move.
-        if ((int) ($item->parent_id ?? 0) !== (int) $parentId) {
+        // ⚠️ The target is the record's own section, not com_proclaim — the
+        // same call Table::_getAssetParentId() makes, so the two cannot
+        // disagree. It falls back to com_proclaim when the section is absent.
+        $targetParent = self::sectionParentId($assetName);
+
+        if ($targetParent < 1) {
+            $targetParent = $parentId;
+        }
+
+        if ((int) ($item->parent_id ?? 0) !== (int) $targetParent) {
             $assetTable = new \Joomla\CMS\Table\Asset($db);
 
-            if (!$assetTable->moveByReference($parentId, 'last-child', (int) $item->asset_id)) {
+            if (!$assetTable->moveByReference($targetParent, 'last-child', (int) $item->asset_id)) {
                 Log::add(
-                    'fixSingleRecord: failed to move asset ' . $item->asset_id . ' under parent ' . $parentId,
+                    'fixSingleRecord: failed to move asset ' . $item->asset_id . ' under parent ' . $targetParent,
                     Log::WARNING,
                     'com_proclaim'
                 );
@@ -1453,6 +1511,12 @@ class Cwmassets
             $sourceTbl = $info['name'];
             $assetName = $info['assetname'];
 
+            // ⚠️ Drift is measured against the parent this table's records are
+            // actually given — sectionParentId(), the same call
+            // Table::_getAssetParentId() makes — not against com_proclaim. A
+            // correctly stored record is parented to its section.
+            $expectedParent = self::sectionParentId($assetName);
+
             // numrows/inherited/custom_rules/needs_cleanup/drifted collapsed
             // into one conditional-aggregation query per table (was 5).
             // The LEFT JOIN keeps COUNT(*) equal to the source row count —
@@ -1469,7 +1533,7 @@ class Cwmassets
                             . ', SUM(CASE WHEN ' . $db->quoteName('a.id') . ' IS NOT NULL AND '
                                 . $db->quoteName('a.rules') . ' IN (' . $emptyQuoted . ') THEN 1 ELSE 0 END) AS needs_cleanup'
                             . ', SUM(CASE WHEN ' . $db->quoteName('a.id') . ' IS NOT NULL AND '
-                                . $db->quoteName('a.parent_id') . ' <> ' . (int) $parentId . ' THEN 1 ELSE 0 END) AS drifted'
+                                . $db->quoteName('a.parent_id') . ' <> ' . (int) $expectedParent . ' THEN 1 ELSE 0 END) AS drifted'
                         )
                         ->from($db->quoteName($sourceTbl, 's'))
                         ->leftJoin(
@@ -1578,19 +1642,20 @@ class Cwmassets
             return null;
         }
 
-        $needsCleanup = (int) ($counts['needs_cleanup'] ?? 0);
+        // ⚠️ A section row with empty rules is not cleanup material: it means
+        // no override is set, which is the ordinary state, and the row is
+        // load-bearing because every item asset is parented to it. Reported as
+        // inheriting, which is what it does.
+        $noOverride = (int) ($counts['needs_cleanup'] ?? 0);
 
         return [
-            'realname'  => 'JBS_ADM_ASSETS_SECTION_ROWS',
-            'tablename' => '#__assets',
-            'assetname' => 'section',
-            'numrows'   => $numrows,
-            // A section row is not "inherited" in the per-record sense: nothing
-            // points at it. Carrying the ones with rules of their own under
-            // custom_rules keeps the columns meaning what their headings say.
-            'inherited'     => 0,
-            'custom_rules'  => $numrows - $needsCleanup,
-            'needs_cleanup' => $needsCleanup,
+            'realname'      => 'JBS_ADM_ASSETS_SECTION_ROWS',
+            'tablename'     => '#__assets',
+            'assetname'     => 'section',
+            'numrows'       => $numrows,
+            'inherited'     => $noOverride,
+            'custom_rules'  => $numrows - $noOverride,
+            'needs_cleanup' => 0,
             'drifted'       => (int) ($counts['drifted'] ?? 0),
             'orphans'       => 0,
             'parent_id'     => $parentId,

--- a/admin/src/Lib/Cwmassets.php
+++ b/admin/src/Lib/Cwmassets.php
@@ -924,34 +924,47 @@ class Cwmassets
             array_map(static fn ($v) => $db->quote($v), self::EMPTY_RULE_VARIANTS)
         );
 
-        // ⚠️ Item-scoped on both halves. Empty rules are normal on a section
-        // row — it simply has no override — so only an item row with empty
-        // rules is cleanup material. And an item belongs under its section, so
-        // the acceptable parents are com_proclaim plus every section row.
-        $acceptable = [$parentId];
-
-        foreach (self::declaredSections() as $section) {
-            $sectionId = self::sectionId($section);
-
-            if ($sectionId > 0) {
-                $acceptable[] = $sectionId;
-            }
-        }
-
+        // ⚠️ Item-scoped, and per-section. Empty rules are normal on a section
+        // row — it simply has no override — so only an *item* row with empty
+        // rules is cleanup material.
+        //
+        // The parent test has to name the section, not merely accept any of
+        // them. An item sitting on com_proclaim while its own section row
+        // exists is exactly the state a flatten leaves behind, and treating
+        // com_proclaim as universally acceptable would report that site as
+        // clean and never repair it. sectionParentId() returns com_proclaim
+        // only when the section is genuinely absent, which is where an item
+        // does belong.
         try {
             $query = $db->createQuery()
                 ->select('COUNT(*)')
                 ->from($db->quoteName('#__assets'))
                 ->where($db->quoteName('name') . ' LIKE ' . $db->quote('com_proclaim.%.%'))
-                ->where(
-                    '(' . $db->quoteName('rules') . ' IN (' . $emptyQuoted . ')'
-                    . ' OR ' . $db->quoteName('parent_id')
-                    . ' NOT IN (' . implode(',', array_map('intval', $acceptable)) . '))'
-                );
+                ->where($db->quoteName('rules') . ' IN (' . $emptyQuoted . ')');
             $db->setQuery($query);
 
             if ((int) $db->loadResult() > 0) {
                 return true;
+            }
+
+            foreach (self::getAssetObjects() as $info) {
+                $section  = $info['assetname'];
+                $expected = self::sectionParentId($section);
+
+                if ($expected < 1) {
+                    continue;
+                }
+
+                $query = $db->createQuery()
+                    ->select('COUNT(*)')
+                    ->from($db->quoteName('#__assets'))
+                    ->where($db->quoteName('name') . ' LIKE ' . $db->quote('com_proclaim.' . $section . '.%'))
+                    ->where($db->quoteName('parent_id') . ' <> ' . (int) $expected);
+                $db->setQuery($query);
+
+                if ((int) $db->loadResult() > 0) {
+                    return true;
+                }
             }
         } catch (\Exception $e) {
             // If the drift probe fails, fall through to the full fix path

--- a/admin/src/Lib/Cwmassets.php
+++ b/admin/src/Lib/Cwmassets.php
@@ -752,6 +752,60 @@ class Cwmassets
     }
 
     /**
+     * Map every declared section to the parent an item of it should carry,
+     * without creating anything.
+     *
+     * ⚠️ Read-only on purpose. sectionParentId() resolves through sectionId(),
+     * which *creates* a missing section row — fine on a repair path, wrong for
+     * a status report, and expensive: called once per table it turned a bounded
+     * report into 113 queries and had it writing rows as a side effect. One
+     * query here serves all 14 tables, and a section that does not exist falls
+     * back to com_proclaim, which is where such an item does belong.
+     *
+     * @param   DatabaseInterface  $db        Database driver
+     * @param   int                $parentId  com_proclaim asset id, the fallback
+     *
+     * @return  array<string, int>  Section name => expected parent asset id
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private static function sectionParentMap(DatabaseInterface $db, int $parentId): array
+    {
+        $sections = self::declaredSections();
+        $map      = array_fill_keys($sections, $parentId);
+
+        if ($sections === []) {
+            return $map;
+        }
+
+        $names = array_map(
+            static fn ($section) => $db->quote('com_proclaim.' . $section),
+            $sections
+        );
+
+        try {
+            $db->setQuery(
+                $db->createQuery()
+                    ->select([$db->quoteName('id'), $db->quoteName('name')])
+                    ->from($db->quoteName('#__assets'))
+                    ->where($db->quoteName('name') . ' IN (' . implode(',', $names) . ')')
+            );
+
+            foreach ($db->loadAssocList() as $row) {
+                $section = substr((string) $row['name'], \strlen('com_proclaim.'));
+
+                if (isset($map[$section])) {
+                    $map[$section] = (int) $row['id'];
+                }
+            }
+        } catch (\Exception $e) {
+            Log::add('sectionParentMap lookup failed: ' . $e->getMessage(), Log::WARNING, 'com_proclaim');
+        }
+
+        return $map;
+    }
+
+    /**
      * Get the com_proclaim parent asset ID, creating it if missing.
      *
      * CRITICAL: This method MUST never return 0.  All 14 Table classes call
@@ -947,9 +1001,11 @@ class Cwmassets
                 return true;
             }
 
+            $parentMap = self::sectionParentMap($db, $parentId);
+
             foreach (self::getAssetObjects() as $info) {
                 $section  = $info['assetname'];
-                $expected = self::sectionParentId($section);
+                $expected = $parentMap[$section] ?? $parentId;
 
                 if ($expected < 1) {
                     continue;
@@ -1511,9 +1567,10 @@ class Cwmassets
      */
     public static function getAssetStatus(): array
     {
-        $db       = Factory::getContainer()->get(DatabaseInterface::class);
-        $parentId = self::parentId();
-        $status   = [];
+        $db        = Factory::getContainer()->get(DatabaseInterface::class);
+        $parentId  = self::parentId();
+        $parentMap = self::sectionParentMap($db, $parentId);
+        $status    = [];
 
         $emptyQuoted = implode(
             ',',
@@ -1525,10 +1582,9 @@ class Cwmassets
             $assetName = $info['assetname'];
 
             // ⚠️ Drift is measured against the parent this table's records are
-            // actually given — sectionParentId(), the same call
-            // Table::_getAssetParentId() makes — not against com_proclaim. A
+            // actually given — its section — not against com_proclaim. A
             // correctly stored record is parented to its section.
-            $expectedParent = self::sectionParentId($assetName);
+            $expectedParent = $parentMap[$assetName] ?? $parentId;
 
             // numrows/inherited/custom_rules/needs_cleanup/drifted collapsed
             // into one conditional-aggregation query per table (was 5).

--- a/tests/integration/Admin/Lib/CwmassetsSectionSurvivalTest.php
+++ b/tests/integration/Admin/Lib/CwmassetsSectionSurvivalTest.php
@@ -320,6 +320,86 @@ class CwmassetsSectionSurvivalTest extends IntegrationTestCase
     }
 
     /**
+     * The repair path for sites the old cleanup already flattened.
+     *
+     * Those sites hold item assets sitting directly on com_proclaim with their
+     * section rows deleted. A later update reseeds the sections, but nothing
+     * moves the items back unless the drift probe recognises the state — and
+     * treating com_proclaim as a universally acceptable parent would report
+     * such a site as clean for ever.
+     *
+     * @return  void
+     * @since __DEPLOY_VERSION__
+     */
+    #[TestDox('An item flattened onto com_proclaim is moved back under its section')]
+    public function testFlattenedItemIsRepaired(): void
+    {
+        Cwmassets::seedSections();
+        Cwmassets::clearSectionCache();
+
+        $sectionId = Cwmassets::sectionParentId('message');
+        $rootId    = Cwmassets::parentId();
+
+        if ($sectionId < 1 || $sectionId === $rootId) {
+            $this->markTestSkipped('The message section could not be resolved on this install.');
+        }
+
+        $this->created[] = $sectionId;
+
+        // ⚠️ The record has to exist first, and the asset has to be named after
+        // its real id. cleanOrphanedAssets() deletes any com_proclaim.<sec>.<id>
+        // whose source record is gone, so an asset named for an id that never
+        // existed is removed as an orphan before the reparent is even reached —
+        // which is what a first version of this test actually measured.
+        $studyId = $this->createStudyRow(0);
+
+        // The flattened shape: a real-rules item parked on com_proclaim.
+        $asset = new Asset($this->db);
+        $asset->setLocation($rootId, 'last-child');
+        $asset->name  = 'com_proclaim.message.' . $studyId;
+        $asset->title = 'Flattened fixture';
+        $asset->rules = '{"core.edit":{"6":1}}';
+
+        $this->assertTrue($asset->check() && $asset->store(), 'Fixture asset could not be stored.');
+
+        $assetId         = (int) $asset->id;
+        $this->created[] = $assetId;
+
+        $this->db->setQuery(
+            'UPDATE ' . $this->db->quoteName('#__bsms_studies')
+            . ' SET ' . $this->db->quoteName('asset_id') . ' = ' . $assetId
+            . ' WHERE ' . $this->db->quoteName('id') . ' = ' . (int) $studyId
+        )->execute();
+
+        // ⚠️ Assert the starting state, or a pass could mean the fixture never
+        // landed where the test says it did.
+        $this->db->setQuery(
+            'SELECT parent_id FROM ' . $this->db->quoteName('#__assets')
+            . ' WHERE ' . $this->db->quoteName('id') . ' = ' . $assetId
+        );
+        $this->assertSame($rootId, (int) $this->db->loadResult(), 'Fixture did not start flattened.');
+
+        $this->assertTrue(
+            Cwmassets::hasAnyDrift($this->db, $rootId),
+            'A flattened item must register as drift, or fixAllAssets() returns early and never repairs it.'
+        );
+
+        Cwmassets::fixAllAssets();
+
+        $this->db->setQuery(
+            'SELECT parent_id FROM ' . $this->db->quoteName('#__assets')
+            . ' WHERE ' . $this->db->quoteName('id') . ' = ' . $assetId
+        );
+
+        $this->assertSame(
+            $sectionId,
+            (int) $this->db->loadResult(),
+            'The item was not moved back under com_proclaim.message, so a site flattened by the '
+            . 'old cleanup would stay flattened and its section rules would never reach it.'
+        );
+    }
+
+    /**
      * The prune still has to do its job — this is the behaviour the section
      * exclusion must not have broken.
      *

--- a/tests/integration/Admin/Lib/CwmassetsSectionSurvivalTest.php
+++ b/tests/integration/Admin/Lib/CwmassetsSectionSurvivalTest.php
@@ -1,0 +1,347 @@
+<?php
+
+/**
+ * #2018: the asset cleanup destroyed the structure it was meant to repair.
+ *
+ * Since 10.5.8 every Table::_getAssetParentId() returns
+ * `sectionParentId(<section>)`, so a stored record's asset is parented to its
+ * section. But the status and cleanup code compared against `com_proclaim`:
+ *
+ *   - `getAssetStatus()` reported every correctly parented record as drifted,
+ *     which is why Parent Drifted equalled Custom Rules exactly, in every row.
+ *   - `hasAnyDrift()` therefore always returned true, so the "nothing to do"
+ *     fast path could never fire and every install ran the full rewrite.
+ *   - `pruneEmptyAssetRows()` matched `com_proclaim.%`, so it deleted the
+ *     section rows `seedSections()` had just created — an empty-rules section
+ *     means "no override set", not "unused".
+ *   - `reparentSurvivingAssets()` then flattened the survivors onto
+ *     `com_proclaim`, moving items out of the sections whose rules are meant
+ *     to reach them.
+ *
+ * The net effect was that per-section permissions were torn down by the same
+ * install that set them up, silently. Every dev site here had already been
+ * flattened, which is why nothing reproduced it.
+ *
+ * ⚠️ These assert the surviving structure after a real `fixAllAssets()` run,
+ * not the return values of the individual steps. The previous tests seeded
+ * sections and asserted properties of them directly, so nothing ever observed
+ * a seed and a cleanup in the same test — which is the only place the bug was
+ * visible.
+ *
+ * @package    Proclaim.IntegrationTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ *
+ * @since __DEPLOY_VERSION__
+ */
+
+namespace CWM\Component\Proclaim\Tests\Integration\Admin\Lib;
+
+use CWM\Component\Proclaim\Administrator\Lib\Cwmassets;
+use CWM\Component\Proclaim\Tests\Integration\IntegrationTestCase;
+use Joomla\CMS\Access\Access;
+use Joomla\CMS\Factory;
+use Joomla\CMS\Table\Asset;
+use Joomla\Database\DatabaseInterface;
+use PHPUnit\Framework\Attributes\TestDox;
+
+/**
+ * @since __DEPLOY_VERSION__
+ */
+class CwmassetsSectionSurvivalTest extends IntegrationTestCase
+{
+    /**
+     * @var DatabaseInterface|null
+     * @since __DEPLOY_VERSION__
+     */
+    private ?DatabaseInterface $db = null;
+
+    /**
+     * Asset ids this test created, removed again in tearDown.
+     *
+     * @var list<int>
+     * @since __DEPLOY_VERSION__
+     */
+    private array $created = [];
+
+    /**
+     * Source rows this test inserted, removed again in tearDown.
+     *
+     * @var list<int>
+     * @since __DEPLOY_VERSION__
+     */
+    private array $createdStudies = [];
+
+    /**
+     * @return  void
+     * @since __DEPLOY_VERSION__
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->db = Factory::getContainer()->get(DatabaseInterface::class);
+
+        if (!Cwmassets::declaredSections()) {
+            $this->markTestSkipped('access.xml is not readable from this install path.');
+        }
+    }
+
+    /**
+     * ⚠️ Explicit deletes, not a transaction. Table\Asset::store() takes a
+     * table lock, and a lock is an implicit COMMIT in MySQL, so a
+     * transaction-wrapped asset test leaks its rows rather than rolling back.
+     *
+     * @return  void
+     * @since __DEPLOY_VERSION__
+     */
+    protected function tearDown(): void
+    {
+        foreach (array_reverse($this->created) as $id) {
+            $asset = new Asset($this->db);
+
+            if ($asset->load($id)) {
+                $asset->delete();
+            }
+        }
+
+        foreach ($this->createdStudies as $studyId) {
+            $this->db->setQuery(
+                'DELETE FROM ' . $this->db->quoteName('#__bsms_studies')
+                . ' WHERE ' . $this->db->quoteName('id') . ' = ' . (int) $studyId
+            )->execute();
+        }
+
+        $this->createdStudies = [];
+        $this->created        = [];
+
+        Cwmassets::clearSectionCache();
+        Access::clearStatics();
+
+        parent::tearDown();
+    }
+
+    /**
+     * Create an item asset under its section, the way a stored record's would be.
+     *
+     * @param   string  $section  Section name, e.g. 'message'.
+     * @param   int     $id       Synthetic record id.
+     * @param   string  $rules    Rules JSON; '{}' means no override.
+     *
+     * @return  int  The new asset id.
+     *
+     * @since __DEPLOY_VERSION__
+     */
+    private function createItemAsset(string $section, int $id, string $rules): int
+    {
+        $asset = new Asset($this->db);
+        $asset->setLocation(Cwmassets::sectionParentId($section), 'last-child');
+        $asset->name  = 'com_proclaim.' . $section . '.' . $id;
+        $asset->title = 'Survival fixture ' . $section . ' ' . $id;
+        $asset->rules = $rules;
+
+        $this->assertTrue($asset->check() && $asset->store(), 'Fixture asset could not be stored.');
+
+        $this->created[] = (int) $asset->id;
+
+        return (int) $asset->id;
+    }
+
+    /**
+     * Insert a message row pointing at an asset.
+     *
+     * ⚠️ Required. getAssetStatus() counts
+     * `FROM #__bsms_studies s LEFT JOIN #__assets a ON s.asset_id = a.id`, so
+     * an asset row with no record referencing it is never counted — a first
+     * version of this test created the asset alone and measured nothing.
+     *
+     * @param   int  $assetId  The asset the record should carry.
+     *
+     * @return  int  The new record id.
+     *
+     * @since __DEPLOY_VERSION__
+     */
+    private function createStudyRow(int $assetId): int
+    {
+        $this->db->setQuery(
+            'INSERT INTO ' . $this->db->quoteName('#__bsms_studies')
+            . ' (' . $this->db->quoteName('studytitle') . ', ' . $this->db->quoteName('asset_id')
+            . ', ' . $this->db->quoteName('language') . ')'
+            . ' VALUES (' . $this->db->quote('Survival fixture') . ', ' . (int) $assetId . ', '
+            . $this->db->quote('*') . ')'
+        )->execute();
+
+        $id = (int) $this->db->insertid();
+
+        $this->createdStudies[] = $id;
+
+        return $id;
+    }
+
+    /**
+     * Read a section asset's id straight from the table, bypassing the cache.
+     *
+     * @param   string  $section  Section name.
+     *
+     * @return  int  Asset id, or 0 when the row is absent.
+     *
+     * @since __DEPLOY_VERSION__
+     */
+    private function sectionRowId(string $section): int
+    {
+        $this->db->setQuery(
+            $this->db->getQuery(true)
+                ->select($this->db->quoteName('id'))
+                ->from($this->db->quoteName('#__assets'))
+                ->where($this->db->quoteName('name') . ' = ' . $this->db->quote('com_proclaim.' . $section))
+        );
+
+        return (int) $this->db->loadResult();
+    }
+
+    /**
+     * The headline: a cleanup pass must not delete the sections a seed created.
+     *
+     * @return  void
+     * @since __DEPLOY_VERSION__
+     */
+    #[TestDox('Section assets survive a full fixAllAssets() pass')]
+    public function testSectionsSurviveCleanup(): void
+    {
+        $before = [];
+
+        foreach (Cwmassets::declaredSections() as $section) {
+            $before[$section] = $this->sectionRowId($section);
+        }
+
+        Cwmassets::seedSections();
+        Cwmassets::clearSectionCache();
+
+        $seeded = [];
+
+        foreach (Cwmassets::declaredSections() as $section) {
+            $id = $this->sectionRowId($section);
+
+            if ($id > 0 && ($before[$section] ?? 0) === 0) {
+                $this->created[] = $id;
+            }
+
+            $seeded[$section] = $id;
+        }
+
+        // ⚠️ Positive control. If seeding produced nothing, every assertion
+        // below would pass against an empty set and prove nothing.
+        $this->assertNotEmpty(
+            array_filter($seeded),
+            'seedSections() resolved no section rows — the assertions below would be vacuous.'
+        );
+
+        // ⚠️ Without this the test proves nothing. fixAllAssets() returns early
+        // when hasAnyDrift() is false, so with a clean database the prune never
+        // runs and the sections "survive" only because nothing happened — a
+        // first version of this test passed against the unfixed code for
+        // exactly that reason. An empty-rules item asset is drift, so the full
+        // path runs and the prune genuinely gets its chance at the sections.
+        $bait = $this->createItemAsset('message', 999003, '{}');
+
+        Cwmassets::fixAllAssets();
+        Cwmassets::clearSectionCache();
+
+        // Proof the cleanup ran rather than short-circuiting.
+        $baitAsset = new Asset($this->db);
+
+        $this->assertFalse(
+            $baitAsset->load($bait),
+            'The empty-rules item asset was not pruned, so fixAllAssets() took the early '
+            . 'return — the section assertions below would be survival by inaction.'
+        );
+
+        foreach ($seeded as $section => $id) {
+            if ($id === 0) {
+                continue;
+            }
+
+            $this->assertSame(
+                $id,
+                $this->sectionRowId($section),
+                "com_proclaim.$section was deleted by the cleanup. An empty-rules section means "
+                . 'no override is set, not that the row is unused — every item asset is parented to it.'
+            );
+        }
+    }
+
+    /**
+     * @return  void
+     * @since __DEPLOY_VERSION__
+     */
+    #[TestDox('A record parented to its section is not reported as drifted')]
+    public function testCorrectlyParentedRecordIsNotDrifted(): void
+    {
+        Cwmassets::seedSections();
+        Cwmassets::clearSectionCache();
+
+        $sectionId = Cwmassets::sectionParentId('message');
+
+        if ($sectionId < 1 || $sectionId === Cwmassets::parentId()) {
+            $this->markTestSkipped('The message section could not be resolved on this install.');
+        }
+
+        $this->created[] = $sectionId;
+
+        $assetId = $this->createItemAsset('message', 999001, '{"core.edit":{"6":1}}');
+        $this->createStudyRow($assetId);
+
+        $messages = null;
+
+        foreach (Cwmassets::getAssetStatus() as $row) {
+            if (($row['assetname'] ?? '') === 'message') {
+                $messages = $row;
+                break;
+            }
+        }
+
+        $this->assertNotNull($messages, 'No status row for the message table — nothing was measured.');
+
+        // ⚠️ Positive control: the fixture record must be among the counted
+        // custom-rules rows. Without this, `drifted === 0` would also hold for
+        // a query that counted nothing at all.
+        $this->assertGreaterThan(
+            0,
+            (int) $messages['custom_rules'],
+            'The fixture record was not counted, so a drift count of 0 means nothing.'
+        );
+
+        $this->assertSame(
+            0,
+            (int) $messages['drifted'],
+            'A record parented to com_proclaim.message is where _getAssetParentId() puts it. '
+            . 'Reporting it as drifted is what made Parent Drifted equal Custom Rules on every row.'
+        );
+    }
+
+    /**
+     * The prune still has to do its job — this is the behaviour the section
+     * exclusion must not have broken.
+     *
+     * @return  void
+     * @since __DEPLOY_VERSION__
+     */
+    #[TestDox('An item asset with no override is still pruned')]
+    public function testEmptyRulesItemAssetIsStillPruned(): void
+    {
+        Cwmassets::seedSections();
+        Cwmassets::clearSectionCache();
+
+        $assetId = $this->createItemAsset('message', 999002, '{}');
+
+        Cwmassets::pruneEmptyAssetRows($this->db);
+
+        $asset = new Asset($this->db);
+
+        $this->assertFalse(
+            $asset->load($assetId),
+            'A record with no custom rules should not keep an asset row — it inherits. '
+            . 'Sparing the section rows must not spare the item rows too.'
+        );
+    }
+}


### PR DESCRIPTION
Closes #2018.

The asset panel reported **every correctly parented record** as "Parent Drifted", and Clean Up would have dismantled the structure it exists to repair.

## The mismatch

Since 10.5.8 all 14 Table classes return `sectionParentId(<section>)` from `_getAssetParentId()`, so a stored record's asset hangs off its **section** — that is what lets a rule on `com_proclaim.message` reach the record instead of being bypassed by it.

Four places still compared against `com_proclaim`:

| | effect |
|---|---|
| `getAssetStatus()` | every section-parented record read as drifted — why **Parent Drifted equalled Custom Rules exactly** in every row |
| `hasAnyDrift()` | same predicate, so always true; the "nothing to do" fast path could never fire |
| `pruneEmptyAssetRows()` | matched `com_proclaim.%`, deleting the section rows `seedSections()` creates on install |
| `reparentSurvivingAssets()` | flattened the survivors onto `com_proclaim` |

## Sections vs items

An empty-rules **section** is not an unused row: it means no override is set *yet*, and every item asset is parented to it. Deleting it drops those items back to `com_proclaim`, where a section rule added later can no longer reach them — the bypass the section parenting was introduced to prevent.

The name test could not tell the two apart. Items carry a third segment, so `com_proclaim.%.%` separates them:

| name | pruned when rules are empty |
|---|---|
| `com_proclaim` | no |
| `com_proclaim.message` | **no** (was: yes) |
| `com_proclaim.message.42` | yes |

Empty-rules **item** assets are still pruned — a record with no override should not carry an asset row, and that is unchanged.

## ⚠️ Why no dev site reproduced it

Every one of them had already been flattened by this. j6-dev has run the installer yet holds **zero** section assets and one item asset parented straight to `com_proclaim` — the post-prune shape. So a site showing zero drift is not necessarily healthy; it may simply have had its section tree deleted, with per-section permissions silently inert since 10.5.8. The site reporting hundreds of drifted rows was the one in the *intended* state.

## ⚠️ The first version of these tests was vacuous

It passed against the unfixed code. Both reasons are now asserted against:

- `fixAllAssets()` returns early when `hasAnyDrift()` is false, so on a clean database the sections survived because **nothing ran**. The test now plants an empty-rules item as bait and asserts it was pruned — proving the cleanup reached the sections at all.
- `getAssetStatus()` counts `FROM #__bsms_studies s LEFT JOIN #__assets a`, so an asset row with no record referencing it is never counted. The test now inserts a real message row and asserts it was counted *before* asserting zero drift.

**Canary-verified**: restoring either the old prune pattern or the old drift comparison fails the suite.

## Correction to the issue

I originally wrote that the raw `parent_id` update would leave `lft`/`rgt` stale and corrupt the nested set. That was wrong — `fixAllAssets()` step 5 calls `Asset::rebuild()` whenever anything changed. The structural damage (sections deleted, hierarchy flattened) was real; the nested-set corruption was not. The reparent still writes `parent_id` directly, and now says in a comment that it depends on that rebuild.

## Testing

`tests/integration/Admin/Lib/CwmassetsSectionSurvivalTest.php` — sections survive a real cleanup pass, a section-parented record is not drifted, and an empty-rules item is still pruned.

Full suite: **3507 tests, 11383 assertions, OK** · comment lint clean · PHP CS Fixer clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)