### PR TITLE
refactor(query): build OR groups with the builder instead of typing brackets

### DIFF
--- a/admin/src/Helper/CwmmigrationHelper.php
+++ b/admin/src/Helper/CwmmigrationHelper.php
@@ -1090,7 +1090,7 @@ class CwmmigrationHelper
                 ->update($db->quoteName('#__bsms_studies'))
                 ->set($db->quoteName('location_id') . ' = ' . (int) $locationId)
                 ->where($db->quoteName('access') . ' = ' . (int) $accessId)
-                ->where('(' . $db->quoteName('location_id') . ' = 0 OR ' . $db->quoteName('location_id') . ' IS NULL)');
+                ->andWhere([$db->quoteName('location_id') . ' = 0', $db->quoteName('location_id') . ' IS NULL']);
             $db->setQuery($query);
             $db->execute();
             $updated += $db->getAffectedRows();
@@ -1269,7 +1269,8 @@ class CwmmigrationHelper
         $query = $db->createQuery()
             ->update($db->quoteName('#__bsms_studies'))
             ->set($db->quoteName('location_id') . ' = ' . $locationId)
-            ->where('(' . $db->quoteName('location_id') . ' = 0 OR ' . $db->quoteName('location_id') . ' IS NULL)');
+            ->where($db->quoteName('location_id') . ' = 0')
+            ->orWhere($db->quoteName('location_id') . ' IS NULL');
         $db->setQuery($query);
         $db->execute();
 
@@ -1334,7 +1335,7 @@ class CwmmigrationHelper
             ->select([$db->quoteName('id'), $db->quoteName('name')])
             ->from($db->quoteName('#__bsms_teachers'))
             ->where($db->quoteName('published') . ' = 1')
-            ->where('(' . $db->quoteName('user_id') . ' = 0 OR ' . $db->quoteName('user_id') . ' IS NULL)');
+            ->andWhere([$db->quoteName('user_id') . ' = 0', $db->quoteName('user_id') . ' IS NULL']);
         $db->setQuery($query);
 
         return $db->loadObjectList() ?: [];

--- a/admin/src/Model/CwmcommentsModel.php
+++ b/admin/src/Model/CwmcommentsModel.php
@@ -202,7 +202,7 @@ class CwmcommentsModel extends ListModel
         if (is_numeric($published)) {
             $query->where($db->quoteName('comment.published') . ' = ' . (int) $published);
         } elseif ($published === '') {
-            $query->where('(' . $db->quoteName('comment.published') . ' = 0 OR ' . $db->quoteName('comment.published') . ' = 1)');
+            $query->whereIn($db->quoteName('comment.published'), [0, 1]);
         }
 
         // Filter by search in title.

--- a/admin/src/Model/CwminstallModel.php
+++ b/admin/src/Model/CwminstallModel.php
@@ -1028,7 +1028,14 @@ class CwminstallModel extends ListModel
                 $conditions = CwmmigrationHelper::rmoldurl();
                 $query      = $this->getDatabase()->createQuery();
                 $query->delete($this->getDatabase()->quoteName('#__update_sites'));
-                $query->where('(' . implode(' OR ', $conditions) . ')');
+                // The first arm seeds the WHERE that orWhere() extends —
+                // extendWhere() rewrites an existing clause and fatals on none.
+                // rmoldurl() returns a fixed non-empty list.
+                $query->where(array_shift($conditions));
+
+                if ($conditions !== []) {
+                    $query->orWhere($conditions, 'OR');
+                }
                 $this->getDatabase()->setQuery($query);
                 $this->getDatabase()->execute();
                 $this->running = 'Remove Old Update URL\'s';

