### PR TITLE
chore(release): open the 10.6.3 cycle, with notes

### DIFF
--- a/build/pkg_proclaim.xml
+++ b/build/pkg_proclaim.xml
@@ -2,8 +2,8 @@
 <extension type="package" method="upgrade">
     <packagename>proclaim</packagename>
     <name>PKG_PROCLAIM</name>
-    <version>10.6.2</version>
-    <creationDate>2026-08-29</creationDate>
+    <version>10.6.3</version>
+    <creationDate>2026-09-01</creationDate>
     <author>CWM Team</author>
     <authorEmail>info@christianwebministries.org</authorEmail>
     <authorUrl>www.christianwebministries.org</authorUrl>

--- a/build/release-notes-10.6.3.md
+++ b/build/release-notes-10.6.3.md
@@ -1,0 +1,36 @@
+A patch release fixing three faults on the Servers screens, one of which stopped you setting up a server at all. If you manage servers in Proclaim, take this one.
+
+## You could not choose a server type
+
+Picking a type when creating or editing a server replaced the screen with an error page. There was no way past it, so a new server could not be set up and an existing one could not be changed.
+
+Two separate faults were behind it, and both are fixed. The type you choose is now stored correctly, and the form returns to your server with that platform's own settings ready to fill in.
+
+## Publishing a server from the list did nothing but show an error
+
+Changing a server's status from the Servers list — publishing, unpublishing, archiving, trashing, or bringing a trashed server back — produced an error page instead. Checking in a server someone had left open did the same.
+
+Every other list in Proclaim was unaffected; the Servers list alone was pointing at something that did not exist. It now works as the other lists do.
+
+## Health checks no longer report content you have thrown away
+
+System Health counted trashed messages, media files and images as work still to do. Most visibly, a **restricted media** warning could be raised about a sermon that had been deleted — a security notice about content nobody can reach.
+
+Trashed content is no longer counted. Unpublished and archived content still is, because that is content that will show again.
+
+## Findings now tell you what to do about them
+
+Several health findings described a problem and stopped. They now say what the remedy is, and where it does not lie with Proclaim they say that too — an unenforced protected media folder is a web server setting, and the finding says so rather than implying a switch exists somewhere in the component.
+
+The protected media folder also no longer warns that files kept there are publicly downloadable when nothing is kept there.
+
+## Settings that were never reachable
+
+Two fields were asked for by a screen but never declared by its form, so they simply did not appear:
+
+- The site-wide **Custom CSS** tab showed a description and no editor. It never worked, no site could have saved anything in it, and it has been removed. Custom CSS on a **template** is unaffected and is where styling belongs.
+- The Comments screen offered an **Access** field that could not appear. Comments take their visibility from the message they belong to, which is now also how the moderation list decides what to show you — previously it could hide comments left by visitors from anyone who was not a Super User.
+
+## Requirements
+
+Joomla 5.4 or later, PHP 8.3 or later. Unchanged.

--- a/build/release-notes-10.6.3.md
+++ b/build/release-notes-10.6.3.md
@@ -24,6 +24,12 @@ Several health findings described a problem and stopped. They now say what the r
 
 The protected media folder also no longer warns that files kept there are publicly downloadable when nothing is kept there.
 
+## Finding the media a warning is about
+
+When Proclaim reported that restricted recordings were reachable by anyone holding their address, the button opened the whole media library. On a site with thousands of files that is not something you can act on.
+
+It now opens the list filtered to restricted media, with a **Visibility** filter you can see and clear like any other. On our test data that is the difference between 112 rows and 14.
+
 ## Settings that were never reachable
 
 Two fields were asked for by a screen but never declared by its form, so they simply did not appear:

--- a/modules/admin/mod_proclaimicon/mod_proclaimicon.xml
+++ b/modules/admin/mod_proclaimicon/mod_proclaimicon.xml
@@ -2,12 +2,12 @@
 <extension type="module" client="administrator" method="upgrade">
     <name>mod_proclaimicon</name>
     <author>CWM Team</author>
-    <creationDate>2026-08-29</creationDate>
+    <creationDate>2026-09-01</creationDate>
     <copyright>(C) 2026 Proclaim All rights reserved.</copyright>
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
     <authorEmail>info@christianwebministries.org</authorEmail>
     <authorUrl>www.christianwebministries.org</authorUrl>
-    <version>10.6.2</version>
+    <version>10.6.3</version>
     <description>MOD_PROCLAIMICON_XML_DESCRIPTION</description>
     <namespace path="src">CWM\Module\Proclaimicon</namespace>
     <files>

