### PR TITLE
chore(deps): cwm/build-tools 1.32.1

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -548,16 +548,16 @@
         },
         {
             "name": "cwm/build-tools",
-            "version": "v1.32.0",
+            "version": "v1.32.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Joomla-Bible-Study/cwm-build-tools.git",
-                "reference": "9478395521ac28a8b4c022593d047ee7c8d1a0fb"
+                "reference": "708538fc9846c9504feed9e11e7dfe987bd0e73b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Joomla-Bible-Study/cwm-build-tools/zipball/9478395521ac28a8b4c022593d047ee7c8d1a0fb",
-                "reference": "9478395521ac28a8b4c022593d047ee7c8d1a0fb",
+                "url": "https://api.github.com/repos/Joomla-Bible-Study/cwm-build-tools/zipball/708538fc9846c9504feed9e11e7dfe987bd0e73b",
+                "reference": "708538fc9846c9504feed9e11e7dfe987bd0e73b",
                 "shasum": ""
             },
             "require": {
@@ -665,10 +665,10 @@
                 "release"
             ],
             "support": {
-                "source": "https://github.com/Joomla-Bible-Study/cwm-build-tools/tree/v1.32.0",
+                "source": "https://github.com/Joomla-Bible-Study/cwm-build-tools/tree/v1.32.1",
                 "issues": "https://github.com/Joomla-Bible-Study/cwm-build-tools/issues"
             },
-            "time": "2026-08-19T22:51:15+00:00"
+            "time": "2026-09-01T19:35:10+00:00"
         },
         {
             "name": "danog/advanced-json-rpc",


### PR DESCRIPTION
Picks up three fixes in the release path — one of them reported from this repo's own 10.6.3 release.

## The one you saw

A release that finished cleanly ended with this at the prompt:

```
brentcordis@host Proclaim % 11;rgb:1919/1a1a/1c1c;1R
```

`gh` probes the terminal for its background colour (OSC 11) and cursor position (CPR) when its output is a TTY, to pick a light or dark theme — then exits without reading the replies, so the terminal's answers land in the input buffer and the shell echoes them.

Isolated by probing every release stage under a pty: build, composer, op, git, curl, cwm-bump and the PHP verifiers are all clean; **gh alone answered**. Confirmed on a machine that reproduced it — `NO_COLOR=1` takes `osc11=1 cpr=1` to `0 0`, while a control variable still leaks.

Fixed upstream in Joomla-Bible-Study/cwm-build-tools#162, released as v1.32.1.

## Also in

- an unrecognised pre-release suffix no longer publishes to ARS as **stable** (maturity is the distribution gate, so an edge build was offered to every site that checked for updates)
- `cwm-ars-publish` applies the same version gate `cwm-release` does

## Scope

**Lock only.** The `^1.32` constraint already allowed this, so `composer.json` is untouched. Verified the fix is actually vendored — all three `gh` call sites carry `NO_COLOR` in `libraries/vendor/`.

The other five CWM repos that vendor the toolset (`CWMLivingWord`, `CWMScriptureLinks`, `lib_cwmscripture`, `cwmconnect`, `com_licenseportal`) are on `^1.28`–`^1.32` and likewise need only a lock refresh — no constraint changes anywhere.

Suite: **3514 tests, 11402 assertions, OK**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)