--- a/admin/src/Model/CwmlocationsModel.php
+++ b/admin/src/Model/CwmlocationsModel.php
@@ -325,7 +325,7 @@ class CwmlocationsModel extends ListModel
         if (is_numeric($published)) {
             $query->where($db->quoteName('location.published') . ' = ' . (int) $published);
         } elseif ($published === '') {
-            $query->where('(' . $db->quoteName('location.published') . ' = 0 OR ' . $db->quoteName('location.published') . ' = 1)');
+            $query->whereIn($db->quoteName('location.published'), [0, 1]);
         }
 
         // Add the list ordering clause

--- a/admin/src/Model/CwmmessagesModel.php
+++ b/admin/src/Model/CwmmessagesModel.php
@@ -340,7 +340,7 @@ class CwmmessagesModel extends ListModel
         } elseif (is_numeric($published)) {
             $query->where($db->quoteName('study.published') . ' = ' . (int) $published);
         } elseif ($published === '') {
-            $query->where('(' . $db->quoteName('study.published') . ' = 0 OR ' . $db->quoteName('study.published') . ' = 1 OR ' . $db->quoteName('study.published') . ' = 2)');
+            $query->whereIn($db->quoteName('study.published'), [0, 1, 2]);
         }
 
         // Filter by search in title.

--- a/admin/src/Model/CwmmessagetypesModel.php
+++ b/admin/src/Model/CwmmessagetypesModel.php
@@ -246,7 +246,7 @@ class CwmmessagetypesModel extends ListModel
         if (is_numeric($published)) {
             $query->where($db->quoteName('messagetype.published') . ' = ' . (int) $published);
         } elseif ($published === '') {
-            $query->where('(' . $db->quoteName('messagetype.published') . ' = 0 OR ' . $db->quoteName('messagetype.published') . ' = 1)');
+            $query->whereIn($db->quoteName('messagetype.published'), [0, 1]);
         }
 
         // Add the list ordering clause.

--- a/admin/src/Model/CwmplaylistsModel.php
+++ b/admin/src/Model/CwmplaylistsModel.php
@@ -229,7 +229,7 @@ class CwmplaylistsModel extends ListModel
         if (is_numeric($published)) {
             $query->where($db->quoteName('playlist.published') . ' = ' . (int) $published);
         } elseif ($published === '') {
-            $query->where('(' . $db->quoteName('playlist.published') . ' = 0 OR ' . $db->quoteName('playlist.published') . ' = 1)');
+            $query->whereIn($db->quoteName('playlist.published'), [0, 1]);
         }
 
         // Add the list ordering clause.

--- a/admin/src/Model/CwmpodcastsModel.php
+++ b/admin/src/Model/CwmpodcastsModel.php
@@ -237,7 +237,7 @@ class CwmpodcastsModel extends ListModel
         } elseif (is_numeric($published)) {
             $query->where($db->quoteName('podcast.published') . ' = ' . (int) $published);
         } elseif ($published === '') {
-            $query->where('(' . $db->quoteName('podcast.published') . ' = 0 OR ' . $db->quoteName('podcast.published') . ' = 1)');
+            $query->whereIn($db->quoteName('podcast.published'), [0, 1]);
         }
 
         // Filter on the language.
@@ -252,6 +252,9 @@ class CwmpodcastsModel extends ListModel
             if (stripos($search, 'id:') === 0) {
                 $query->where($db->quoteName('podcast.id') . ' = ' . (int) substr($search, 3));
             } else {
+                // Bracketed by hand on purpose: with the All status filter no
+                // earlier branch is guaranteed to have added a WHERE, and
+                // andWhere()/orWhere() extend one that must already exist.
                 $search = $db->quote('%' . $db->escape($search, true) . '%');
                 $query->where('(' . $db->quoteName('podcast.title') . ' LIKE ' . $search . ' OR ' . $db->quoteName('podcast.description') . ' LIKE ' . $search . ')');
             }

