### PR TITLE
chore(release): open the 10.6.2 cycle, with notes

### DIFF
--- a/build/pkg_proclaim.xml
+++ b/build/pkg_proclaim.xml
@@ -2,7 +2,7 @@
 <extension type="package" method="upgrade">
     <packagename>proclaim</packagename>
     <name>PKG_PROCLAIM</name>
-    <version>10.6.1</version>
+    <version>10.6.2</version>
     <creationDate>2026-08-29</creationDate>
     <author>CWM Team</author>
     <authorEmail>info@christianwebministries.org</authorEmail>

--- a/build/release-notes-10.6.2.md
+++ b/build/release-notes-10.6.2.md
@@ -1,0 +1,29 @@
+A patch release fixing a permissions problem introduced in 10.5.8. If you use Proclaim's per-section permissions, or if the Assets screen has been showing large numbers in the **Parent Drifted** column, this one matters.
+
+## The Assets screen was reporting healthy records as broken
+
+Proclaim's Permissions → Assets screen lists, per table, how many records inherit their permissions and how many carry rules of their own. Since 10.5.8 it has also been reporting almost all of them under **Parent Drifted**, alongside a row of **Section permission records** marked as needing cleanup.
+
+Nothing was actually wrong with those records. The screen was checking them against the wrong expectation: it asked whether each record's permissions hang directly off Proclaim, when since 10.5.8 they correctly hang off their section — Messages, Teachers, Media Files and so on. Everything filed correctly was reported as misfiled.
+
+The giveaway, if you saw it, was that the Parent Drifted number matched the Custom Rules number exactly on every row.
+
+## ⚠️ Clean Up was undoing your per-section permissions
+
+This is the part worth reading if you have pressed that button.
+
+Because every record looked misfiled, **Clean Up** set about "repairing" them. It deleted the section permission records — the ones that hold your per-section settings — and moved every record's permissions back onto Proclaim itself. A rule set on, say, Messages then had nothing left to apply to.
+
+It did this quietly, and it could run during an update as well as from the button.
+
+Clean Up now leaves correctly filed records alone, keeps your section permission records, and repairs only what is genuinely misfiled.
+
+## If your permissions were already flattened
+
+Updating restores the section permission records by itself. Records that were moved off them are put back the first time you run **Clean Up** on the Assets screen, or the migration wizard — it is not done automatically, so nothing changes underneath you without being asked for.
+
+Your per-section settings themselves are not recoverable if the records holding them were deleted, so it is worth checking Permissions after updating and re-applying anything that has gone.
+
+## Requirements
+
+Joomla 5.4 or later, PHP 8.3 or later. Unchanged.

--- a/modules/admin/mod_proclaimicon/mod_proclaimicon.xml
+++ b/modules/admin/mod_proclaimicon/mod_proclaimicon.xml
@@ -7,7 +7,7 @@
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
     <authorEmail>info@christianwebministries.org</authorEmail>
     <authorUrl>www.christianwebministries.org</authorUrl>
-    <version>10.6.1</version>
+    <version>10.6.2</version>
     <description>MOD_PROCLAIMICON_XML_DESCRIPTION</description>
     <namespace path="src">CWM\Module\Proclaimicon</namespace>
     <files>

--- a/modules/site/mod_proclaim/mod_proclaim.xml
+++ b/modules/site/mod_proclaim/mod_proclaim.xml
@@ -5,7 +5,7 @@
     <authorEmail>info@christianwebministries.org</authorEmail>
     <authorUrl>www.christianwebministries.org</authorUrl>
     <copyright>(C) 2026 Proclaim All rights reserved.</copyright>
-    <version>10.6.1</version>
+    <version>10.6.2</version>
     <creationDate>2026-08-29</creationDate>
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
     <description>MOD_PROCLAIM_DESCRIPTION</description>

--- a/modules/site/mod_proclaim_podcast/mod_proclaim_podcast.xml
+++ b/modules/site/mod_proclaim_podcast/mod_proclaim_podcast.xml
@@ -7,7 +7,7 @@
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
     <authorEmail>info@christianwebministries.org</authorEmail>
     <authorUrl>www.christianwebministries.org</authorUrl>
-    <version>10.6.1</version>
+    <version>10.6.2</version>
     <description>MOD_PROCLAIM_PODCAST_XML_DESCRIPTION</description>
     <namespace path="src">CWM\Module\ProclaimPodcast</namespace>
     <files>

--- a/modules/site/mod_proclaim_youtube/mod_proclaim_youtube.xml
+++ b/modules/site/mod_proclaim_youtube/mod_proclaim_youtube.xml
@@ -5,7 +5,7 @@
     <authorEmail>info@christianwebministries.org</authorEmail>
     <authorUrl>www.christianwebministries.org</authorUrl>
     <copyright>(C) 2026 CWM Team All rights reserved</copyright>
