### PR TITLE
fix(analytics): count a play or download only when the visitor may have it

### DIFF
--- a/site/src/Controller/CwmsermonsController.php
+++ b/site/src/Controller/CwmsermonsController.php
@@ -47,7 +47,8 @@ class CwmsermonsController extends BaseController
         $input = Factory::getApplication()->getInput();
         $mid   = $input->getInt('mid') ?: $input->getInt('id');
 
-        CwmanalyticsHelper::logEvent('download', 0, $mid);
+        // The event is recorded inside download(), once it knows the visitor
+        // may actually have the file. Logged from here it counted refusals.
         $downloader = new Cwmdownload();
         $downloader->download($mid);
     }
@@ -75,9 +76,8 @@ class CwmsermonsController extends BaseController
         $input = Factory::getApplication()->getInput();
         $mid   = $input->getInt('mid') ?: $input->getInt('id');
 
-        // Counted as a play, not a download: this is the player asking.
-        CwmanalyticsHelper::logEvent('play', 0, $mid);
-
+        // Recorded as a play rather than a download — this is the player
+        // asking — and recorded inside download(), after the access check.
         $downloader = new Cwmdownload();
         $downloader->download($mid, true);
     }
@@ -92,11 +92,20 @@ class CwmsermonsController extends BaseController
      */
     public function playHit(): void
     {
-        $app      = Factory::getApplication();
-        $id       = $app->getInput()->getInt('id', 0);
-        $getMedia = new Cwmmedia();
-        $getMedia->hitPlay($id);
-        CwmanalyticsHelper::logEvent('play', 0, $id);
+        $app = Factory::getApplication();
+        $id  = $app->getInput()->getInt('id', 0);
+
+        // ⚠️ Counting is gated, redirecting is not. This endpoint takes a bare
+        // media id from the request and increments a counter, so without a
+        // check anyone can inflate any message's play count — and needs no
+        // access to the media to do it. The redirect is left alone: it goes
+        // wherever it went before, and refusing to navigate would be a
+        // behaviour change dressed up as a statistics fix.
+        if (Cwmdownload::reachable($id)) {
+            $getMedia = new Cwmmedia();
+            $getMedia->hitPlay($id);
+            CwmanalyticsHelper::logEvent('play', 0, $id);
+        }
 
         // Now the hit has been updated will redirect to the url.
         $return = $app->getInput()->getBase64('return', '');
@@ -123,14 +132,19 @@ class CwmsermonsController extends BaseController
         $app = Factory::getApplication();
         $id  = $app->getInput()->getInt('id', 0);
 
-        if ($id > 0) {
+        // The cheapest way to inflate a counter of the four: no file is
+        // transferred, so a refused visitor could previously drive the play
+        // count of any message at the cost of one request.
+        $counted = Cwmdownload::reachable($id);
+
+        if ($counted) {
             $getMedia = new Cwmmedia();
             $getMedia->hitPlay($id);
             CwmanalyticsHelper::logEvent('play', 0, $id);
         }
 
         header('Content-Type: application/json; charset=utf-8');
-        echo json_encode(['success' => $id > 0], JSON_THROW_ON_ERROR);
+        echo json_encode(['success' => $counted], JSON_THROW_ON_ERROR);
         $app->close();
     }
 

--- a/site/src/Helper/Cwmdownload.php
+++ b/site/src/Helper/Cwmdownload.php
@@ -16,6 +16,7 @@ namespace CWM\Component\Proclaim\Site\Helper;
 
 // phpcs:enable PSR1.Files.SideEffects
 
+use CWM\Component\Proclaim\Administrator\Helper\CwmanalyticsHelper;
 use CWM\Component\Proclaim\Administrator\Helper\CwmDebug;
 use CWM\Component\Proclaim\Administrator\Helper\Cwmhelper;
 use CWM\Component\Proclaim\Administrator\Helper\CwmmediaStreamer;
@@ -52,6 +53,85 @@ class Cwmdownload
         'video/mp4', 'video/ogg', 'video/quicktime', 'video/webm',
         'video/x-matroska', 'video/x-ms-wmv', 'video/x-msvideo',
     ];