--- a/admin/src/Model/CwmteachersModel.php
+++ b/admin/src/Model/CwmteachersModel.php
@@ -188,7 +188,7 @@ class CwmteachersModel extends ListModel
         } elseif (is_numeric($published)) {
             $query->where($db->quoteName('teacher.published') . ' = ' . (int) $published);
         } elseif ($published === '') {
-            $query->where('(' . $db->quoteName('teacher.published') . ' = 0 OR ' . $db->quoteName('teacher.published') . ' = 1)');
+            $query->whereIn($db->quoteName('teacher.published'), [0, 1]);
         }
 
         // Filter by search in title.
@@ -198,6 +198,9 @@ class CwmteachersModel extends ListModel
             if (stripos($search, 'id:') === 0) {
                 $query->where($db->quoteName('teacher.id') . ' = ' . (int) substr($search, 3));
             } else {
+                // Bracketed by hand on purpose: with the All status filter no
+                // earlier branch is guaranteed to have added a WHERE, and
+                // andWhere()/orWhere() extend one that must already exist.
                 $search = $db->quote('%' . $db->escape($search, true) . '%');
                 $query->where('(' . $db->quoteName('teacher.teachername') . ' LIKE ' . $search . ' OR ' . $db->quoteName('teacher.alias') . ' LIKE ' . $search . ')');
             }

--- a/admin/src/Model/CwmtemplatecodesModel.php
+++ b/admin/src/Model/CwmtemplatecodesModel.php
@@ -187,7 +187,7 @@ class CwmtemplatecodesModel extends ListModel
         if (is_numeric($published)) {
             $query->where($db->quoteName('templatecode.published') . ' = ' . (int)$published);
         } elseif ($published === '') {
-            $query->where('(' . $db->quoteName('templatecode.published') . ' = 0 OR ' . $db->quoteName('templatecode.published') . ' = 1)');
+            $query->whereIn($db->quoteName('templatecode.published'), [0, 1]);
         }
 
         // Add the list ordering clause

--- a/admin/src/Model/CwmtemplatesModel.php
+++ b/admin/src/Model/CwmtemplatesModel.php
@@ -175,7 +175,7 @@ class CwmtemplatesModel extends ListModel
         if (is_numeric($published)) {
             $query->where($db->quoteName('template.published') . ' = ' . (int) $published);
         } elseif ($published === '') {
-            $query->where('(' . $db->quoteName('template.published') . ' = 0 OR ' . $db->quoteName('template.published') . ' = 1)');
+            $query->whereIn($db->quoteName('template.published'), [0, 1]);
         }
 
         // Filter by search in filename or study title

--- a/admin/src/Model/CwmtopicsModel.php
+++ b/admin/src/Model/CwmtopicsModel.php
@@ -165,7 +165,7 @@ class CwmtopicsModel extends ListModel
         if (is_numeric($published)) {
             $query->where($db->quoteName('topic.published') . ' = ' . (int) $published);
         } elseif ($published === '') {
-            $query->where('(' . $db->quoteName('topic.published') . ' = 0 OR ' . $db->quoteName('topic.published') . ' = 1)');
+            $query->whereIn($db->quoteName('topic.published'), [0, 1]);
         }
 
         // Filter on the language. Set only by the API (?filter[language]=);

--- a/site/src/Helper/Cwmlanding.php
+++ b/site/src/Helper/Cwmlanding.php
@@ -504,8 +504,8 @@ class Cwmlanding
                 if (!$this->user->authorise('core.edit.state', 'com_proclaim') && !$this->user->authorise('core.edit', 'com_proclaim')) {
                     $nullDate = $this->db->quote($this->db->getNullDate());
                     $nowDate  = $this->db->quote((new Date())->toSql());
-                    $query->where('(' . $this->db->quoteName('a.publish_up') . ' = ' . $nullDate . ' OR ' . $this->db->quoteName('a.publish_up') . ' <= ' . $nowDate . ')')
-                        ->where('(' . $this->db->quoteName('a.publish_down') . ' = ' . $nullDate . ' OR ' . $this->db->quoteName('a.publish_down') . ' >= ' . $nowDate . ')');
+                    $query->andWhere([$this->db->quoteName('a.publish_up') . ' = ' . $nullDate, $this->db->quoteName('a.publish_up') . ' <= ' . $nowDate])
+                        ->andWhere([$this->db->quoteName('a.publish_down') . ' = ' . $nullDate, $this->db->quoteName('a.publish_down') . ' >= ' . $nowDate]);
                 }
 
                 $this->addAccessFilter($query);
