### PR TITLE
fix(admin): remove the half-copied workflow branch, and the batch button it was hiding

### DIFF
--- a/admin/src/View/Cwmmediafiles/HtmlView.php
+++ b/admin/src/View/Cwmmediafiles/HtmlView.php
@@ -16,13 +16,11 @@ use CWM\Component\Proclaim\Administrator\Helper\CwmmediaProtectionHelper;
 use CWM\Component\Proclaim\Administrator\Helper\CwmprotectedStorage;
 use CWM\Component\Proclaim\Administrator\Lib\Cwmassets;
 use CWM\Component\Proclaim\Administrator\Model\CwmmediafilesModel;
-use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Multilanguage;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
-use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\Session\Session;
 use Joomla\CMS\Toolbar\Button\DropdownButton;
 use Joomla\CMS\Toolbar\Toolbar;
@@ -108,14 +106,6 @@ class HtmlView extends BaseHtmlView
     protected ?object $state = null;
 
     /**
-     * All transitions, which can be executed of one if the items
-     *
-     * @var  array
-     * @since 4.0.0
-     */
-    protected array $transitions = [];
-
-    /**
      * Is this view an Empty State
      *
      * @var   bool
@@ -149,12 +139,6 @@ class HtmlView extends BaseHtmlView
         $this->activeFilters = $model->getActiveFilters();
 
         $this->warnIfProtectedStorageIsNotWorking();
-
-        if (ComponentHelper::getParams('com_proclaim')->get('workflow_enabled')) {
-            PluginHelper::importPlugin('workflow');
-
-            $this->transitions = $model->getTransitions();
-        }
 
         // Check for errors.
         if (\count($errors = $model->getErrors())) {

--- a/admin/src/View/Cwmmessages/HtmlView.php
+++ b/admin/src/View/Cwmmessages/HtmlView.php
@@ -19,7 +19,6 @@ namespace CWM\Component\Proclaim\Administrator\View\Cwmmessages;
 use CWM\Component\Proclaim\Administrator\Extension\ProclaimComponent;
 use CWM\Component\Proclaim\Administrator\Lib\Cwmassets;
 use CWM\Component\Proclaim\Administrator\Model\CwmmessagesModel;
-use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Form\Form;
 use Joomla\CMS\Language\Multilanguage;
@@ -27,7 +26,6 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Pagination\Pagination;
-use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Session\Session;
 use Joomla\CMS\Toolbar\Button\DropdownButton;
@@ -85,14 +83,6 @@ class HtmlView extends BaseHtmlView
     public ?object $canDo = null;
 
     /**
-     * All transition, which can be executed of one if the items
-     *
-     * @var  array
-     * @since 4.0.0
-     */
-    protected array $transitions = [];
-
-    /**
      * Is this view an Empty State
      *
      * @var   bool
@@ -125,14 +115,8 @@ class HtmlView extends BaseHtmlView
         $this->filterForm    = $model->getFilterForm();
         $this->activeFilters = $model->getActiveFilters();
 
-        if (ComponentHelper::getParams('com_proclaim')->get('workflow_enabled')) {
-            PluginHelper::importPlugin('workflow');
-
-            $this->transitions = $model->getTransitions();
-        }
-
         // Check for errors.
-        if ($this->transitions === false || \count($errors = $model->getErrors())) {
+        if (\count($errors = $model->getErrors())) {
             throw new GenericDataException(implode("\n", $errors), 500);
         }
 
@@ -183,7 +167,7 @@ class HtmlView extends BaseHtmlView
                 ->icon('icon-wand');
         }
 
-        if (!$this->isEmptyState && ($canDo->get('core.edit.state') || \count($this->transitions))) {
+        if (!$this->isEmptyState && $canDo->get('core.edit.state')) {
             /** @var  DropdownButton $dropdown */
             $dropdown = $toolbar->dropdownButton('status-group', 'JTOOLBAR_CHANGE_STATUS')
                 ->toggleSplit(false)
@@ -193,46 +177,23 @@ class HtmlView extends BaseHtmlView
 
             $childBar = $dropdown->getChildToolbar();
 
