### PR TITLE
fix(servers): three live bugs on the servers screens

### DIFF
--- a/admin/language/en-GB/en-GB.com_proclaim.ini
+++ b/admin/language/en-GB/en-GB.com_proclaim.ini
@@ -2542,6 +2542,7 @@ JBS_STYLE_RESTRICED_FILE_NAME = "File cannot be named 'main' or 'custom'"
 
 ;; SVR Server
 JBS_SVR_MEDIA_SETTINGS = "Media Settings"
+JBS_SVR_TYPE_NOT_RECOGNISED="No server type was chosen, or the form was submitted with a type Proclaim could not read. Nothing was changed — open the server again and pick a type."
 JBS_SVR_SERVER_NAME = "Server Name"
 JBS_SVR_SERVER_NAME_DESC = "Alias name to describe the server"
 JBS_SVR_SERVER_LIST = "Server List"

--- a/admin/src/Controller/CwmserverController.php
+++ b/admin/src/Controller/CwmserverController.php
@@ -141,7 +141,38 @@ class CwmserverController extends FormController
 
         $data  = $input->get('jform', [], 'post');
         $sname = $data['server_name'] ?? '';
-        $type  = json_decode(base64_decode($data['type'] ?? ''), true, 512, JSON_THROW_ON_ERROR);
+
+        // ⚠️ This is request data, and it was decoded straight into
+        // JSON_THROW_ON_ERROR with nothing to catch the throw. Submitting the
+        // form without a type — a stale form, a modal that never set the field,
+        // a re-post — reached json_decode('') and put a white error page in
+        // front of the administrator instead of the screen they asked for.
+        $type = [];
+        $raw  = base64_decode((string) ($data['type'] ?? ''), true);
+
+        if (\is_string($raw) && $raw !== '') {
+            try {
+                $decoded = json_decode($raw, true, 512, JSON_THROW_ON_ERROR);
+
+                if (\is_array($decoded)) {
+                    $type = $decoded;
+                }
+            } catch (\JsonException) {
+                // Not a type payload. Handled below, as "none chosen".
+            }
+        }
+
+        // Nothing usable came back. Say so and return them to the form rather
+        // than storing an empty type and redirecting as though it worked.
+        if (($type['name'] ?? '') === '') {
+            $app->enqueueMessage(Text::_('JBS_SVR_TYPE_NOT_RECOGNISED'), 'warning');
+
+            $this->setRedirect(
+                Route::_('index.php?option=' . $this->option . '&view=' . $this->view_list, false)
+            );
+
+            return;
+        }
 
         $recordId = $type['id'] ?? 0;
 

--- a/admin/src/Controller/CwmserverController.php
+++ b/admin/src/Controller/CwmserverController.php
@@ -142,29 +142,21 @@ class CwmserverController extends FormController
         $data  = $input->get('jform', [], 'post');
         $sname = $data['server_name'] ?? '';
 
-        // ⚠️ This is request data, and it was decoded straight into
-        // JSON_THROW_ON_ERROR with nothing to catch the throw. Submitting the
-        // form without a type — a stale form, a modal that never set the field,
-        // a re-post — reached json_decode('') and put a white error page in
-        // front of the administrator instead of the screen they asked for.
-        $type = [];
-        $raw  = base64_decode((string) ($data['type'] ?? ''), true);
+        // ⚠️ A plain server-type key, e.g. "youtube". It used to be decoded as
+        // base64 JSON, which never worked: the type field is a
+        // ModalSelectField, and its readonly title input and hidden value input
+        // share the name jform[type]. The picker's assignment to
+        // elements['jform[type]'] hit a RadioNodeList and did nothing, so what
+        // arrived here was the hidden input's key, not the payload — which
+        // base64_decode then turned into rubbish and json_decode threw on,
+        // taking the whole screen down with it.
+        //
+        // Read as request data, so a stale form or a hand-made POST is a
+        // message rather than an error page.
+        $typeKey  = strtolower(trim((string) ($data['type'] ?? '')));
+        $recordId = (int) ($data['id'] ?? 0);
 
