### PR TITLE
fix(health): look inside the protected folder, not just at its top level

### DIFF
--- a/admin/src/Health/Check/ProtectedStorageCheck.php
+++ b/admin/src/Health/Check/ProtectedStorageCheck.php
@@ -85,15 +85,15 @@ final class ProtectedStorageCheck implements HealthCheckInterface
      * The sentence for a folder that is not confirmed protected.
      *
      * @param   string  $stored  The recorded verdict.
-     * @param   int     $files   How many media files the folder holds.
+     * @param   bool    $holds   Whether the folder holds any media of its own.
      *
      * @return  string
      *
      * @since   __DEPLOY_VERSION__
      */
-    private function describe(string $stored, int $files): string
+    private function describe(string $stored, bool $holds): string
     {
-        if ($files === 0) {
+        if (!$holds) {
             return Text::_('JBS_HEALTH_PROTECTED_STORAGE_EMPTY');
         }
 
@@ -138,20 +138,20 @@ final class ProtectedStorageCheck implements HealthCheckInterface
         // this sat orange on every install for a folder holding only its own
         // guard files, and on a local or firewalled site the probe can never
         // succeed, so it never cleared.
-        $stored_files = CwmprotectedStorage::fileCount();
+        $holds_files  = CwmprotectedStorage::holdsAnything();
 
         if ($stored !== CwmmediaProtectionHelper::PROTECTED) {
             return new HealthResult(
                 $this->getId(),
-                $stored_files === 0 ? HealthStatus::Notice : HealthStatus::Warning,
+                $holds_files ? HealthStatus::Warning : HealthStatus::Notice,
                 // ⚠️ One statement, not a warning with a disclaimer bolted on.
                 // Stacking "not treated as safe" against "nothing is exposed"
                 // made a paragraph that alarms and then withdraws it; the empty
                 // case gets its own calm wording instead.
-                $this->describe($stored, $stored_files),
+                $this->describe($stored, $holds_files),
                 // The verdict, so quietening an EXPOSED site does not also
                 // quieten it once the verdict changes to something else.
-                $stored . ':' . ($stored_files === 0 ? 'empty' : 'holding'),
+                $stored . ':' . ($holds_files ? 'holding' : 'empty'),
                 'index.php?option=com_proclaim&view=cwmmediafiles&filter[restricted]=1',
                 Text::_('JBS_HEALTH_PROTECTED_STORAGE_ACTION')
             );

--- a/admin/src/Helper/CwmprotectedStorage.php
+++ b/admin/src/Helper/CwmprotectedStorage.php
@@ -111,7 +111,19 @@ class CwmprotectedStorage
     }
 
     /**
-     * How many media files the protected directory actually holds.
+     * How many entries may be examined before the answer is assumed.
+     *
+     * A bound, not a limit on what may be stored. Reached only by a directory
+     * tree of many folders holding no files, since the scan stops at the first
+     * file it finds — but this runs on every media list render, so it must not
+     * be able to walk an arbitrary tree.
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private const SCAN_LIMIT = 5000;
+
+    /**
+     * Whether the protected directory holds any media at all.
      *
      * ⚠️ The question that decides whether any of this is worth reporting. The
      * folder ships with `.htaccess` and `web.config` and nothing else, so an
@@ -122,35 +134,95 @@ class CwmprotectedStorage
      * The guard files are excluded because they are ours, not media, and they
      * are the whole contents of an unused folder.
      *
-     * @return  int  Zero when the directory is absent or holds only its guards.
+     * ⚠️ A boolean rather than a count, because a count is more than either
+     * caller asks for and more than this can honestly promise: it stops at the
+     * first file rather than walking the whole tree, and it stops at
+     * SCAN_LIMIT entries regardless. Returning a number those shortcuts make
+     * wrong would invite someone to display it.
+     *
+     * @return  bool  False only when the directory is absent, or genuinely
+     *                holds nothing but its own guard files.
      *
      * @since   __DEPLOY_VERSION__
      */
-    public static function fileCount(): int
+    public static function holdsAnything(): bool
     {
-        $path = self::path();
+        return self::containsMedia(self::path());
+    }
 
-        if (!is_dir($path)) {
-            return 0;
+    /**
+     * Whether a directory contains anything that is media rather than a guard.
+     *
+     * Takes the directory instead of reading it from the class so the walk can
+     * be exercised against a real tree. The behaviour that matters here is
+     * recursion, and recursion cannot be asserted against a folder whose
+     * location is fixed to JPATH_ROOT.
+     *
+     * ⚠️ Recursive on purpose. A single-level scan reported a folder holding
+     * media in a subdirectory as empty, and an empty folder is precisely the
+     * state System Health describes as "nothing is exposed". Nothing places
+     * files there yet, so every file in it was put there by hand — and an
+     * administrator mirroring their media layout uses subdirectories. The one
+     * path that exists in practice was the one not covered.
+     *
+     * @param   string  $dir  Directory to walk.
+     *
+     * @return  bool  True on the first media file found, or if the scan was
+     *                cut short — an unfinished scan must never be reported as
+     *                an empty folder, which is the reassuring answer.
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public static function containsMedia(string $dir): bool
+    {
+        if (!is_dir($dir)) {
+            return false;
         }
 
-        $found = 0;
+        try {
+            // CATCH_GET_CHILD: a subdirectory this process cannot read is
+            // skipped rather than aborting the walk. Its contents are unknown,
+            // not absent, but refusing to answer at all would leave the caller
+            // with nothing.
+            // ⚠️ SELF_FIRST, not LEAVES_ONLY. LEAVES_ONLY never yields a
+            // directory, so a tree of empty folders produces no entries at all
+            // and the bound below counts nothing while the walk still descends
+            // every one of them — a limit that cannot be reached is not a
+            // limit. Yielding directories too makes the count reflect the work.
+            $walk = new \RecursiveIteratorIterator(
+                new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS),
+                \RecursiveIteratorIterator::SELF_FIRST,
+                \RecursiveIteratorIterator::CATCH_GET_CHILD
+            );
+        } catch (\Throwable) {
+            // Unreadable at the top. Same reasoning as the limit below.
+            return true;
+        }
 
-        foreach (glob($path . '/*') ?: [] as $entry) {
-            if (!is_file($entry)) {
+        $seen = 0;
+
+        foreach ($walk as $entry) {
+            if (++$seen > self::SCAN_LIMIT) {
+                return true;
+            }
+
+            if (!$entry->isFile()) {
                 continue;
             }
 
-            $name = basename($entry);
+            $name = $entry->getFilename();
 
+            // Guards are skipped wherever they appear: an administrator who
+            // copies the directory's own deny files into a subfolder has still
+            // not stored media there.
             if ($name === 'web.config' || str_starts_with($name, '.')) {
                 continue;
             }
 
-            $found++;
+            return true;
         }
 
-        return $found;
+        return false;
     }
 
     /**

--- a/admin/src/View/Cwmmediafiles/HtmlView.php
+++ b/admin/src/View/Cwmmediafiles/HtmlView.php
@@ -319,7 +319,7 @@ class HtmlView extends BaseHtmlView
         // Whether the deny rules work is worth knowing before relying on them,
         // but that is a readiness question for System Health, not a warning on
         // a list screen about files that do not exist.
-        if (CwmprotectedStorage::fileCount() === 0) {
+        if (!CwmprotectedStorage::holdsAnything()) {
             return;
         }
 

--- a/tests/unit/Admin/Health/ProtectedStorageCheckTest.php
+++ b/tests/unit/Admin/Health/ProtectedStorageCheckTest.php
@@ -1,0 +1,109 @@
+<?php
+
+/**
+ * Unit tests for ProtectedStorageCheck
+ *
+ * @package    Proclaim.UnitTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Proclaim\Tests\Admin\Health;
+
+use CWM\Component\Proclaim\Administrator\Health\Check\ProtectedStorageCheck;
+use CWM\Component\Proclaim\Administrator\Health\HealthResult;
+use CWM\Component\Proclaim\Administrator\Health\HealthStatus;
+use CWM\Component\Proclaim\Administrator\Helper\CwmmediaProtectionHelper;
+use CWM\Component\Proclaim\Tests\ProclaimTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestDox;
+
+/**
+ * ⚠️ Nothing executed this check before. HealthContractTest reads the check
+ * classes at source level — ids, groups, language keys, whether an active check
+ * is run unprompted — and never calls run() on any of them. So a check whose
+ * body no longer type-checks passes the whole suite and fails on the
+ * Administration screen, which is the one place it is reached.
+ *
+ * That is not hypothetical here: this check's severity and wording are chosen
+ * from whether the protected folder holds anything, and the shape of that
+ * answer changed twice while no test ran the code that consumes it.
+ *
+ * These tests exercise the parts a source-level scan cannot see. The wider gap
+ * — that no passive check is ever run by the suite — is its own problem.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+#[CoversClass(ProtectedStorageCheck::class)]
+class ProtectedStorageCheckTest extends ProclaimTestCase
+{
+    #[TestDox('The check runs and returns a result')]
+    public function testRunReturnsAResult(): void
+    {
+        $result = (new ProtectedStorageCheck())->run();
+
+        $this->assertInstanceOf(HealthResult::class, $result);
+        $this->assertInstanceOf(HealthStatus::class, $result->status);
+    }
+
+    #[TestDox('It is passive, so running it here is what the panel does')]
+    public function testCheckIsPassive(): void
+    {
+        // ⚠️ Guards the test above. An active check must not be run without
+        // being asked, so if this ever becomes active, calling run() stops
+        // being a safe thing for a test to do.
+        $this->assertTrue(
+            (new ProtectedStorageCheck())->isPassive(),
+            'The check became active; running it unprompted is no longer safe and testRunReturnsAResult must change.'
+        );
+    }
+
+    /**
+     * @return  array<string, array{0: string, 1: bool, 2: string}>
+     */
+    public static function verdicts(): array
+    {
+        return [
+            'empty folder, unverified' => [CwmmediaProtectionHelper::UNVERIFIED, false, 'EMPTY'],
+            'empty folder, exposed'    => [CwmmediaProtectionHelper::EXPOSED,    false, 'EMPTY'],
+            'holding, exposed'         => [CwmmediaProtectionHelper::EXPOSED,    true,  'EXPOSED'],
+            'holding, unverified'      => [CwmmediaProtectionHelper::UNVERIFIED, true,  'UNVERIFIED'],
+        ];
+    }
+
+    #[TestDox('The wording follows what is actually at stake')]
+    #[\PHPUnit\Framework\Attributes\DataProvider('verdicts')]
+    public function testDescribeChoosesTheRightSentence(string $stored, bool $holds, string $expectedKey): void
+    {
+        $method = new \ReflectionMethod(ProtectedStorageCheck::class, 'describe');
+        $text   = (string) $method->invoke(new ProtectedStorageCheck(), $stored, $holds);
+
+        $this->assertNotSame('', $text);
+
+        // ⚠️ Asserted on the language key, not the sentence. Untranslated,
+        // Text::_() returns the key, which is exactly what identifies the
+        // branch — and it does not re-break every time the copy is reworded.
+        $this->assertStringContainsString(
+            'JBS_HEALTH_PROTECTED_STORAGE_' . $expectedKey,
+            $text,
+            "An empty folder must be described calmly and an occupied one plainly; this took the wrong branch."
+        );
+    }
+
+    #[TestDox('An empty folder is never reported as a fault')]
+    public function testEmptyFolderIsNotAWarning(): void
+    {
+        // The regression the severity split exists to prevent: reported as a
+        // Warning regardless, this sat orange on every install over a folder
+        // holding nothing but its own deny files.
+        $method = new \ReflectionMethod(ProtectedStorageCheck::class, 'describe');
+        $text   = (string) $method->invoke(new ProtectedStorageCheck(), CwmmediaProtectionHelper::EXPOSED, false);
+
+        $this->assertStringNotContainsString(
+            'JBS_HEALTH_PROTECTED_STORAGE_EXPOSED',
+            $text,
+            'An empty folder was described as exposing files. There is nothing in it to expose.'
+        );
+    }
+}

--- a/tests/unit/Admin/Helper/CwmprotectedStorageScanTest.php
+++ b/tests/unit/Admin/Helper/CwmprotectedStorageScanTest.php
@@ -1,0 +1,169 @@
+<?php
+
+/**
+ * Unit tests for CwmprotectedStorage::containsMedia()
+ *
+ * @package    Proclaim.UnitTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Proclaim\Tests\Admin\Helper;
+
+use CWM\Component\Proclaim\Administrator\Helper\CwmprotectedStorage;
+use CWM\Component\Proclaim\Tests\ProclaimTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestDox;
+
+/**
+ * Regression coverage for #2046.
+ *
+ * This predicate decides whether Proclaim says anything at all about the
+ * protected directory. When it answers "empty", the media list suppresses its
+ * banner and System Health reports, in as many words, that nothing is exposed.
+ *
+ * ⚠️ It used to scan one level. Media in a subdirectory counted as nothing, so
+ * a folder holding restricted files could be described as empty while the deny
+ * rules were unproven — a confident wrong answer, which is worse than not
+ * checking. Nothing moves files there yet, so every file in that folder was
+ * placed by hand, and hand-placement is exactly what uses subdirectories.
+ *
+ * Exercised against real directories in a temp tree: the behaviour under test
+ * is a filesystem walk, and a walk cannot be asserted against a folder whose
+ * location is fixed to JPATH_ROOT.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+#[CoversClass(CwmprotectedStorage::class)]
+class CwmprotectedStorageScanTest extends ProclaimTestCase
+{
+    private string $dir = '';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->dir = sys_get_temp_dir() . '/cwm-protected-' . bin2hex(random_bytes(6));
+        mkdir($this->dir, 0o755, true);
+
+        // Every real protected directory carries these and nothing else until
+        // someone stores media. They must never count as media themselves.
+        file_put_contents($this->dir . '/.htaccess', "Deny from all\n");
+        file_put_contents($this->dir . '/web.config', "<configuration/>\n");
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeTree($this->dir);
+
+        parent::tearDown();
+    }
+
+    private function removeTree(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        foreach (scandir($dir) ?: [] as $entry) {
+            if ($entry === '.' || $entry === '..') {
+                continue;
+            }
+
+            $path = $dir . '/' . $entry;
+            is_dir($path) ? $this->removeTree($path) : unlink($path);
+        }
+
+        rmdir($dir);
+    }
+
+    #[TestDox('A folder holding only its own guard files is empty')]
+    public function testGuardFilesAloneAreNotMedia(): void
+    {
+        // ⚠️ Positive control for every "holds media" assertion below. If the
+        // walk counted the guards, every one of them would pass without the
+        // recursion being right, or indeed present.
+        $this->assertFalse(
+            CwmprotectedStorage::containsMedia($this->dir),
+            'The directory\'s own .htaccess and web.config were counted as stored media.'
+        );
+    }
+
+    #[TestDox('A file at the top level is found')]
+    public function testTopLevelFileIsFound(): void
+    {
+        file_put_contents($this->dir . '/sermon.mp3', 'x');
+
+        $this->assertTrue(CwmprotectedStorage::containsMedia($this->dir));
+    }
+
+    #[TestDox('A file in a subdirectory is found')]
+    public function testFileInSubdirectoryIsFound(): void
+    {
+        mkdir($this->dir . '/2026', 0o755, true);
+        file_put_contents($this->dir . '/2026/sermon.mp3', 'x');
+
+        $this->assertTrue(
+            CwmprotectedStorage::containsMedia($this->dir),
+            'Media one folder down was reported as an empty directory. System Health then states '
+            . 'that nothing is exposed while restricted files sit there.'
+        );
+    }
+
+    #[TestDox('A file several folders down is found')]
+    public function testDeeplyNestedFileIsFound(): void
+    {
+        mkdir($this->dir . '/2026/summer/john', 0o755, true);
+        file_put_contents($this->dir . '/2026/summer/john/sermon.mp3', 'x');
+
+        $this->assertTrue(CwmprotectedStorage::containsMedia($this->dir));
+    }
+
+    #[TestDox('Guard files copied into a subfolder are still not media')]
+    public function testGuardsAreSkippedAtEveryDepth(): void
+    {
+        mkdir($this->dir . '/2026', 0o755, true);
+        file_put_contents($this->dir . '/2026/web.config', "<configuration/>\n");
+        file_put_contents($this->dir . '/2026/.htaccess', "Deny from all\n");
+
+        $this->assertFalse(CwmprotectedStorage::containsMedia($this->dir));
+    }
+
+    #[TestDox('Empty subdirectories are not mistaken for stored media')]
+    public function testEmptyDirectoriesAreNotMedia(): void
+    {
+        mkdir($this->dir . '/2026/summer', 0o755, true);
+
+        // The walk yields directories as well as files, so that the scan bound
+        // reflects the traversal. isFile() is what keeps structure from reading
+        // as content.
+        $this->assertFalse(CwmprotectedStorage::containsMedia($this->dir));
+    }
+
+    #[TestDox('A directory that does not exist holds nothing')]
+    public function testMissingDirectory(): void
+    {
+        $this->assertFalse(CwmprotectedStorage::containsMedia($this->dir . '/nope'));
+    }
+
+    #[TestDox('A scan cut short reports the folder as occupied, never as empty')]
+    public function testScanLimitFailsTowardsReporting(): void
+    {
+        $limit = (new \ReflectionClass(CwmprotectedStorage::class))->getConstant('SCAN_LIMIT');
+
+        $this->assertIsInt($limit, 'SCAN_LIMIT is gone; this test no longer checks the bound.');
+
+        // Enough empty directories to exhaust the bound before any file is
+        // reached. "Empty" is the reassuring answer and the one that silences
+        // every warning, so it must not be what an unfinished scan produces.
+        for ($i = 0; $i <= $limit; $i++) {
+            mkdir($this->dir . '/d' . $i, 0o755, true);
+        }
+
+        $this->assertTrue(
+            CwmprotectedStorage::containsMedia($this->dir),
+            'A scan that gave up reported the folder as empty, which is what suppresses the warning.'
+        );
+    }
+}


### PR DESCRIPTION
Closes #2046.

## The defect

The scan globbed one level:

```php
foreach (glob($path . "/*") ?: [] as $entry) {
    if (!is_file($entry)) { continue; }
```

Media in a subdirectory counted as **nothing**. At zero, the media list suppresses its banner and System Health reports — in as many words — that *"nothing is exposed"*. A confident wrong answer over a folder holding restricted files, which is worse than not checking at all.

Nothing moves files into that folder yet (#2041), so everything in it was placed by hand, and an administrator mirroring their `images/biblestudy/media/` layout uses subdirectories. **The one path that exists in practice was the one not covered.**

## `fileCount()` becomes `holdsAnything()`

Both callers only ever asked whether the count was zero:

```php
if (CwmprotectedStorage::fileCount() === 0) { return; }   // HtmlView
$stored_files === 0 ? Notice : Warning                     // health check
```

A count is also more than the walk can honestly promise — it stops at the first file it finds. Returning a number those shortcuts make wrong would invite someone to display it. The method was added in the same unreleased cycle, so nothing depends on the old name.

The walk itself is `containsMedia()`, taking the directory rather than reading it from the class, so recursion can be exercised against a real tree. It cannot be asserted against a folder whose location is fixed to `JPATH_ROOT` — the same reason `candidatePath()` was extracted in #2049.

## ⚠️ SELF_FIRST, not LEAVES_ONLY — and the test is what caught it

My first version used `LEAVES_ONLY`, which never yields a directory. A tree of empty folders therefore produced **no entries at all**: the scan bound counted nothing while the walk still descended every one of them. A limit that cannot be reached is not a limit.

The test written for the bound failed, not review. `SELF_FIRST` makes the count reflect the traversal, and `isFile()` then does real work keeping structure from reading as content.

**An exhausted scan answers "occupied."** Empty is the reassuring answer and the one that silences every warning, so it must not be what an unfinished scan produces. Same reasoning for a directory that cannot be read.

## Also: the first test that executes a health check

⚠️ `HealthContractTest` reads the check classes at source level — ids, groups, language keys, registration — and **never calls `run()` on any of them**. So this check's severity and wording have never been exercised, while the shape of the value they are chosen from changed twice (#2042, and again here).

`ProtectedStorageCheckTest` runs it. The wider gap — that no passive check is run by the suite, for any of the 26 — is filed as **#2050**.

📝 One correction to my own note on the issue: I expected the `describe(string, int)` → `describe(string, bool)` change to be a type risk. It is not. There is no `declare(strict_types=1)` in that file, so `bool` coerces to `int` cleanly and behaviour was identical. I confirmed that by reverting the signature — the tests pass either way. The new test guards the *branch logic*, not a coercion that was never going to fail.

## Tests

Bait-checked, each reversion caught by named assertions:

| Reverted | Fails |
|---|---|
| single-level glob (the original bug) | 3 — subdirectory, deeply nested, and the scan bound |
| skipping the guard files | 3 |
| "empty" on an exhausted scan | 1 |
| the empty-folder wording branch | 5 |

`CwmprotectedStorageScanTest` builds real temp directories — guards only, top-level file, one level down, several levels down, guards copied into a subfolder, empty directories, a missing directory, and the bound. `testGuardFilesAloneAreNotMedia` is the positive control: if the guards were counted, every other assertion would pass without the recursion being right, or present.

Suite: 3546 tests, 11451 assertions. `lint:syntax`, `lint`, `lint:comments`, `lint:queries` all clean before pushing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)