### PR TITLE
chore(deps): pick up build-tools v1.33.0 before the next release runs

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -548,16 +548,16 @@
         },
         {
             "name": "cwm/build-tools",
-            "version": "v1.32.1",
+            "version": "v1.33.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Joomla-Bible-Study/cwm-build-tools.git",
-                "reference": "708538fc9846c9504feed9e11e7dfe987bd0e73b"
+                "reference": "1f43053d69d617cda113d7d9c929f64a698f00ec"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Joomla-Bible-Study/cwm-build-tools/zipball/708538fc9846c9504feed9e11e7dfe987bd0e73b",
-                "reference": "708538fc9846c9504feed9e11e7dfe987bd0e73b",
+                "url": "https://api.github.com/repos/Joomla-Bible-Study/cwm-build-tools/zipball/1f43053d69d617cda113d7d9c929f64a698f00ec",
+                "reference": "1f43053d69d617cda113d7d9c929f64a698f00ec",
                 "shasum": ""
             },
             "require": {
@@ -665,10 +665,10 @@
                 "release"
             ],
             "support": {
-                "source": "https://github.com/Joomla-Bible-Study/cwm-build-tools/tree/v1.32.1",
+                "source": "https://github.com/Joomla-Bible-Study/cwm-build-tools/tree/v1.33.0",
                 "issues": "https://github.com/Joomla-Bible-Study/cwm-build-tools/issues"
             },
-            "time": "2026-09-01T19:35:10+00:00"
+            "time": "2026-09-02T02:29:42+00:00"
         },
         {
             "name": "danog/advanced-json-rpc",


### PR DESCRIPTION
Lock refresh: `cwm/build-tools` v1.32.1 → **v1.33.0**, which carries the fixes for the two step-7 deaths ([cwm-build-tools#160](https://github.com/Joomla-Bible-Study/cwm-build-tools/issues/160) / [#161](https://github.com/Joomla-Bible-Study/cwm-build-tools/issues/161)):

- a failed ARS publish no longer skips the `versions.json` update — the run ends with the exact debt and the commands that settle it, and still exits non-zero
- the artifact-presence check retries once and, on real failure, prints where it looked and what it found

⚠️ These protect the **10.7.0 release run** only if the vendored copy executing it carries them — which is the whole reason to land this before cutting the release. Verified in the vendored tree: `cwm_require_artifact` present, the decoupled step-7/8 flow present, and the full lint + test gate green through the updated tooling (3559 tests / 11500 assertions).

The other five CWM repos owe the same one-line refresh; noted separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)