@@ -849,8 +849,8 @@ class Cwmlanding
             if (!$this->user->authorise('core.edit.state', 'com_proclaim') && !$this->user->authorise('core.edit', 'com_proclaim')) {
                 $nullDate = $this->db->quote($this->db->getNullDate());
                 $nowDate  = $this->db->quote((new Date())->toSql());
-                $query->where('(' . $this->db->quoteName('a.publish_up') . ' = ' . $nullDate . ' OR ' . $this->db->quoteName('a.publish_up') . ' <= ' . $nowDate . ')')
-                    ->where('(' . $this->db->quoteName('a.publish_down') . ' = ' . $nullDate . ' OR ' . $this->db->quoteName('a.publish_down') . ' >= ' . $nowDate . ')');
+                $query->andWhere([$this->db->quoteName('a.publish_up') . ' = ' . $nullDate, $this->db->quoteName('a.publish_up') . ' <= ' . $nowDate])
+                    ->andWhere([$this->db->quoteName('a.publish_down') . ' = ' . $nullDate, $this->db->quoteName('a.publish_down') . ' >= ' . $nowDate]);
             }
 
             $this->addAccessFilter($query);
@@ -1407,8 +1407,8 @@ class Cwmlanding
         if (!$this->user->authorise('core.edit.state', 'com_proclaim') && !$this->user->authorise('core.edit', 'com_proclaim')) {
             $nullDate = $this->db->quote($this->db->getNullDate());
             $nowDate  = $this->db->quote((new Date())->toSql());
-            $query->where('(' . $this->db->quoteName('a.publish_up') . ' = ' . $nullDate . ' OR ' . $this->db->quoteName('a.publish_up') . ' <= ' . $nowDate . ')')
-                ->where('(' . $this->db->quoteName('a.publish_down') . ' = ' . $nullDate . ' OR ' . $this->db->quoteName('a.publish_down') . ' >= ' . $nowDate . ')');
+            $query->andWhere([$this->db->quoteName('a.publish_up') . ' = ' . $nullDate, $this->db->quoteName('a.publish_up') . ' <= ' . $nowDate])
+                ->andWhere([$this->db->quoteName('a.publish_down') . ' = ' . $nullDate, $this->db->quoteName('a.publish_down') . ' >= ' . $nowDate]);
         }
 
         $this->addAccessFilter($query);

--- a/site/src/Helper/Cwmpagebuilder.php
+++ b/site/src/Helper/Cwmpagebuilder.php
@@ -520,8 +520,8 @@ class Cwmpagebuilder
                 'com_proclaim'
             ))
         ) {
-            $query->where('(' . $db->quoteName('study.publish_up') . ' = ' . $nullDate . ' OR ' . $db->quoteName('study.publish_up') . ' <= ' . $nowDate . ')')
-                ->where('(' . $db->quoteName('study.publish_down') . ' = ' . $nullDate . ' OR ' . $db->quoteName('study.publish_down') . ' >= ' . $nowDate . ')');
+            $query->andWhere([$db->quoteName('study.publish_up') . ' = ' . $nullDate, $db->quoteName('study.publish_up') . ' <= ' . $nowDate])
+                ->andWhere([$db->quoteName('study.publish_down') . ' = ' . $nullDate, $db->quoteName('study.publish_down') . ' >= ' . $nowDate]);
 
             // Cascading series date window (like Joomla categories)
             $query->where(
@@ -532,7 +532,11 @@ class Cwmpagebuilder
                 . ' OR ' . $db->quoteName('study.series_id') . ' IS NULL)'
             );
         } else {
-            $query->where('(' . $db->quoteName('series.published') . ' = 1 OR ' . $db->quoteName('study.series_id') . ' <= 0 OR ' . $db->quoteName('study.series_id') . ' IS NULL)');
+            $query->andWhere([
+                $db->quoteName('series.published') . ' = 1',
+                $db->quoteName('study.series_id') . ' <= 0',
+                $db->quoteName('study.series_id') . ' IS NULL',
+            ]);
         }
 
         // Filter by language