-    <version>10.6.1</version>
+    <version>10.6.2</version>
     <creationDate>2026-08-29</creationDate>
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
     <description>MOD_PROCLAIM_YOUTUBE_DESCRIPTION</description>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "com_proclaim",
-  "version": "10.6.1",
+  "version": "10.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "com_proclaim",
-      "version": "10.6.1",
+      "version": "10.6.2",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@fancyapps/ui": "^6.1.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com_proclaim",
-  "version": "10.6.1",
+  "version": "10.6.2",
   "description": "CWM Proclaim - A Joomla! Extension for Church Media Management",
   "license": "GPL-2.0-or-later",
   "repository": {

--- a/plugins/finder/proclaim/proclaim.xml
+++ b/plugins/finder/proclaim/proclaim.xml
@@ -7,7 +7,7 @@
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
     <authorEmail>info@christianwebministries.org</authorEmail>
     <authorUrl>www.christianwebministries.org</authorUrl>
-    <version>10.6.1</version>
+    <version>10.6.2</version>
     <description>PLG_FINDER_PROCLAIM_XML_DESCRIPTION</description>
     <namespace path="src">CWM\Plugin\Finder\Proclaim</namespace>
     <files>

--- a/plugins/schemaorg/proclaim/proclaim.xml
+++ b/plugins/schemaorg/proclaim/proclaim.xml
@@ -7,7 +7,7 @@
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
     <authorEmail>info@christianwebministries.org</authorEmail>
     <authorUrl>www.christianwebministries.org</authorUrl>
-    <version>10.6.1</version>
+    <version>10.6.2</version>
     <description>PLG_SCHEMAORG_PROCLAIM_XML_DESCRIPTION</description>
     <namespace path="src">CWM\Plugin\Schemaorg\Proclaim</namespace>
     <files>

--- a/plugins/system/proclaim/proclaim.xml
+++ b/plugins/system/proclaim/proclaim.xml
@@ -7,7 +7,7 @@
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
     <authorEmail>info@christianwebministries.org</authorEmail>
     <authorUrl>www.christianwebministries.org</authorUrl>
-    <version>10.6.1</version>
+    <version>10.6.2</version>
     <description>PLG_SYSTEM_PROCLAIM_DESCRIPTION</description>
     <namespace path="src">CWM\Plugin\System\Proclaim</namespace>
     <files>

--- a/plugins/task/proclaim/proclaim.xml
+++ b/plugins/task/proclaim/proclaim.xml
@@ -7,7 +7,7 @@
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<authorEmail>info@christianwebministries.org</authorEmail>
 	<authorUrl>www.christianwebministries.org</authorUrl>
-	<version>10.6.1</version>
+	<version>10.6.2</version>
 	<description>PLG_TASK_PROCLAIM_XML_DESCRIPTION</description>
 	<namespace path="src">CWM\Plugin\Task\Proclaim</namespace>
 	<files>

--- a/plugins/webservices/proclaim/proclaim.xml
+++ b/plugins/webservices/proclaim/proclaim.xml
@@ -7,7 +7,7 @@
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
     <authorEmail>support@christianwebministries.org</authorEmail>
     <authorUrl>https://www.christianwebministries.org</authorUrl>
-    <version>10.6.1</version>
+    <version>10.6.2</version>
     <description>PLG_WEBSERVICES_PROCLAIM_DESCRIPTION</description>
     <namespace path="src">CWM\Plugin\WebServices\Proclaim</namespace>
     <files>

--- a/proclaim.xml
+++ b/proclaim.xml
@@ -6,7 +6,7 @@
     <authorEmail>info@christianwebministries.org</authorEmail>
     <authorUrl>www.christianwebministries.org</authorUrl>
     <copyright>(C) 2026 Proclaim All rights reserved.</copyright>
-    <version>10.6.1</version>
+    <version>10.6.2</version>
     <creationDate>2026-08-29</creationDate>
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
     <description>JBS_INS_XML_DESCRIPTION</description>


### PR DESCRIPTION
Opens **10.6.2**, which ships #2019 — the asset drift misclassification and the Clean Up behaviour it invited.

## Manifests

`composer version -- -v 10.6.2` moves the 11 manifests plus `package.json`/`package-lock.json` off 10.6.1. Required before the gate: `build/test-upgrade.sh` refuses when the package manifest and the version being released disagree (#1916's guard), and `cwm-release` runs the gate *before* its own bump step. `versions.json` already carries `active_development: 10.6.2`.

## Notes

Written for an administrator, leading with what they see rather than the cause. Two things called out deliberately:

- **Clean Up was undoing per-section permissions** — the part worth their attention if they have pressed it, and it could run during an update too.
- **Settings held in deleted section records are not recoverable.** The records come back; the rules that were in them do not. The notes say to check Permissions after updating rather than implying the release repairs everything.

It also states that the repair is not automatic — section records return on update, but records moved off them are only put back when Clean Up or the migration wizard runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)