+
+    /**
+     * Load a published media file together with the access levels it inherits.
+     *
+     * The study and series levels come along because a media file is only as
+     * reachable as the message it belongs to. Kept as one query with one
+     * caller-visible shape so that everything deciding whether someone may
+     * have this media asks the same question — a second copy of these joins is
+     * a second chance to leave one of them out.
+     *
+     * @param   int  $mid  Media file id.
+     *
+     * @return  ?object  The row, with study_access and series_access, or null
+     *                   when there is no such media file or it is unpublished.
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public static function loadMedia(int $mid): ?object
+    {
+        $db    = Factory::getContainer()->get(DatabaseInterface::class);
+        $query = $db->createQuery();
+
+        $query->select(
+            $db->quoteName('#__bsms_mediafiles') . '.*,'
+            . $db->quoteName('#__bsms_servers.id', 'ssid') . ', ' . $db->quoteName('#__bsms_servers.params', 'sparams')
+            . ', ' . $db->quoteName('study.access', 'study_access')
+            . ', ' . $db->quoteName('series.access', 'series_access')
+        )
+            ->from($db->quoteName('#__bsms_mediafiles'))
+            ->leftJoin(
+                $db->quoteName('#__bsms_servers') . ' ON ('
+                . $db->quoteName('#__bsms_servers.id') . ' = ' . $db->quoteName('#__bsms_mediafiles.server_id') . ')'
+            )
+            ->leftJoin(
+                $db->quoteName('#__bsms_studies', 'study') . ' ON ('
+                . $db->quoteName('study.id') . ' = ' . $db->quoteName('#__bsms_mediafiles.study_id') . ')'
+            )
+            ->leftJoin(
+                $db->quoteName('#__bsms_series', 'series') . ' ON ('
+                . $db->quoteName('series.id') . ' = ' . $db->quoteName('study.series_id') . ')'
+            )
+            ->where($db->quoteName('#__bsms_mediafiles.id') . ' = ' . $mid)
+            ->where($db->quoteName('#__bsms_mediafiles.published') . ' = 1');
+
+        $db->setQuery($query, 0, 1);
+
+        return $db->loadObject();
+    }
+
+    /**
+     * Whether the visitor making this request may reach this media file.
+     *
+     * The reachability question on its own, for callers that record something
+     * about a media file without serving it. A counter is a statement that
+     * something happened, and a request that would have been refused did not
+     * happen — it was turned away.
+     *
+     * @param   int  $mid  Media file id.
+     *
+     * @return  bool
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public static function reachable(int $mid): bool
+    {
+        if ($mid <= 0) {
+            return false;
+        }
+
+        $media = self::loadMedia($mid);
+
+        if (!$media) {
+            return false;
+        }
+
+        $user = Factory::getApplication()->getIdentity();
+
+        return self::isAccessible($media, $user?->getAuthorisedViewLevels() ?? []);
+    }
 
     /**
      * Method to send a file to the browser
@@ -92,33 +172,7 @@ class Cwmdownload
         $registry->loadString($template->params);
         $params = $registry;
 
-        // The study and series levels come along because a media file is only
-        // as reachable as the message it belongs to — see the access check below.
-        $query = $db->createQuery();
-        $query->select(
-            $db->quoteName('#__bsms_mediafiles') . '.*,'
-            . $db->quoteName('#__bsms_servers.id', 'ssid') . ', ' . $db->quoteName('#__bsms_servers.params', 'sparams')
-            . ', ' . $db->quoteName('study.access', 'study_access')
-            . ', ' . $db->quoteName('series.access', 'series_access')
-        )
-            ->from($db->quoteName('#__bsms_mediafiles'))
-            ->leftJoin(
-                $db->quoteName('#__bsms_servers') . ' ON ('
-                . $db->quoteName('#__bsms_servers.id') . ' = ' . $db->quoteName('#__bsms_mediafiles.server_id') . ')'
-            )
-            ->leftJoin(
-                $db->quoteName('#__bsms_studies', 'study') . ' ON ('
-                . $db->quoteName('study.id') . ' = ' . $db->quoteName('#__bsms_mediafiles.study_id') . ')'
-            )
-            ->leftJoin(
-                $db->quoteName('#__bsms_series', 'series') . ' ON ('
-                . $db->quoteName('series.id') . ' = ' . $db->quoteName('study.series_id') . ')'
-            )
-            ->where($db->quoteName('#__bsms_mediafiles.id') . ' = ' . $mid)
-            ->where($db->quoteName('#__bsms_mediafiles.published') . ' = 1');
-        $db->setQuery($query, 0, 1);
-
-        $media = $db->loadObject();
+        $media = self::loadMedia($mid);
 
         if (!$media) {
             $this->sendError($app, 404, 'Media not found');
@@ -147,6 +201,13 @@ class Cwmdownload
 
         // Increment download count after validation
         $this->hitDownloads($mid);
+
+        // ⚠️ Logged here rather than by the controller that called us, which
+        // logged before this method ran and therefore counted requests this
+        // check then refused. A counter that includes the traffic it turned
+        // away is not measuring what its name says, and nothing downstream can
+        // separate the two afterwards.
+        CwmanalyticsHelper::logEvent($inline ? 'play' : 'download', 0, $mid);
 
         $reg = new Registry();
         $reg->loadString($media->sparams);

--- a/tests/integration/Site/Helper/CwmdownloadReachableTest.php
+++ b/tests/integration/Site/Helper/CwmdownloadReachableTest.php
@@ -1,0 +1,229 @@
+<?php
+
+/**
+ * Integration tests for Cwmdownload::loadMedia() and reachable().
+ *
+ * @package    Proclaim.IntegrationTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Proclaim\Tests\Integration\Site\Helper;
+
+use CWM\Component\Proclaim\Site\Helper\Cwmdownload;
+use CWM\Component\Proclaim\Tests\Integration\IntegrationTestCase;
+use Joomla\CMS\Factory;
+use Joomla\CMS\User\UserFactoryInterface;
+use Joomla\Database\DatabaseDriver;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestDox;
+
+/**
+ * Regression coverage for #2047.
+ *
+ * Four endpoints record that a media file was played or downloaded, and all
+ * four did so before anything decided whether the visitor could have it. Two
+ * of them — playHit and playHitAjax — took a bare media id from the request
+ * and incremented a counter with no check at all, so any message's play count
+ * could be driven up by anyone, and playHitAjax transfers no file to do it.
+ *
+ * reachable() is the question those endpoints now ask first. A counter is a
+ * statement that something happened, and a request that would have been
+ * refused did not happen — it was turned away.
+ *
+ * ⚠️ loadMedia() is the load-bearing half: it carries the study and series
+ * levels that isAccessible() needs. A row fetched without those joins produces
+ * an object whose study_access is simply absent, and the chain check then finds
+ * nothing to refuse — it fails open, silently, and every test asserting a
+ * refusal would still pass if the refusal came from somewhere else.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+#[CoversClass(Cwmdownload::class)]
+class CwmdownloadReachableTest extends IntegrationTestCase
+{
+    private ?DatabaseDriver $db = null;
+
+    private int $mediaAtStart = 0;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (!\defined('PROCLAIM_TEST_DB_AVAILABLE') || !PROCLAIM_TEST_DB_AVAILABLE) {
+            $this->markTestSkipped('Database not available for integration tests');
+        }
+
+        $this->db = Factory::getContainer()->get(DatabaseDriver::class);
+        $this->db->transactionStart(true);
+
+        $this->mediaAtStart = $this->countMedia();
+
+        // ⚠️ reachable() asks the application who is making the request, and a
+        // test process arrives with no identity at all — getAuthorisedViewLevels()
+        // then returns nothing and everything is refused. That refusal is an
+        // artefact of the harness, and it would make every assertion in this
+        // class pass for a reason unrelated to what it claims to test. Load a
+        // real guest so the levels come from the site's own view-level rows.
+        $guest = Factory::getContainer()->get(UserFactoryInterface::class)->loadUserById(0);
+        Factory::getApplication()->loadIdentity($guest);
+
+        $this->assertNotEmpty(
+            $guest->getAuthorisedViewLevels(),
+            'The guest holds no view levels; nothing here would be distinguishing a refusal from an empty set.'
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        $leaked = null;
+
+        if ($this->db !== null) {
+            try {
+                $this->db->transactionRollback(true);
+
+                $after = $this->countMedia();
+
+                if ($after !== $this->mediaAtStart) {
+                    $leaked = \sprintf(
+                        'Test isolation broke: #__bsms_mediafiles went from %d to %d rows.',
+                        $this->mediaAtStart,
+                        $after
+                    );
+                }
+            } catch (\Throwable) {
+                // Connection lost; nothing to roll back.
+            }
+        }
+
+        parent::tearDown();
+
+        if ($leaked !== null) {
+            $this->fail($leaked);
+        }
+    }
+
+    /**
+     * @return  int  Total rows in the media table.
+     */
+    private function countMedia(): int
+    {
+        return (int) $this->db->setQuery(
+            $this->db->createQuery()->select('COUNT(*)')->from($this->db->quoteName('#__bsms_mediafiles'))
+        )->loadResult();
+    }
+
+    /**
+     * @param   array<string, int>  $state  Overrides for any flag.
+     *
+     * @return  int  The new media file's id.
+     */
+    private function makeChain(array $state = []): int
+    {
+        $state += [
+            'series_access'   => 1,
+            'study_access'    => 1,
+            'media_published' => 1,
+            'media_access'    => 1,
+        ];
+
+        $series = (object) [
+            'series_text' => 'reachable fixture series',
+            'published'   => 1,
+            'access'      => $state['series_access'],
+            'language'    => '*',
+        ];
+        $this->db->insertObject('#__bsms_series', $series, 'id');
+        $seriesId = (int) $this->db->insertid();
+
+        $study = (object) [
+            'studytitle' => 'reachable fixture message',
+            'series_id'  => $seriesId,
+            'published'  => 1,
+            'access'     => $state['study_access'],
+            'language'   => '*',
+        ];
+        $this->db->insertObject('#__bsms_studies', $study, 'id');
+        $studyId = (int) $this->db->insertid();
+
+        $media = (object) [
+            'study_id'  => $studyId,
+            'server_id' => 0,
+            'published' => $state['media_published'],
+            'access'    => $state['media_access'],
+            'params'    => '{"filename":"reachable-fixture.mp3"}',
+            'metadata'  => '',
+            'language'  => '*',
+        ];
+        $this->db->insertObject('#__bsms_mediafiles', $media, 'id');
+
+        return (int) $this->db->insertid();
+    }
+
+    #[TestDox('The loaded row carries the levels the chain check needs')]
+    public function testLoadMediaCarriesTheInheritedLevels(): void
+    {
+        $id    = $this->makeChain(['study_access' => 2, 'series_access' => 3]);
+        $media = Cwmdownload::loadMedia($id);
+
+        $this->assertNotNull($media, 'A published media file was not found.');
+
+        // ⚠️ Without these the chain check has nothing to test and fails open.
+        // Every refusal assertion elsewhere would still pass, for the wrong
+        // reason, so this is asserted on its own.
+        $this->assertObjectHasProperty('study_access', $media);
+        $this->assertObjectHasProperty('series_access', $media);
+        $this->assertSame(2, (int) $media->study_access);
+        $this->assertSame(3, (int) $media->series_access);
+    }
+
+    #[TestDox('An unpublished media file is not loaded')]
+    public function testUnpublishedMediaIsNotLoaded(): void
+    {
+        $id = $this->makeChain(['media_published' => 0]);
+
+        $this->assertNull(Cwmdownload::loadMedia($id));
+    }
+
+    #[TestDox('A media id that does not exist is not loaded')]
+    public function testUnknownMediaIsNotLoaded(): void
+    {
+        $this->assertNull(Cwmdownload::loadMedia(0));
+    }
+
+    #[TestDox('Nothing is reachable without a real, published media id')]
+    public function testReachableRefusesMissingAndUnpublished(): void
+    {
+        // Independent of who is asking, so these hold whatever identity the
+        // test process carries.
+        $this->assertFalse(Cwmdownload::reachable(0));
+        $this->assertFalse(Cwmdownload::reachable(-1));
+        $this->assertFalse(Cwmdownload::reachable($this->makeChain(['media_published' => 0])));
+    }
+
+    #[TestDox('Each link in the chain puts the media out of a guest\'s reach on its own')]
+    public function testEachLinkRefusesAGuest(): void
+    {
+        // The whole point of the gate. Before this, all four endpoints counted
+        // a play or a download for media in exactly these states.
+        foreach (['media_access', 'study_access', 'series_access'] as $field) {
+            $this->assertFalse(
+                Cwmdownload::reachable($this->makeChain([$field => 2])),
+                "A guest reached media behind a restricted $field, so playing it would still be counted."
+            );
+        }
+    }
+
+    #[TestDox('A fully public chain is reachable by a guest')]
+    public function testPublicChainIsReachable(): void
+    {
+        // Positive control. Without it, a reachable() broken for all input
+        // would satisfy every refusal assertion above — and breaking it that
+        // way stops every legitimate play and download being counted.
+        $this->assertTrue(
+            Cwmdownload::reachable($this->makeChain()),
+            'A public media file was judged unreachable; no play or download would ever be recorded.'
+        );
+    }
+}