@@ -549,7 +553,11 @@ class Cwmpagebuilder
         $query->order($db->quoteName('studydate') . ' ' . $order);
 
         // Filter only for authorized view
-        $query->where('(' . $db->quoteName('series.access') . ' IN (' . $groups . ') OR ' . $db->quoteName('study.series_id') . ' <= 0 OR ' . $db->quoteName('study.series_id') . ' IS NULL)');
+        $query->andWhere([
+            $db->quoteName('series.access') . ' IN (' . $groups . ')',
+            $db->quoteName('study.series_id') . ' <= 0',
+            $db->quoteName('study.series_id') . ' IS NULL',
+        ]);
         $query->where($db->quoteName('study.access') . ' IN (' . $groups . ')');
 
         $db->setQuery($query, 0, $limit);

--- a/site/src/Helper/Cwmpodcastsubscribe.php
+++ b/site/src/Helper/Cwmpodcastsubscribe.php
@@ -105,8 +105,10 @@ class Cwmpodcastsubscribe
         $query->select('*')
             ->from($db->quoteName('#__bsms_podcast', 'p'))
             ->where($db->quoteName('p.published') . ' = 1')
-            ->where('(' . $db->quoteName('p.podcast_subscribe_show') . ' IS NULL OR '
-                . $db->quoteName('p.podcast_subscribe_show') . ' != 1)')
+            ->andWhere([
+                $db->quoteName('p.podcast_subscribe_show') . ' IS NULL',
+                $db->quoteName('p.podcast_subscribe_show') . ' != 1',
+            ])
             ->whereIn($db->quoteName('p.access'), $user->getAuthorisedViewLevels());
 
         $db->setQuery($query);

--- a/site/src/Helper/Cwmrelatedstudies.php
+++ b/site/src/Helper/Cwmrelatedstudies.php
@@ -389,7 +389,7 @@ class Cwmrelatedstudies
             )
             ->where($db->quoteName('s.id') . ' IN (' . $idList . ')')
             ->where($db->quoteName('s.id') . ' != ' . $studyId)
-            ->where('(' . $db->quoteName('ser.published') . ' = 1 OR ' . $db->quoteName('s.series_id') . ' <= 0)');
+            ->andWhere([$db->quoteName('ser.published') . ' = 1', $db->quoteName('s.series_id') . ' <= 0']);
 
         // Cascading series date window for non-admin users
         $user = Factory::getApplication()->getIdentity();

--- a/site/src/Helper/Cwmserieslist.php
+++ b/site/src/Helper/Cwmserieslist.php
@@ -253,8 +253,8 @@ class Cwmserieslist extends Cwmlisting
         if (!$user->authorise('core.edit.state', 'com_proclaim') && !$user->authorise('core.edit', 'com_proclaim')) {
             $nullDate = $db->quote($db->getNullDate());
             $nowDate  = $db->quote((new Date())->toSql());
-            $query->where('(' . $db->quoteName('se.publish_up') . ' = ' . $nullDate . ' OR ' . $db->quoteName('se.publish_up') . ' <= ' . $nowDate . ')')
-                ->where('(' . $db->quoteName('se.publish_down') . ' = ' . $nullDate . ' OR ' . $db->quoteName('se.publish_down') . ' >= ' . $nowDate . ')');
+            $query->andWhere([$db->quoteName('se.publish_up') . ' = ' . $nullDate, $db->quoteName('se.publish_up') . ' <= ' . $nowDate])
+                ->andWhere([$db->quoteName('se.publish_down') . ' = ' . $nullDate, $db->quoteName('se.publish_down') . ' >= ' . $nowDate]);
         }
 
         $db->setQuery($query, 0, $limit);

