### PR TITLE
fix(media): stop repeating the site's base path when a URL is mapped to disk

### DIFF
--- a/admin/src/Helper/CwmmediaStreamer.php
+++ b/admin/src/Helper/CwmmediaStreamer.php
@@ -17,6 +17,7 @@ namespace CWM\Component\Proclaim\Administrator\Helper;
 // phpcs:enable PSR1.Files.SideEffects
 
 use Joomla\CMS\Factory;
+use Joomla\CMS\Uri\Uri;
 
 /**
  * Streams a media file to the client, honouring Range, HEAD and
@@ -91,6 +92,55 @@ class CwmmediaStreamer
         self::streamRemoteFile($target, $range, $ifModifiedSince, $ifNoneMatch, $headOnly);
     }
     /**
+     * Where on disk a target would live, before asking whether it is there.
+     *
+     * ⚠️ Pure string arithmetic, deliberately separated from the filesystem
+     * checks around it, because getting this wrong is invisible from the
+     * outside: a mis-joined path simply fails to resolve and the caller
+     * concludes the file is not local. Separated out, the join can be asserted
+     * directly, without a web server and without depending on where the repo
+     * happens to be checked out.
+     *
+     * $base is the site's own path within the domain: empty at a domain root,
+     * `/joomla` for a site at `https://example.com/joomla/`. A URL carries it
+     * and JPATH_ROOT already ends in it, so joining the two without removing
+     * it first produces `/var/www/html/joomla/joomla/...`.
+     *
+     * An absolute filesystem path is passed through untouched — it is already
+     * rooted, and stripping a base from it would corrupt it.
+     *
+     * @param   string  $target  A URL on this site, or an absolute filesystem path.
+     * @param   string  $base    The site's base path, as Uri::root(true) returns it.
+     * @param   string  $root    The web root, as JPATH_ROOT holds it.
+     *
+     * @return  string  The path to test. Empty when $target carries no path at all.
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public static function candidatePath(string $target, string $base, string $root): string
+    {
+        $path = (string) (parse_url($target, PHP_URL_PATH) ?: '');
+
+        if ($path === '') {
+            return '';
+        }
+
+        $root = rtrim($root, '/\\');
+        $base = rtrim($base, '/');
+
+        // Already a filesystem path: nothing to join, nothing to strip.
+        if (str_starts_with($path, $root . '/')) {
+            return $path;
+        }
+
+        if ($base !== '' && str_starts_with($path, $base . '/')) {
+            $path = substr($path, \strlen($base));
+        }
+
+        return $root . '/' . ltrim(rawurldecode($path), '/');
+    }
+
+    /**
      * Map a same-host target URL back to a filesystem path, refusing anything
      * that resolves outside the web root (defense in depth — $target is
      * server-derived, never request-supplied, but this keeps that guarantee
@@ -104,14 +154,14 @@ class CwmmediaStreamer
      */
     private static function resolveLocalPath(string $target): ?string
     {
-        $urlPath = parse_url($target, PHP_URL_PATH);
+        $webRoot   = rtrim(JPATH_ROOT, '/');
+        $candidate = self::candidatePath($target, Uri::root(true), $webRoot);
 
-        if (empty($urlPath)) {
+        if ($candidate === '') {
             return null;
         }
 
-        $webRoot = rtrim(JPATH_ROOT, '/');
-        $real    = realpath($webRoot . '/' . ltrim(rawurldecode($urlPath), '/'));
+        $real = realpath($candidate);
 
         if ($real === false || !str_starts_with($real, $webRoot . '/') || !is_readable($real)) {
             return null;

--- a/admin/src/Helper/CwmprotectedStorage.php
+++ b/admin/src/Helper/CwmprotectedStorage.php
@@ -177,13 +177,29 @@ class CwmprotectedStorage
             return false;
         }
 
-        $path = parse_url($target, PHP_URL_PATH) ?: $target;
-        $root = rtrim(JPATH_ROOT, '/\\');
+        // ⚠️ A URL on someone else's host is served by them, whatever its path
+        // spells. Without this a remote server whose media happens to sit under
+        // /images/biblestudy/protected/ would be judged by whether a file of
+        // that name exists here — a coincidence deciding how a file is
+        // delivered. CwmmediaStreamer::serve() checks the host for the same
+        // reason before it resolves anything locally.
+        $host = strtolower((string) (parse_url($target, PHP_URL_HOST) ?: ''));
+        $site = strtolower((string) (parse_url(Uri::root(), PHP_URL_HOST) ?: ''));
 
-        // A site URL arrives as a web path; an absolute filesystem path is
-        // already rooted. Both end up compared as real paths.
-        $candidate = str_starts_with($path, $root) ? $path : $root . '/' . ltrim(rawurldecode($path), '/');
-        $real      = realpath($candidate);
+        if ($host !== '' && $host !== $site) {
+            return false;
+        }
+
+        // Shares the join with the streamer rather than repeating it: the two
+        // have to agree about where a URL lands on disk, or a file can be
+        // judged to be in protected storage and then not found there.
+        $candidate = CwmmediaStreamer::candidatePath($target, Uri::root(true), JPATH_ROOT);
+
+        if ($candidate === '') {
+            return false;
+        }
+
+        $real = realpath($candidate);
 
         if ($real === false) {
             return false;

--- a/tests/unit/Admin/Helper/CwmmediaStreamerPathTest.php
+++ b/tests/unit/Admin/Helper/CwmmediaStreamerPathTest.php
@@ -1,0 +1,165 @@
+<?php
+
+/**
+ * Unit tests for CwmmediaStreamer::candidatePath()
+ *
+ * @package    Proclaim.UnitTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Proclaim\Tests\Admin\Helper;
+
+use CWM\Component\Proclaim\Administrator\Helper\CwmmediaStreamer;
+use CWM\Component\Proclaim\Tests\ProclaimTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\TestDox;
+
+/**
+ * Regression coverage for #2045.
+ *
+ * A media URL carries the site's own base path — `/joomla` for a site at
+ * `https://example.com/joomla/` — and JPATH_ROOT already ends in that same
+ * segment. Joining the two without removing it first wrote the segment twice,
+ * so `realpath()` failed and every local file looked like it lived on someone
+ * else's server.
+ *
+ * ⚠️ That failure is invisible from the outside. Ordinary media survived it,
+ * because the streamer falls through to re-fetching its own URL over HTTP and
+ * the web server answers. A file in `images/biblestudy/protected/` cannot: the
+ * deny rules refuse that fetch, which is the entire point of the directory. So
+ * protected storage was inoperable on subdirectory installs while System
+ * Health reported the folder healthy.
+ *
+ * These assertions are on the join alone, which is why the join was separated
+ * from the filesystem checks around it. No web server, no fixture, and no
+ * dependence on where this test happens to be checked out.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+#[CoversClass(CwmmediaStreamer::class)]
+class CwmmediaStreamerPathTest extends ProclaimTestCase
+{
+    /**
+     * @return  array<string, array{0: string, 1: string, 2: string, 3: string}>
+     */
+    public static function joins(): array
+    {
+        return [
+            // target, base, root, expected
+            'domain root' => [
+                'https://example.com/images/biblestudy/protected/x.mp3',
+                '',
+                '/var/www/html',
+                '/var/www/html/images/biblestudy/protected/x.mp3',
+            ],
+            'subdirectory install' => [
+                'https://example.com/joomla/images/biblestudy/protected/x.mp3',
+                '/joomla',
+                '/var/www/html/joomla',
+                '/var/www/html/joomla/images/biblestudy/protected/x.mp3',
+            ],
+            'nested subdirectory install' => [
+                'https://example.com/sites/church/images/biblestudy/media/x.mp3',
+                '/sites/church',
+                '/var/www/html/sites/church',
+                '/var/www/html/sites/church/images/biblestudy/media/x.mp3',
+            ],
+            // ⚠️ A base with a trailing slash must behave identically. Uri::root(true)
+            // does not add one, but nothing stops a caller passing Uri::root().
+            'base carrying a trailing slash' => [
+                'https://example.com/joomla/images/x.mp3',
+                '/joomla/',
+                '/var/www/html/joomla',
+                '/var/www/html/joomla/images/x.mp3',
+            ],
+            // The segment appears twice for real: the site is at /joomla and the
+            // media genuinely lives in a folder of the same name. Only the
+            // leading one is the base.
+            'path repeating the base name' => [
+                'https://example.com/joomla/joomla/x.mp3',
+                '/joomla',
+                '/var/www/html/joomla',
+                '/var/www/html/joomla/joomla/x.mp3',
+            ],
+            'percent-encoded filename' => [
+                'https://example.com/images/biblestudy/media/a%20file.mp3',
+                '',
+                '/var/www/html',
+                '/var/www/html/images/biblestudy/media/a file.mp3',
+            ],
+            // Already rooted: pass through, and do not strip a base from it.
+            'absolute filesystem path' => [
+                '/var/www/html/joomla/images/biblestudy/protected/x.mp3',
+                '/joomla',
+                '/var/www/html/joomla',
+                '/var/www/html/joomla/images/biblestudy/protected/x.mp3',
+            ],
+            'root given with a trailing slash' => [
+                'https://example.com/images/x.mp3',
+                '',
+                '/var/www/html/',
+                '/var/www/html/images/x.mp3',
+            ],
+        ];
+    }
+
+    /**
+     * @param   string  $target    Target passed to the streamer.
+     * @param   string  $base      Site base path.
+     * @param   string  $root      Web root.
+     * @param   string  $expected  Path the join must produce.
+     *
+     * @return  void
+     */
+    #[DataProvider('joins')]
+    #[TestDox('A URL lands at the same place on disk however the site is installed')]
+    public function testJoin(string $target, string $base, string $root, string $expected): void
+    {
+        $this->assertSame($expected, CwmmediaStreamer::candidatePath($target, $base, $root));
+    }
+
+    #[TestDox('A subdirectory install does not repeat its own base path')]
+    public function testSubdirectoryBaseIsNotDoubled(): void
+    {
+        $got = CwmmediaStreamer::candidatePath(
+            'https://example.com/joomla/images/biblestudy/protected/x.mp3',
+            '/joomla',
+            '/var/www/html/joomla'
+        );
+
+        // The bug, stated as the thing that must not happen, so a reader of a
+        // failure sees what regressed rather than only which string differed.
+        $this->assertStringNotContainsString(
+            '/joomla/joomla/',
+            $got,
+            'The base path was written twice (#2045). realpath() then fails, the file is treated '
+            . 'as remote, and a protected file becomes undeliverable.'
+        );
+    }
+
+    #[TestDox('A target with no path yields nothing rather than the bare web root')]
+    public function testPathlessTargetYieldsEmpty(): void
+    {
+        // ⚠️ Returning the root would make realpath() succeed on a directory,
+        // and the containment check would pass. The caller has to be able to
+        // tell "no path" from "a path that resolves".
+        $this->assertSame('', CwmmediaStreamer::candidatePath('https://example.com', '', '/var/www/html'));
+        $this->assertSame('', CwmmediaStreamer::candidatePath('', '', '/var/www/html'));
+    }
+
+    #[TestDox('Traversal survives the join intact, for realpath to collapse and the caller to reject')]
+    public function testTraversalIsLeftForRealpathToResolve(): void
+    {
+        // Not sanitised here on purpose. This function answers "where would it
+        // be"; resolveLocalPath() collapses the result and refuses anything
+        // outside the web root. Silently rewriting a hostile path would hide
+        // it from the check that exists to catch it.
+        $this->assertSame(
+            '/var/www/html/images/../../etc/passwd',
+            CwmmediaStreamer::candidatePath('https://example.com/images/../../etc/passwd', '', '/var/www/html')
+        );
+    }
+}


### PR DESCRIPTION
Closes #2045.

## The defect

A media URL carries the site's own path within its domain — `/joomla` for a site at `https://example.com/joomla/` — and `JPATH_ROOT` **already ends in that same segment**. Both places that turn such a URL into a filesystem path joined the two without removing it first:

| | |
|---|---|
| `CwmmediaStreamer::resolveLocalPath()` | pre-existing since 10.5.6 |
| `CwmprotectedStorage::holds()` | added in #2042 |

```
domain root          OK    /var/www/html/images/biblestudy/protected/x.mp3
SUBDIRECTORY install !!    /var/www/html/joomla/joomla/images/biblestudy/protected/x.mp3
                     want  /var/www/html/joomla/images/biblestudy/protected/x.mp3
```

`realpath()` fails, and every local file is judged to live on someone else's server.

## Why it mattered more for protected storage than anything else

⚠️ **Ordinary media survives this.** `serve()` falls through to re-fetching its own URL over HTTP and the web server answers, so a download works — while quietly proxying a local file through the network.

A file in `images/biblestudy/protected` **cannot**, because refusing that fetch is the entire purpose of the directory. So protected storage was inoperable on subdirectory installs, and nothing said so: the deny-rule probe passes either way, so System Health reported the folder healthy while playback was broken.

## The fix

The join is now one function — `CwmmediaStreamer::candidatePath()` — used by both call sites. They have to agree about where a URL lands on disk, or a file can be judged to be *in* protected storage and then not found there. Before this they agreed only at a domain root.

It is pure, and deliberately separated from the filesystem checks around it, because getting it wrong is **invisible from outside**: a mis-joined path simply fails to resolve and the caller concludes the file is remote. Separated, the join can be asserted directly.

`holds()` also gains the host check `serve()` already had. It decided from the URL path alone, so a remote server whose media happened to sit under `/images/biblestudy/protected/` would have been judged by whether a file of that name existed here — a coincidence deciding how a file is delivered.

⚠️ **Traversal is left intact by the join on purpose**, for `realpath()` to collapse and `resolveLocalPath()` to refuse. Rewriting a hostile path here would hide it from the check that exists to catch it. There is a test asserting exactly that.

## Test

`CwmmediaStreamerPathTest` — 11 cases asserting the join itself. No web server, no fixture, no dependence on where the repo is checked out, which is what made this reachable at all.

Bait-checked, three reversions, each caught by the right cases:

| Reverted | Fails |
|---|---|
| the base strip (the actual bug) | 5 — every subdirectory case, plus the named `/joomla/joomla/` assertion |
| empty return for a pathless target | 1 |
| pass-through for an absolute filesystem path | 1 |

Covers a nested base (`/sites/church`), a base with a trailing slash, a path that legitimately repeats the base name (`/joomla/joomla/x.mp3` — only the leading segment is the base), and percent-encoded filenames.

## Verified unchanged on a domain-root install

Against j6-dev with a real file in protected storage:

| | |
|---|---|
| direct URL | 403 |
| `cwmsermons.stream`, public | 200, 4108 bytes |
| `Range: bytes=100-199` | 206, `Content-Range: bytes 100-199/4108` |
| restricted message | 403 |

Fixture cleaned up and the cleanup verified. Suite: 3531 tests, 11430 assertions, green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)