-            if (\count($this->transitions)) {
-                $childBar->separatorButton('transition-headline')
-                    ->text('COM_PROCLAIM_RUN_TRANSITIONS')
-                    ->buttonClass('text-center py-2 h3');
+            $childBar->publish('cwmmessages.publish')->listCheck(true);
 
-                $cmd      = "Joomla.submitbutton('cwmmessages.runTransition');";
-                $messages = "{error: [Joomla.Text._('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST')]}";
-                $alert    = 'Joomla.renderMessages(' . $messages . ')';
-                $cmd      = 'if (document.adminForm.boxchecked.value == 0) { ' . $alert . ' } else { ' . $cmd . ' }';
+            $childBar->unpublish('cwmmessages.unpublish')->listCheck(true);
 
-                foreach ($this->transitions as $transition) {
-                    $childBar->standardButton('transition')
-                        ->text($transition['text'])
-                        ->buttonClass('transition-' . (int)$transition['value'])
-                        ->icon('icon-project-diagram')
-                        ->onclick('document.adminForm.transition_id.value=' . (int)$transition['value'] . ';' . $cmd);
-                }
+            $childBar->archive('cwmmessages.archive')->listCheck(true);
 
-                $childBar->separatorButton('transition-separator');
-            }
+            $childBar->checkin('cwmmessages.checkin')->listCheck(true);
 