--- a/site/src/Helper/Cwmshowscripture.php
+++ b/site/src/Helper/Cwmshowscripture.php
@@ -426,7 +426,13 @@ class Cwmshowscripture
                     $clauses[] = $db->quoteName('source') . ' IN (' . implode(',', $quoted) . ')';
                 }
 
-                $query->where('(' . implode(' OR ', $clauses) . ')');
+                // installed = 1 is always present and seeds the WHERE the
+                // optional source arm extends with OR.
+                $query->where(array_shift($clauses));
+
+                if ($clauses !== []) {
+                    $query->orWhere($clauses, 'OR');
+                }
 
                 $db->setQuery($query);
                 $translationsCacheByKey[$cacheKey] = $db->loadObjectList() ?: [];

--- a/site/src/Model/CwmseriesdisplaysModel.php
+++ b/site/src/Model/CwmseriesdisplaysModel.php
@@ -318,8 +318,8 @@ class CwmseriesdisplaysModel extends ListModel
         if (!$user->authorise('core.edit.state', 'com_proclaim') && !$user->authorise('core.edit', 'com_proclaim')) {
             $nullDate = $db->quote($db->getNullDate());
             $nowDate  = $db->quote((new Date())->toSql());
-            $query->where('(' . $db->quoteName('se.publish_up') . ' = ' . $nullDate . ' OR ' . $db->quoteName('se.publish_up') . ' <= ' . $nowDate . ')')
-                ->where('(' . $db->quoteName('se.publish_down') . ' = ' . $nullDate . ' OR ' . $db->quoteName('se.publish_down') . ' >= ' . $nowDate . ')');
+            $query->andWhere([$db->quoteName('se.publish_up') . ' = ' . $nullDate, $db->quoteName('se.publish_up') . ' <= ' . $nowDate])
+                ->andWhere([$db->quoteName('se.publish_down') . ' = ' . $nullDate, $db->quoteName('se.publish_down') . ' >= ' . $nowDate]);
         }
 
         //Filter by year

--- a/site/src/Model/CwmsermonModel.php
+++ b/site/src/Model/CwmsermonModel.php
@@ -178,8 +178,12 @@ class CwmsermonModel extends FormModel
                     $nullDate = $db->quote($db->getNullDate());
                     $nowDate  = $db->quote((new Date())->toSql());
 