--- a/modules/site/mod_proclaim/mod_proclaim.xml
+++ b/modules/site/mod_proclaim/mod_proclaim.xml
@@ -5,8 +5,8 @@
     <authorEmail>info@christianwebministries.org</authorEmail>
     <authorUrl>www.christianwebministries.org</authorUrl>
     <copyright>(C) 2026 Proclaim All rights reserved.</copyright>
-    <version>10.6.2</version>
-    <creationDate>2026-08-29</creationDate>
+    <version>10.6.3</version>
+    <creationDate>2026-09-01</creationDate>
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
     <description>MOD_PROCLAIM_DESCRIPTION</description>
     <namespace path="src">CWM\Module\Proclaim</namespace>

--- a/modules/site/mod_proclaim_podcast/mod_proclaim_podcast.xml
+++ b/modules/site/mod_proclaim_podcast/mod_proclaim_podcast.xml
@@ -2,12 +2,12 @@
 <extension type="module" client="site" method="upgrade">
     <name>mod_proclaim_podcast</name>
     <author>CWM Team</author>
-    <creationDate>2026-08-29</creationDate>
+    <creationDate>2026-09-01</creationDate>
     <copyright>(C) 2026 Christian Web Ministries All rights reserved.</copyright>
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
     <authorEmail>info@christianwebministries.org</authorEmail>
     <authorUrl>www.christianwebministries.org</authorUrl>
-    <version>10.6.2</version>
+    <version>10.6.3</version>
     <description>MOD_PROCLAIM_PODCAST_XML_DESCRIPTION</description>
     <namespace path="src">CWM\Module\ProclaimPodcast</namespace>
     <files>

--- a/modules/site/mod_proclaim_youtube/mod_proclaim_youtube.xml
+++ b/modules/site/mod_proclaim_youtube/mod_proclaim_youtube.xml
@@ -5,8 +5,8 @@
     <authorEmail>info@christianwebministries.org</authorEmail>
     <authorUrl>www.christianwebministries.org</authorUrl>
     <copyright>(C) 2026 CWM Team All rights reserved</copyright>
-    <version>10.6.2</version>
-    <creationDate>2026-08-29</creationDate>
+    <version>10.6.3</version>
+    <creationDate>2026-09-01</creationDate>
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
     <description>MOD_PROCLAIM_YOUTUBE_DESCRIPTION</description>
     <namespace path="src">CWM\Module\ProclaimYoutube</namespace>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "com_proclaim",
