### PR TITLE
chore(deps): allow @parcel/watcher's install script

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
   "allowScripts": {
     "core-js@3.50.0": true,
     "unrs-resolver@1.12.2": true,
-    "fsevents@2.3.3": true
+    "fsevents@2.3.3": true,
+    "@parcel/watcher@2.6.0": true
   }
 }


### PR DESCRIPTION
Every `npm install` has been printing:

```
npm warn install-scripts 1 package has install scripts not yet covered by allowScripts:
npm warn install-scripts   @parcel/watcher@2.6.0 (install: node scripts/build-from-source.js)
```

The **jest 30.4.2 → 30.5.0** bump (#2024) brought it in four levels down — `jest` → `@jest/core` → `jest-haste-map` → `@parcel/watcher`. Dependabot updates versions, not the install-script policy, so the warning arrived with a PR that looked complete and passed CI.

## ⚠️ Not only noise

npm 11 **skips** the install script of a package that isn't listed. On a platform with no prebuilt binary, the watcher never compiles and jest silently falls back to polling.

On macOS arm64 it happens to be covered by `@parcel/watcher-darwin-arm64`, which is why nothing looked broken here — I verified the module loads and exposes `subscribe()`. A CI image without a prebuild would not have been so lucky.

## Verified

- Removed the package and reinstalled: **warning present without this entry, gone with it**
- `@parcel/watcher` loads and `subscribe()` is available
- **20 JS suites, 252 tests pass**
- `npm run build` clean on the bumped rollup and terser — 72 minified bundles

🤖 Generated with [Claude Code](https://claude.com/claude-code)