### PR DESCRIPTION
Closes #2047.

## Wider than the issue describes, and here is why

The issue is about ordering in `download()` and `stream()`. Looking at the file turned up two more callers with the same problem in a sharper form, so the fix covers all four.

| endpoint | before |
|---|---|
| `download()` | logged from the controller, before the access chain ran and answered 403 |
| `stream()` | same |
| **`playHit()`** | **no check of any kind** — bare media id from the request, counter incremented |
| **`playHitAjax()`** | **no check of any kind**, and transfers no file to do it |

⚠️ The last two mean any message's play count could be driven up by anyone, for any media, at the cost of one request. Fixing only the ordering would have left the cheaper path wide open.

## What changed

**`download()` / `stream()`** — the event moves into `Cwmdownload::download()`, next to `hitDownloads()`, which was already deliberately placed after validation. `play` or `download` is chosen from whether the file was served inline, so the two controller actions no longer each carry their own copy of that decision.

**`playHit()` / `playHitAjax()`** — both ask `Cwmdownload::reachable()` first.

⚠️ **Counting is gated; redirecting is not.** `playHit` goes wherever it went before. Refusing to navigate would be a behaviour change dressed up as a statistics fix, and the redirect target is a URL the web server serves anyway. `playHitAjax` reports `success` only when it counted, which is what that flag always claimed to mean.