-            if ($canDo->get('core.edit.state')) {
-                $childBar->publish('cwmmessages.publish')->listCheck(true);
-
-                $childBar->unpublish('cwmmessages.unpublish')->listCheck(true);
-
-                $childBar->archive('cwmmessages.archive')->listCheck(true);
-
-                $childBar->checkin('cwmmessages.checkin')->listCheck(true);
-
-                if ((int) $this->state->get('filter.published') !== ProclaimComponent::CONDITION_TRASHED) {
-                    $childBar->trash('cwmmessages.trash')->listCheck(true);
-                }
+            if ((int) $this->state->get('filter.published') !== ProclaimComponent::CONDITION_TRASHED) {
+                $childBar->trash('cwmmessages.trash')->listCheck(true);
             }
 
             // Add a batch button
             if (
                 $user->authorise('core.create', 'com_proclaim.message')
                 && $user->authorise('core.edit', 'com_proclaim.message')
-                && $user->authorise('core.execute.transition', 'com_proclaim')
+                && $user->authorise('core.edit.state', 'com_proclaim.message')
             ) {
                 $childBar->popupButton('batch')
                     ->text('JTOOLBAR_BATCH')

--- a/admin/src/View/Cwmseries/HtmlView.php
+++ b/admin/src/View/Cwmseries/HtmlView.php
@@ -86,14 +86,6 @@ class HtmlView extends BaseHtmlView
     public ?object $canDo = null;
 
     /**
-     * All transitions, which can be executed if the items
-     *
-     * @var  array
-     * @since 4.0.0
-     */
-    protected array $transitions = [];
-
-    /**
      * Is this view an Empty State
      *
      * @var   bool

--- a/admin/tmpl/cwmmessages/default.php
+++ b/admin/tmpl/cwmmessages/default.php
@@ -45,18 +45,6 @@ $wa->useScript('table.columns')
 
 CwmlangHelper::registerAllForJs();
 
-$workflow_enabled  = ComponentHelper::getParams('com_proclaim')->get('workflow_enabled');
-$workflow_state    = false;
-$workflow_featured = false;
-
-if ($workflow_enabled) :
-    $wa->getRegistry()->addExtensionRegistryFile('com_workflow');
-    $wa->useScript('com_workflow.admin-items-workflow-buttons');
-
-    $workflow_state    = Factory::getApplication()->bootComponent('com_proclaim')->isFunctionalityUsed('core.state', 'com_proclaim.message');
-    $workflow_featured = Factory::getApplication()->bootComponent('com_proclaim')->isFunctionalityUsed('core.featured', 'com_proclaim.messages');
-endif;
-
 if (str_contains($listOrder, 'publish_up')) {
     $orderingColumn = 'publish_up';
 } elseif (str_contains($listOrder, 'publish_down')) {
@@ -282,7 +270,7 @@ echo Route::_('index.php?option=com_proclaim&view=cwmmessages'); ?>" method="pos
                                     <?php
                             $options = [
                                 'task_prefix' => 'cwmmessages.',
-                                'disabled'    => $workflow_state || !$canChange,
+                                'disabled'    => !$canChange,
                                 'id'          => 'state-' . $item->id,
                             ];
 

--- a/admin/tmpl/cwmservers/default.php
+++ b/admin/tmpl/cwmservers/default.php
@@ -38,41 +38,6 @@ $trashed   = $this->state->get('filter.published') == -2;
 $locationEnabled = CwmlocationHelper::isEnabled();
 $columns         = $locationEnabled ? 5 : 4;
 
-$workflow_enabled  = ComponentHelper::getParams('com_proclaim')->get('workflow_enabled');
-$workflow_state    = false;
-$workflow_featured = false;
-if ($workflow_enabled) :
-
-    // @todo move the script to a file
-    $js = <<<JS
-	(function() {
-		document.addEventListener('DOMContentLoaded', function() {
-		  var elements = [].slice.call(document.querySelectorAll('.message-status'));
-	
-		  elements.forEach(function (element) {
-			element.addEventListener('click', function(event) {
-				event.stopPropagation();
-			});
-		  });
-		});
-	})();
-	JS;
-
-    $wa->getRegistry()->addExtensionRegistryFile('com_workflow');
-    $wa->useScript('com_workflow.admin-items-workflow-buttons')
-        ->addInlineScript($js, [], ['type' => 'module']);
-
-
-    $workflow_state    = Factory::getApplication()->bootComponent('com_proclaim')->isFunctionalityUsed(
-        'core.state',
-        'com_proclaim.server'
-    );
-    $workflow_featured = Factory::getApplication()->bootComponent('com_prcolaim')->isFunctionalityUsed(
-        'core.featured',
-        'com_proclaim.server'
-    );
-endif;
-
 $sortFields = $this->getSortFields();
 ?>
 <form action="<?php
@@ -171,7 +136,7 @@ echo Route::_('index.php?option=com_proclaim&view=cwmservers'); ?>" method="post
                                         // status button dispatched task=server.publish and the
                                         // dispatcher answered "Invalid controller class: server".
                                         'task_prefix' => 'cwmservers.',
-                                        'disabled'    => $workflow_state || !$canChange,
+                                        'disabled'    => !$canChange,
                                         'id'          => 'state-' . $item->id,
                                     ];
 


### PR DESCRIPTION
Closes #2043.

## The dead branch, and the proof it never ran

Two list views and two templates carried fragments copied from com_content's workflow support, gated on `workflow_enabled` — a parameter declared in **no form**, settable from nowhere. Inside the gate:

- `getTransitions()` — a method **no Proclaim model has** (fatal on first execution)
- `runTransition` — a task no controller defines
- `bootComponent('com_prcolaim')` — a **typo** in the servers template that would throw immediately

That last one is the proof: the branch has not run once since it was written. Dead behind an unreachable flag — but one hand-edited row in `#__extensions` away from fataling both screens.

## ⚠️ One piece was live, and user-facing

The Messages **batch button** required `core.execute.transition` — a Joomla workflow permission that appears **nowhere in `access.xml`** and so can never be granted to anyone. The batch button on the Messages list has therefore been **Super-User-only, silently**, while Comments and Locations gate theirs on create + edit + edit.state. It now gates the same way they do — a small live fix hiding inside a dead-code removal.

## Also removed

Unused `$transitions` properties (including one that had drifted into **Cwmseries**), the `=== false` check a typed array property made unsatisfiable, the workflow asset loading and `isFunctionalityUsed()` calls in both templates, the `$workflow_state ||` dead half of two `disabled` expressions, and the orphaned imports.

## Left alone on purpose

`ProclaimComponent` still implements `WorkflowServiceInterface` (+ `filterTransitions()`). That is the component-registration surface with a wider blast radius than the fatal branch, and whether Proclaim should advertise workflow support to com_workflow at all is its own decision — happy to file it if wanted.

## Verified

- **Live render** on a symlinked dev site: Messages and Servers lists both 200, `#adminForm` visible, no fatal, no undefined-variable warning (throwaway Playwright spec, not committed)
- Admin **smoke** (5 tests, includes opening a sermon from the list) and **media-list a11y** specs pass
- Full gate: 3559 tests / 11500 assertions, all four lint steps clean

Net: **11 insertions, 121 deletions.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)