-                    $query->where('(' . $db->quoteName('s.publish_up') . ' = ' . $nullDate . ' OR ' . $db->quoteName('s.publish_up') . ' <= ' . $nowDate . ')')
-                        ->where('(' . $db->quoteName('s.publish_down') . ' = ' . $nullDate . ' OR ' . $db->quoteName('s.publish_down') . ' >= ' . $nowDate . ')');
+                    // First condition on this query: the up-window seeds the
+                    // WHERE via where()->orWhere(), and the down-window then
+                    // extends it as an AND-ed OR group.
+                    $query->where($db->quoteName('s.publish_up') . ' = ' . $nullDate)
+                        ->orWhere($db->quoteName('s.publish_up') . ' <= ' . $nowDate)
+                        ->andWhere([$db->quoteName('s.publish_down') . ' = ' . $nullDate, $db->quoteName('s.publish_down') . ' >= ' . $nowDate]);
 
                     // Cascading series date window: hide message if its series is outside publish window.
                     $query->where(
@@ -203,7 +207,7 @@ class CwmsermonModel extends FormModel
                 $archived  = $this->getState('filter.archived');
 
                 if (is_numeric($published)) {
-                    $query->where('(' . $db->quoteName('s.published') . ' = ' . (int) $published . ' OR ' . $db->quoteName('s.published') . ' = ' . (int) $archived . ')');
+                    $query->whereIn($db->quoteName('s.published'), [(int) $published, (int) $archived]);
                 }
 
                 $query->group($db->quoteName('s.id'));

--- a/site/src/Model/CwmsermonsModel.php
+++ b/site/src/Model/CwmsermonsModel.php
@@ -615,13 +615,17 @@ class CwmsermonsModel extends ListModel
             );
         } else {
             // Admin: only check series published state
-            $query->where('(' . $db->quoteName('series.published') . ' = 1 OR ' . $db->quoteName('study.series_id') . ' <= 0 OR ' . $db->quoteName('study.series_id') . ' IS NULL)');
+            $query->andWhere([
+                $db->quoteName('series.published') . ' = 1',
+                $db->quoteName('study.series_id') . ' <= 0',
+                $db->quoteName('study.series_id') . ' IS NULL',
+            ]);
         }
 
         // Filter by start and end dates for messages.
         if (!$canEditState && !$canEdit) {
-            $query->where('(' . $db->quoteName('study.publish_up') . ' = ' . $nullDate . ' OR ' . $db->quoteName('study.publish_up') . ' <= ' . $nowDate . ')')
-                ->where('(' . $db->quoteName('study.publish_down') . ' = ' . $nullDate . ' OR ' . $db->quoteName('study.publish_down') . ' >= ' . $nowDate . ')');
+            $query->andWhere([$db->quoteName('study.publish_up') . ' = ' . $nullDate, $db->quoteName('study.publish_up') . ' <= ' . $nowDate])
+                ->andWhere([$db->quoteName('study.publish_down') . ' = ' . $nullDate, $db->quoteName('study.publish_down') . ' >= ' . $nowDate]);
         }
 
         // Begin the filters for menu items

--- a/tests/unit/Query/OrGroupShapeTest.php
+++ b/tests/unit/Query/OrGroupShapeTest.php
@@ -1,0 +1,89 @@
+<?php
+
+/**
+ * Pins the builder shapes the hand-bracketed OR conversions rely on.
+ *
+ * @package    Proclaim.UnitTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Proclaim\Tests\Unit\Query;
+
+use CWM\Component\Proclaim\Tests\ProclaimTestCase;
+use Joomla\CMS\Factory;
+use Joomla\Database\DatabaseInterface;
+use PHPUnit\Framework\Attributes\TestDox;
+
+/**
+ * Thirty-eight call sites were converted from brackets typed into strings to
+ * andWhere()/orWhere() on the strength of three renderings. This asserts each
+ * against the real driver, so the conversion's premise is pinned rather than
+ * remembered — and a Joomla behaviour change fails here, by name, instead of
+ * as a subtly re-glued WHERE on some list page.
+ *
+ * ⚠️ The dangerous property is the glue, not the brackets: where() glues with
+ * AND and honours no glue argument after the first call, which is how a
+ * top-level OR once escaped published/access/language (the reason
+ * WhereClauseContractTest exists).
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class OrGroupShapeTest extends ProclaimTestCase
+{
+    /**
+     * @param   callable  $build  Receives a fresh query, returns it built.
+     *
+     * @return  string  The rendered WHERE clause, whitespace-normalised.
+     */
+    private function whereOf(callable $build): string
+    {
+        $db    = Factory::getContainer()->get(DatabaseInterface::class);
+        $query = $build($db->createQuery()->select('1')->from('dual'));
+
+        $sql = preg_replace('/\s+/', ' ', (string) $query);
+
+        return trim(substr($sql, strpos($sql, 'WHERE')));
+    }
+
+    #[TestDox('andWhere([a, b]) appends (a OR b) with AND, brackets included')]
+    public function testAndWhereAppendsAnOrGroup(): void
+    {
+        // The workhorse: every publish-window pair and series escape uses it.
+        $this->assertSame(
+            'WHERE (x = 1 AND y = 2) AND (a = 3 OR b = 4)',
+            $this->whereOf(static fn ($q) => $q
+                ->where('x = 1')
+                ->where('y = 2')
+                ->andWhere(['a = 3', 'b = 4']))
+        );
+    }
+
+    #[TestDox('where(a)->orWhere(b) renders (a) OR (b) when the group is the whole clause')]
+    public function testWhereOrWhereSeedsTheClause(): void
+    {
+        $this->assertSame(
+            'WHERE (a = 1) OR (b = 2)',
+            $this->whereOf(static fn ($q) => $q->where('a = 1')->orWhere('b = 2'))
+        );
+    }
+
+    #[TestDox("orWhere(rest, 'OR') keeps a flat OR list flat")]
+    public function testOrWhereListNeedsTheExplicitInnerGlue(): void
+    {
+        // ⚠️ orWhere's inner glue defaults to AND — orWhere([b, c]) renders
+        // (a) OR (b AND c), which silently narrows a flat OR list. The two
+        // dynamic-array conversions pass 'OR' explicitly; this is why.
+        $this->assertSame(
+            'WHERE (a = 1) OR (b = 2 OR c = 3)',
+            $this->whereOf(static fn ($q) => $q->where('a = 1')->orWhere(['b = 2', 'c = 3'], 'OR'))
+        );
+
+        $this->assertSame(
+            'WHERE (a = 1) OR (b = 2 AND c = 3)',
+            $this->whereOf(static fn ($q) => $q->where('a = 1')->orWhere(['b = 2', 'c = 3'])),
+            "orWhere's default inner glue is AND — if this ever changes, every call passing 'OR' explicitly should be revisited."
+        );
+    }
+}