-  "version": "10.6.2",
+  "version": "10.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "com_proclaim",
-      "version": "10.6.2",
+      "version": "10.6.3",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@fancyapps/ui": "^6.1.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com_proclaim",
-  "version": "10.6.2",
+  "version": "10.6.3",
   "description": "CWM Proclaim - A Joomla! Extension for Church Media Management",
   "license": "GPL-2.0-or-later",
   "repository": {

--- a/plugins/finder/proclaim/proclaim.xml
+++ b/plugins/finder/proclaim/proclaim.xml
@@ -2,12 +2,12 @@
 <extension type="plugin" group="finder" method="upgrade">
     <name>plg_finder_proclaim</name>
     <author>CWM Team</author>
-    <creationDate>2026-08-29</creationDate>
+    <creationDate>2026-09-01</creationDate>
     <copyright>(C) 2026 Proclaim All rights reserved.</copyright>
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
     <authorEmail>info@christianwebministries.org</authorEmail>
     <authorUrl>www.christianwebministries.org</authorUrl>
-    <version>10.6.2</version>
+    <version>10.6.3</version>
     <description>PLG_FINDER_PROCLAIM_XML_DESCRIPTION</description>
     <namespace path="src">CWM\Plugin\Finder\Proclaim</namespace>
     <files>

--- a/plugins/schemaorg/proclaim/proclaim.xml
+++ b/plugins/schemaorg/proclaim/proclaim.xml
@@ -2,12 +2,12 @@
 <extension type="plugin" group="schemaorg" method="upgrade">
     <name>plg_schemaorg_proclaim</name>
     <author>CWM Team</author>
-    <creationDate>2026-08-29</creationDate>
+    <creationDate>2026-09-01</creationDate>
     <copyright>(C) 2026 CWM Team All rights reserved</copyright>
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
     <authorEmail>info@christianwebministries.org</authorEmail>
     <authorUrl>www.christianwebministries.org</authorUrl>
-    <version>10.6.2</version>
+    <version>10.6.3</version>
     <description>PLG_SCHEMAORG_PROCLAIM_XML_DESCRIPTION</description>
     <namespace path="src">CWM\Plugin\Schemaorg\Proclaim</namespace>
     <files>

--- a/plugins/system/proclaim/proclaim.xml
+++ b/plugins/system/proclaim/proclaim.xml
@@ -2,12 +2,12 @@
 <extension type="plugin" group="system" method="upgrade">
     <name>plg_system_proclaim</name>
     <author>CWM Team</author>
-    <creationDate>2026-08-29</creationDate>
+    <creationDate>2026-09-01</creationDate>
     <copyright>(C) 2026 Proclaim All rights reserved.</copyright>
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
     <authorEmail>info@christianwebministries.org</authorEmail>
     <authorUrl>www.christianwebministries.org</authorUrl>
-    <version>10.6.2</version>
+    <version>10.6.3</version>
     <description>PLG_SYSTEM_PROCLAIM_DESCRIPTION</description>
     <namespace path="src">CWM\Plugin\System\Proclaim</namespace>
     <files>

--- a/plugins/task/proclaim/proclaim.xml
+++ b/plugins/task/proclaim/proclaim.xml
@@ -2,12 +2,12 @@
 <extension type="plugin" group="task" method="upgrade">
 	<name>plg_task_proclaim</name>
 	<author>CWM Team</author>
-	<creationDate>2026-08-29</creationDate>
+	<creationDate>2026-09-01</creationDate>
 	<copyright>(C) 2026 Proclaim All rights reserved.</copyright>
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<authorEmail>info@christianwebministries.org</authorEmail>
 	<authorUrl>www.christianwebministries.org</authorUrl>
-	<version>10.6.2</version>
+	<version>10.6.3</version>
 	<description>PLG_TASK_PROCLAIM_XML_DESCRIPTION</description>
 	<namespace path="src">CWM\Plugin\Task\Proclaim</namespace>
 	<files>

--- a/plugins/webservices/proclaim/proclaim.xml
+++ b/plugins/webservices/proclaim/proclaim.xml
@@ -2,12 +2,12 @@
 <extension type="plugin" group="webservices" method="upgrade">
     <name>plg_webservices_proclaim</name>
     <author>CWM Team</author>
-    <creationDate>2026-08-29</creationDate>
+    <creationDate>2026-09-01</creationDate>
     <copyright>(C) 2026 CWM Team All rights reserved</copyright>
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
     <authorEmail>support@christianwebministries.org</authorEmail>
     <authorUrl>https://www.christianwebministries.org</authorUrl>
-    <version>10.6.2</version>
+    <version>10.6.3</version>
     <description>PLG_WEBSERVICES_PROCLAIM_DESCRIPTION</description>
     <namespace path="src">CWM\Plugin\WebServices\Proclaim</namespace>
     <files>

--- a/proclaim.xml
+++ b/proclaim.xml
@@ -6,8 +6,8 @@
     <authorEmail>info@christianwebministries.org</authorEmail>
     <authorUrl>www.christianwebministries.org</authorUrl>
     <copyright>(C) 2026 Proclaim All rights reserved.</copyright>
-    <version>10.6.2</version>
-    <creationDate>2026-08-29</creationDate>
+    <version>10.6.3</version>
+    <creationDate>2026-09-01</creationDate>
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
     <description>JBS_INS_XML_DESCRIPTION</description>
     <namespace path="src">CWM\Component\Proclaim</namespace>


### PR DESCRIPTION
Opens **10.6.3**. Manifests bumped off 10.6.2 so the gate can run — `test-upgrade.sh` refuses when the manifest and the release version disagree, and `cwm-release` runs the gate before its own bump.

## What ships

| | |
|---|---|
| #2036 | three live server bugs — the reason for the release |
| #2034 | front-end fatal on `custom_css = "0"` (development-only regression) |
| #2030 | fields a template asked for but its form never declared |
| #2021 | health checks stop reporting trashed content as work |
| #2022 | findings say what to do, and link where the rows are |
| #2032 | media list filtered to restricted files |
| #2026 | site-wide Custom CSS removed |

**#2032 is in on your call, and it is the right one.** I had held it back as an enhancement. A finding that names a handful of files and then opens a list of thousands does not give an administrator anything to act on — the missing filter is a defect in the finding, not an addition to it.

⚠️ **#2026 is a feature removal, which is normally minor-version work.** Kept as a patch because that feature never functioned — the field never rendered and `custom_css` was absent from `#__bsms_admin.params` on every install checked. Nobody loses a working capability. The notes say template-level Custom CSS is unaffected, since that is the part in use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)