### PR TITLE
fix(health): stop reporting trashed content as work to do

### DIFF
--- a/admin/src/Health/Check/ImageMigrationCheck.php
+++ b/admin/src/Health/Check/ImageMigrationCheck.php
@@ -79,7 +79,10 @@ final class ImageMigrationCheck implements HealthCheckInterface
      */
     public function run(): HealthResult
     {
-        $counts = CwmImageMigration::getMigrationCounts();
+        // Trashed records excluded: content already thrown away is not work
+        // to report. The migration tools keep the default and still process
+        // it, so a restored record's images are not left behind.
+        $counts = CwmImageMigration::getMigrationCounts(true);
 
         if ($counts['total'] === 0) {
             return new HealthResult(

--- a/admin/src/Health/Check/MissingImagesCheck.php
+++ b/admin/src/Health/Check/MissingImagesCheck.php
@@ -80,7 +80,10 @@ final class MissingImagesCheck implements HealthCheckInterface
      */
     public function run(): HealthResult
     {
-        $unresolvable = CwmImageMigration::getUnresolvableRecords();
+        // Trashed records excluded: content already thrown away is not work
+        // to report. The migration tools keep the default and still process
+        // it, so a restored record's images are not left behind.
+        $unresolvable = CwmImageMigration::getUnresolvableRecords(true);
 
         if ($unresolvable['count'] === 0) {
             return new HealthResult(

--- a/admin/src/Health/Check/OrphanMediaServerCheck.php
+++ b/admin/src/Health/Check/OrphanMediaServerCheck.php
@@ -16,6 +16,7 @@ namespace CWM\Component\Proclaim\Administrator\Health\Check;
 
 // phpcs:enable PSR1.Files.SideEffects
 
+use CWM\Component\Proclaim\Administrator\Extension\ProclaimComponent;
 use CWM\Component\Proclaim\Administrator\Health\HealthCheckInterface;
 use CWM\Component\Proclaim\Administrator\Health\HealthGroup;
 use CWM\Component\Proclaim\Administrator\Health\HealthResult;
@@ -98,7 +99,11 @@ final class OrphanMediaServerCheck implements HealthCheckInterface
                 ->select('COUNT(*)')
                 ->from($db->quoteName('#__bsms_mediafiles'))
                 ->where($db->quoteName('server_id') . ' > 0')
-                ->where($db->quoteName('server_id') . ' NOT IN (' . $servers . ')');
+                ->where($db->quoteName('server_id') . ' NOT IN (' . $servers . ')')
+                // A media row in the trash points nowhere on purpose. Reporting
+                // it as an orphan to fix asks for work on content already
+                // thrown away.
+                ->where($db->quoteName('published') . ' <> ' . ProclaimComponent::CONDITION_TRASHED);
             $db->setQuery($query);
 
             $orphans = (int) $db->loadResult();

--- a/admin/src/Health/Check/RestrictedMediaCheck.php
+++ b/admin/src/Health/Check/RestrictedMediaCheck.php
@@ -16,6 +16,7 @@ namespace CWM\Component\Proclaim\Administrator\Health\Check;
 
 // phpcs:enable PSR1.Files.SideEffects
 
+use CWM\Component\Proclaim\Administrator\Extension\ProclaimComponent;
 use CWM\Component\Proclaim\Administrator\Health\HealthCheckInterface;
 use CWM\Component\Proclaim\Administrator\Health\HealthGroup;
 use CWM\Component\Proclaim\Administrator\Health\HealthResult;
@@ -194,7 +195,24 @@ final class RestrictedMediaCheck implements HealthCheckInterface
                 '(' . $db->quoteName('m.access') . ' NOT IN (' . $levels . ')'
                 . ' OR ' . $db->quoteName('study.access') . ' NOT IN (' . $levels . ')'
                 . ' OR ' . $db->quoteName('series.access') . ' NOT IN (' . $levels . '))'
+            )
+            // A media file in the trash is not an exposure to act on.
+            ->where($db->quoteName('m.published') . ' <> ' . ProclaimComponent::CONDITION_TRASHED)
+            // ⚠️ Bracketed with an IS NULL, because study is a LEFT JOIN: a
+            // media row whose study_id matches nothing joins to NULL, and
+            // `NULL <> -2` is NULL, so a bare comparison would drop those rows
+            // from the count entirely — hiding real exposures rather than
+            // trashed ones. Written inline: WhereClauseContractTest reads the
+            // argument at the call site, and a variable is invisible to it.
+            ->where(
+                '(' . $db->quoteName('study.published') . ' IS NULL'
+                . ' OR ' . $db->quoteName('study.published') . ' <> '
+                . ProclaimComponent::CONDITION_TRASHED . ')'
             );
+
+        // ⚠️ Deliberately no filter on series.published. A trashed series whose
+        // sermon is still live does not make that sermon's media unreachable,
+        // so excluding it here would hide a genuine exposure.
 
         $db->setQuery($query);
 

--- a/admin/src/Helper/CwmImageMigration.php
+++ b/admin/src/Helper/CwmImageMigration.php
@@ -15,6 +15,7 @@ namespace CWM\Component\Proclaim\Administrator\Helper;
 \defined('_JEXEC') or die;
 // phpcs:enable PSR1.Files.SideEffects
 
+use CWM\Component\Proclaim\Administrator\Extension\ProclaimComponent;
 use Joomla\CMS\Application\ApplicationHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
@@ -125,14 +126,27 @@ class CwmImageMigration
      *
      * @param   string  $type  Record type: 'studies', 'teachers', or 'series'
      *
+     * @param   string  $type            Record type: 'studies', 'teachers' or 'series'
+     * @param   bool    $excludeTrashed  Skip records in the trash
+     *
      * @return  array  Records with images not in the new folder structure
      *
      * @since 10.1.0
      */
-    public static function getRecordsNeedingMigration(string $type): array
+    public static function getRecordsNeedingMigration(string $type, bool $excludeTrashed = false): array
     {
         $db    = Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->createQuery();
+
+        // ⚠️ Defaults to including trashed records, and the migration tools rely
+        // on that. A trashed record can be restored, and if its legacy image
+        // path was never migrated it comes back pointing at a file that has
+        // moved. Only the reporting side passes true: a record in the trash is
+        // not work anyone needs to be told about.
+        //
+        // The condition is repeated inline in each branch rather than built
+        // into a variable, because WhereClauseContractTest reads the literal
+        // argument at the call site and cannot verify a variable holds no OR.
 
         // SQL exclusion for core component images
         $coreExclude = ' NOT LIKE ' . $db->q('media/com_proclaim/images/%');
@@ -150,6 +164,12 @@ class CwmImageMigration
                     ->where('LENGTH(' . $col . ') > 1')
                     ->where($col . ' NOT LIKE ' . $db->q('images/biblestudy/studies/%-%/%'))
                     ->where($col . $coreExclude);
+
+                if ($excludeTrashed) {
+                    $query->where(
+                        $db->quoteName('published') . ' <> ' . ProclaimComponent::CONDITION_TRASHED
+                    );
+                }
                 break;
 
             case 'teachers':
@@ -166,6 +186,12 @@ class CwmImageMigration
                     ->where('LENGTH(' . $col . ') > 1')
                     ->where($col . ' NOT LIKE ' . $db->q('images/biblestudy/teachers/%-%/%'))
                     ->where($col . $coreExclude);
+
+                if ($excludeTrashed) {
+                    $query->where(
+                        $db->quoteName('published') . ' <> ' . ProclaimComponent::CONDITION_TRASHED
+                    );
+                }
                 break;
 
             case 'series':
@@ -180,6 +206,12 @@ class CwmImageMigration
                     ->where('LENGTH(' . $col . ') > 1')
                     ->where($col . ' NOT LIKE ' . $db->q('images/biblestudy/series/%-%/%'))
                     ->where($col . $coreExclude);
+
+                if ($excludeTrashed) {
+                    $query->where(
+                        $db->quoteName('published') . ' <> ' . ProclaimComponent::CONDITION_TRASHED
+                    );
+                }
                 break;
 
             default:
@@ -203,12 +235,12 @@ class CwmImageMigration
      *
      * @since 10.1.0
      */
-    public static function getMigrationCounts(): array
+    public static function getMigrationCounts(bool $excludeTrashed = false): array
     {
         $counts = [
-            'studies'  => \count(self::getRecordsNeedingMigration('studies')),
-            'teachers' => \count(self::getRecordsNeedingMigration('teachers')),
-            'series'   => \count(self::getRecordsNeedingMigration('series')),
+            'studies'  => \count(self::getRecordsNeedingMigration('studies', $excludeTrashed)),
+            'teachers' => \count(self::getRecordsNeedingMigration('teachers', $excludeTrashed)),
+            'series'   => \count(self::getRecordsNeedingMigration('series', $excludeTrashed)),
         ];
 
         $counts['total'] = $counts['studies'] + $counts['teachers'] + $counts['series'];
@@ -761,12 +793,12 @@ class CwmImageMigration
      *
      * @since 10.1.0
      */
-    public static function getUnresolvableRecords(): array
+    public static function getUnresolvableRecords(bool $excludeTrashed = false): array
     {
         $unresolvable = [];
 
         foreach (['studies', 'teachers', 'series'] as $type) {
-            $records = self::getRecordsNeedingMigration($type);
+            $records = self::getRecordsNeedingMigration($type, $excludeTrashed);
 
             foreach ($records as $row) {
                 $imagePath = trim($row->image_path ?? '');

--- a/tests/unit/Admin/Health/HealthContractTest.php
+++ b/tests/unit/Admin/Health/HealthContractTest.php
@@ -362,6 +362,92 @@ class HealthContractTest extends ProclaimTestCase
     }
 
     /**
+     * Helpers that read content rows on a check's behalf, and the argument that
+     * makes them leave trashed content out.
+     *
+     * @var    array<string, string>
+     * @since  __DEPLOY_VERSION__
+     */
+    private const CONTENT_HELPERS = [
+        'CwmImageMigration::getMigrationCounts'     => 'getMigrationCounts(true)',
+        'CwmImageMigration::getUnresolvableRecords' => 'getUnresolvableRecords(true)',
+    ];
+
+    /**
+     * A check that reads content must say what it thinks of trashed rows.
+     *
+     * Trashed content is content the administrator has already dealt with.
+     * Counting it makes a finding that cannot be cleared by doing what it asks,
+     * and in RestrictedMediaCheck's case raised a *security warning* about a
+     * sermon that had been thrown away.
+     *
+     * ⚠️ This reads source rather than running the checks, because the failure
+     * is invisible on a clean database: a dev site with no trashed content
+     * gives the same answer either way. It is the omission that has to be
+     * caught, not its effect on whatever data happens to be present.
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    #[TestDox('A check reading content rows constrains their state')]
+    public function testContentChecksExcludeTrashedRows(): void
+    {
+        $offenders = [];
+        $covered   = 0;
+
+        foreach ($this->checkFiles() as $file) {
+            $src  = (string) file_get_contents($file);
+            $name = basename($file);
+
+            $viaHelper = false;
+
+            foreach (self::CONTENT_HELPERS as $helper => $withFlag) {
+                if (str_contains($src, $helper . '(')) {
+                    $viaHelper = true;
+
+                    if (!str_contains($src, $withFlag)) {
+                        $offenders[] = $name . ' calls ' . $helper . '() without excluding trashed';
+                    }
+                }
+            }
+
+            // Direct reads of a content table. Servers and templatecode rows are
+            // configuration rather than content an editor trashes, and
+            // #__bsms_admin is a single settings row.
+            $readsContent = (bool) preg_match(
+                '/#__bsms_(studies|mediafiles|series|teachers|topics|comments|locations|playlists)/',
+                $src
+            );
+
+            if ($readsContent && !str_contains($src, 'CONDITION_TRASHED')) {
+                $offenders[] = $name . ' queries a content table without constraining published state';
+            }
+
+            if ($viaHelper || $readsContent) {
+                $covered++;
+            }
+        }
+
+        // ⚠️ Positive control. If the detection stops matching — a rename, a
+        // moved directory — every assertion above passes against nothing.
+        $this->assertGreaterThanOrEqual(
+            4,
+            $covered,
+            'Fewer content-reading checks were found than exist. The detection above has stopped working, '
+            . 'so this test is no longer guarding anything.'
+        );
+
+        $this->assertSame(
+            [],
+            $offenders,
+            "A health check counts trashed content as a problem:\n  " . implode("\n  ", $offenders)
+            . "\n\nTrashed content is already dealt with. Either constrain the state, or pass the helper's "
+            . 'exclude-trashed argument.'
+        );
+    }
+
+    /**
      * Absolute paths of every check source file.
      *
      * @return  string[]

--- a/tests/unit/Admin/Helper/CwmImageMigrationQueryTest.php
+++ b/tests/unit/Admin/Helper/CwmImageMigrationQueryTest.php
@@ -21,6 +21,7 @@
 
 namespace CWM\Component\Proclaim\Tests\Admin\Helper;
 
+use CWM\Component\Proclaim\Administrator\Extension\ProclaimComponent;
 use CWM\Component\Proclaim\Administrator\Helper\CwmImageMigration;
 use CWM\Component\Proclaim\Tests\ProclaimTestCase;
 use Joomla\CMS\Factory;
@@ -32,6 +33,68 @@ use PHPUnit\Framework\Attributes\TestDox;
  */
 class CwmImageMigrationQueryTest extends ProclaimTestCase
 {
+    /**
+     * The reporting side must skip trashed records; the migration side must not.
+     *
+     * A trashed record can be restored, and if its legacy image path was never
+     * migrated it comes back pointing at a file that has moved — so the tools
+     * keep processing it. Only System Health passes the flag, because content
+     * already thrown away is not work to report.
+     *
+     * ⚠️ Asserts both directions against the same fixture. A test that only
+     * checked the exclusion would also pass if the query returned nothing at
+     * all, which is the failure it is meant to distinguish from success.
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    #[TestDox('Trashed records are excluded on request and included by default')]
+    public function testTrashedRecordsAreExcludedOnlyWhenAsked(): void
+    {
+        $db = Factory::getContainer()->get(DatabaseInterface::class);
+
+        $db->transactionStart();
+
+        try {
+            $db->setQuery(
+                'INSERT INTO ' . $db->quoteName('#__bsms_studies')
+                . ' (' . $db->quoteName('studytitle') . ', ' . $db->quoteName('alias') . ', '
+                . $db->quoteName('thumbnailm') . ', ' . $db->quoteName('published') . ', '
+                . $db->quoteName('language') . ')'
+                . ' VALUES (' . $db->quote('Trashed fixture') . ', ' . $db->quote('trashed-fixture') . ', '
+                . $db->quote('images/legacy/trashed-fixture.jpg') . ', '
+                . ProclaimComponent::CONDITION_TRASHED . ', ' . $db->quote('*') . ')'
+            )->execute();
+
+            $id = (int) $db->insertid();
+
+            $included = CwmImageMigration::getRecordsNeedingMigration('studies');
+            $excluded = CwmImageMigration::getRecordsNeedingMigration('studies', true);
+
+            $idsIn  = array_map(static fn ($r) => (int) $r->id, $included);
+            $idsOut = array_map(static fn ($r) => (int) $r->id, $excluded);
+
+            // Positive control: the fixture must be visible by default, or the
+            // exclusion below proves nothing.
+            $this->assertContains(
+                $id,
+                $idsIn,
+                'The trashed fixture was not returned by default. The migration tools rely on that, and '
+                . 'without it the exclusion assertion is vacuous.'
+            );
+
+            $this->assertNotContains(
+                $id,
+                $idsOut,
+                'A trashed record was reported as needing migration. System Health would ask an administrator '
+                . 'to fix content they have already thrown away.'
+            );
+        } finally {
+            $db->transactionRollback();
+        }
+    }
+
     /**
      * @return  void
      *


### PR DESCRIPTION
Closes #2009.

Four checks counted records the administrator had already thrown away. `RestrictedMediaCheck` was the sharp end: a **trashed sermon's media raised a security warning** about content no longer published anywhere.

## The contract

**Trashed (`-2`) is excluded. Unpublished (`0`) and archived (`2`) are not.** An unpublished record renders the moment it is published and an archived one is live content — both are still work. Only `-2` is content someone has decided to remove.

`ProclaimComponent::CONDITION_TRASHED` already existed and is reused rather than inventing a constant.

## Reporting vs repairing

The image helpers are called by the **migration tools** as well as by System Health, so they take an opt-in flag and keep their old default:

> A trashed record can be restored, and if its legacy image path was never migrated it comes back pointing at a file that has moved.

So the tools keep processing trashed rows; only the checks pass `true`.

| | change |
|---|---|
| `getRecordsNeedingMigration()` | flag added, threaded from both entry points |
| `ImageMigrationCheck` | passes `true` |
| `MissingImagesCheck` | passes `true` |
| `RestrictedMediaCheck` | filters `m.published` and `study.published` |
| `OrphanMediaServerCheck` | filters `published` |

## ⚠️ Two things that would have been bugs

**`study.published` is bracketed with an `IS NULL`.** It arrives through a `LEFT JOIN`, so a media row whose `study_id` matches nothing joins to NULL, and `NULL <> -2` is NULL. A bare comparison would have dropped those rows from the count — **hiding real exposures rather than trashed ones**. Same class of bug as #2018.

**No filter on `series.published`, deliberately.** A trashed series whose sermon is still live does not make that sermon's media unreachable, so filtering there would hide a genuine exposure.

## Audit result

`ImageWebPCheck` was in scope on the face of it but is **not** affected: `getWebPMigrationCounts()` scans the `images/biblestudy` directories, not content rows. `AssetDriftCheck` reads assets, not content.

## Guarding

Two tests, because neither alone is enough:

- **Contract test** (`HealthContractTest`) reads every check and fails one that touches a content table without constraining state. Source rather than behaviour on purpose — on a database with no trashed content both versions give the same answer, so it is the *omission* that has to be caught. Carries a positive control that fails if the detection stops matching.
- **Behavioural test** asserts the helper both excludes on request **and still includes by default**, so the exclusion cannot pass by returning nothing at all.

**Canary-verified three ways** — dropping the constant from `RestrictedMediaCheck`, dropping the flag from `ImageMigrationCheck`, and making the helper ignore it each fail.

## Not in scope

The Notice-level report of trashed content ("3 trashed items still hold media"). It needs a count nothing computes yet, and #2009 lists it as optional. Happy to follow up if you want it.

Suite: **3510 tests, 11392 assertions, OK** · comment lint clean · CS Fixer clean · `WhereClauseContractTest` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)