### PR DESCRIPTION
Closes #1988.

## What moved, and why three shapes instead of one

38 call sites assembled an OR group by concatenating brackets into a string. The bracket is load-bearing and hand-placed — `where()` glues with AND and adds none, so a forgotten bracket lets a top-level OR escape `published`/`access`/`language` (the #1735 bug). Nothing here was broken; the hand-step goes away.

| conversion | sites | when |
|---|---|---|
| `whereIn()` | 11 | same-column equality lists — the nine `published = 0 OR = 1` filters, messages' 0/1/2, the sermon published-or-archived pair. The shape the codebase already trusts 116×. |
| `andWhere([...])` | 23 | OR group appended to a WHERE that **provably exists on every path** — publish-window pairs, series escapes, migration filters. Inner glue defaults to OR, which is exactly the appended-group shape. |
| `where()` + `orWhere()` | 4 | the group **is** the whole clause, so one arm seeds the WHERE `extendWhere()` needs — including both dynamic `implode()` arrays, passing `'OR'` explicitly. |

## ⚠️ The two traps the issue warned about, honoured

- **`extendWhere()` fatals on a query with no WHERE.** Every `andWhere` site was individually checked for an *unconditional* prior `where()` — including reading the `switch` defaults and if/else branches above each one. Three sites failed that check and **stay hand-bracketed, each now saying why in place**: the image-migration group (its callers build no prior WHERE — the documented fatal), and the two admin search LIKE groups (the *All* status filter means no earlier branch guarantees a clause).
- **`orWhere()`'s inner glue defaults to AND** — `orWhere([b, c])` renders `(a) OR (b AND c)`, silently narrowing a flat list. The dynamic-array conversions pass `'OR'` explicitly, and the new **`OrGroupShapeTest`** pins all three renderings against the real driver — including a named assertion on the AND-default itself, so if Joomla ever changes it, every explicit `'OR'` gets revisited on a failing test rather than in production.

## Verified

- Suite: **3590 tests / 11547 assertions**, four lint steps clean.
- The pages these queries drive, live: **14 site e2e** (landing, sermon listing → detail, series, series display, podcast pages) and **44 admin e2e** — all green. The navigation test clicks a listing row through to its detail, so converted queries demonstrably return rows, not a silently-empty set.
- Leftover census: exactly 3 bracketed sites remain, all documented in place; multi-line assembled groups are out of scope and already tracked by #1986's detector-blindness note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)