-        if (\is_string($raw) && $raw !== '') {
-            try {
-                $decoded = json_decode($raw, true, 512, JSON_THROW_ON_ERROR);
-
-                if (\is_array($decoded)) {
-                    $type = $decoded;
-                }
-            } catch (\JsonException) {
-                // Not a type payload. Handled below, as "none chosen".
-            }
-        }
-
-        // Nothing usable came back. Say so and return them to the form rather
-        // than storing an empty type and redirecting as though it worked.
-        if (($type['name'] ?? '') === '') {
+        if ($typeKey === '' || !preg_match('/^[a-z0-9_-]+$/', $typeKey)) {
             $app->enqueueMessage(Text::_('JBS_SVR_TYPE_NOT_RECOGNISED'), 'warning');
 
             $this->setRedirect(
@@ -174,10 +166,8 @@ class CwmserverController extends FormController
             return;
         }
 
-        $recordId = $type['id'] ?? 0;
-
         // Save the endpoint in the session
-        $app->setUserState('com_proclaim.edit.cwmserver.type', $type['name'] ?? '');
+        $app->setUserState('com_proclaim.edit.cwmserver.type', $typeKey);
         $app->setUserState('com_proclaim.edit.cwmserver.server_name', $sname);
 
         $this->setRedirect(

--- a/admin/tmpl/cwmserver/edit.php
+++ b/admin/tmpl/cwmserver/edit.php
@@ -39,7 +39,15 @@ $wa->useScript('keepalive')
         "
 	Joomla.submitbutton = function (task, type) {
 		if (task == 'cwmserver.setType') {
-			document.getElementById('item-form').elements['jform[type]'].value = type;
+			/* The type field is a ModalSelectField: a readonly title input and a
+			   hidden value input SHARE the name jform[type], so
+			   elements['jform[type]'] is a RadioNodeList and assigning .value to
+			   it does nothing at all. Write to the hidden value input by id, and
+			   mirror it into the visible one so the choice shows immediately. */
+			var typeValue = document.getElementById('jform_type_id');
+			var typeTitle = document.getElementById('jform_type');
+			if (typeValue) { typeValue.value = type; }
+			if (typeTitle) { typeTitle.value = type; }
 			Joomla.submitform(task, document.getElementById('item-form'));
 		} else if (task == 'cwmserver.cancel') {
 			Joomla.submitform(task, document.getElementById('item-form'));

--- a/admin/tmpl/cwmservers/default.php
+++ b/admin/tmpl/cwmservers/default.php
@@ -166,7 +166,11 @@ echo Route::_('index.php?option=com_proclaim&view=cwmservers'); ?>" method="post
                                 <td class="text-center d-none d-md-table-cell">
                                     <?php
                                     $options = [
-                                        'task_prefix' => 'server.',
+                                        // ⚠️ The PLURAL controller, as every other list uses.
+                                        // 'server.' resolves to no controller at all, so the
+                                        // status button dispatched task=server.publish and the
+                                        // dispatcher answered "Invalid controller class: server".
+                                        'task_prefix' => 'cwmservers.',
                                         'disabled'    => $workflow_state || !$canChange,
                                         'id'          => 'state-' . $item->id,
                                     ];
@@ -178,7 +182,7 @@ echo Route::_('index.php?option=com_proclaim&view=cwmservers'); ?>" method="post
                                     <div class="float-left">
                                         <?php if ($item->checked_out) : ?>
                                             <?php echo HTMLHelper::_('jgrid.checkedout', $i, $item->editor,
-                                                $item->checked_out_time, 'server.', $canCheckin); ?>
+                                                $item->checked_out_time, 'cwmservers.', $canCheckin); ?>
                                         <?php endif; ?>
                                         <?php
                                 if ($canEdit || $canEditOwn) : ?>

--- a/admin/tmpl/cwmservers/types.php
+++ b/admin/tmpl/cwmservers/types.php
@@ -82,13 +82,17 @@ $typeIcons = [
             <?php foreach ($this->types as $item) :
                 $typeKey  = strtolower($item->name);
                 $iconData = $typeIcons[$typeKey] ?? ['icon' => 'fa-solid fa-plug', 'color' => '#555555'];
-                $encoded  = base64_encode(json_encode(['id' => $this->recordId, 'name' => $item->name]));
+                // ⚠️ The plain type key, not a base64 JSON blob. The form's
+                // type field is a ModalSelectField, whose hidden input holds
+                // exactly this — so what the picker sends and what the field
+                // stores are now the same thing, and the record id comes from
+                // the form rather than being smuggled alongside it.
             ?>
                 <div class="col">
                     <div class="card h-100 border-2 server-type-card"
                          role="button"
                          tabindex="0"
-                         data-type-payload="<?php echo $this->escape($encoded); ?>">
+                         data-type-payload="<?php echo $this->escape($typeKey); ?>">
                         <div class="card-body text-center py-4">
                             <div class="mb-3">
                                 <span class="<?php echo $this->escape($iconData['icon']); ?> fa-3x"


### PR DESCRIPTION
Closes #2035. ⚠️ **All three are present in released 10.6.2**, each verified against the tag.

Reported from a live site and found while fixing the first one.

## 1. Fatal choosing a server type

```
4 Syntax error — json_decode() — CwmserverController.php:144
```

`setType()` decoded a base64 POST field with `JSON_THROW_ON_ERROR` and nothing to catch it.

## 2. …and the value it decoded was never the value that arrived

The root cause, found after the guard turned the fatal into a bounce back to the list.

The type field is a `ModalSelectField`, and Joomla renders it as **two inputs sharing `name="jform[type]"`**:

| id | type | value |
|---|---|---|
| `jform_type` | text, readonly | `YouTube` |
| `jform_type_id` | hidden | `youtube` |

So `elements['jform[type]']` is a **`RadioNodeList`**, and assigning `.value` to it does nothing — the setter only has an effect for radio groups. The picker's base64 payload was never written, the form posted the hidden input's plain key, and the controller base64-decoded `"youtube"` into rubbish and threw.

Fixed by making all three agree on the key the field already stores:

- `types.php` sends the plain type key
- `edit.php` writes to the hidden value input **by id**, and mirrors it into the title
- the controller reads a plain key, takes the record id from `jform[id]`, and validates the shape

The guard stays as defence: a stale form or hand-made POST gets a message, not an error page.

## 3. `Invalid controller class: server`

Changing a server's state from the list — including bringing a trashed one back — hit a controller that does not exist. The status button and checked-out link used the prefix `server.`

Audited **all twelve** lists:

```
cwmlocations  cwmmediafiles  cwmmessages  cwmmessagetypes
cwmplaylists  cwmpodcasts    cwmseries    cwmteachers
cwmtemplatecodes  cwmtemplates  cwmtopics     ← all correct
cwmservers                                    ← prefix "server."
```

One outlier. `CwmserversController extends AdminController`, so the tasks were always there — only the name was wrong.

## Verification

- Type round trip encodes and decodes; a valid key redirects to the **edit view**, not the list
- The field renders exactly the two inputs above — confirmed in a browser
- **You created and saved a server through the fixed flow**: `type = vimeo`, a clean key, with the Vimeo addon's params stored
- The trashed-servers list now renders `cwmservers.` tasks and no longer contains `server.publish`

⚠️ Not verified: the modal click path under automation — the picker would not open headless. The manual create/save above is the evidence for that half.

## On attribution

I called an unrelated 500 "pre-existing" earlier today and was wrong, having tested with `git stash`, which does not revert merged commits. All three of these were checked against the released tag directly.

## Suggested handling

Fatal plus two broken actions on a live release. Worth **10.6.3** now rather than waiting for 10.7.0.

Follow-up filed as #2037: selecting a type should not submit and reload the page at all.

Suite: **3513 tests, 11399 assertions, OK**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)