**`reachable()`** is built on `loadMedia()`, extracted from `download()`'s inline query. Everything deciding whether someone may have a media file now asks through one place — a second copy of those joins is a second chance to leave one out, and leaving one out fails **open**.

## Verified on a running site, both directions

| | restricted, anonymous | made public |
|---|---|---|
| `playHitAjax` | `{"success":false}` | `{"success":true}` |
| `plays` column | stays **0** | becomes **1** |
| `Cwmsermons.download` | 403, **no event** | records `download=1` |
| `cwmsermons.stream` | 403, **no event** | records `play=1` |

`playHit` still redirects either way. Fixture and its analytics rows cleaned up, cleanup verified.

## ⚠️ The positive control earned its keep

`CwmdownloadReachableTest` failed on first run — a test process arrives with **no identity**, so `getAuthorisedViewLevels()` returns nothing and `reachable()` refuses everything. Every refusal assertion in the class would have passed for a reason unrelated to the code under test.

It now loads a real guest via `UserFactoryInterface` and asserts that guest holds view levels before trusting anything else.

Bait-checked:

| Reverted | Fails |
|---|---|
| the access check in `reachable()` | the chain test, on `media_access` |
| the study/series joins in `loadMedia()` | the chain test on a *different* link, plus the test asserting the row carries those levels |

That second one is the failure mode worth naming: a row fetched without those joins has no `study_access` at all, so the chain check finds nothing to refuse and **fails open silently**.

Suite: 3552 tests, 11471 assertions. All four lint steps clean before pushing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)