### PR TITLE
refactor(query): phase 1 of the bind conversion — the four heaviest files

### DIFF
--- a/admin/src/Helper/CwmanalyticsHelper.php
+++ b/admin/src/Helper/CwmanalyticsHelper.php
@@ -211,21 +211,47 @@ class CwmanalyticsHelper
                     $studyId > 0 ? (int) $studyId : 'NULL',
                     $mediaId > 0 ? (int) $mediaId : 'NULL',
                     $locationId > 0 ? (int) $locationId : 'NULL',
-                    $db->quote($type),
-                    $refInfo['type'] !== '' ? $db->quote($refInfo['type']) : 'NULL',
-                    $referrerUrl !== null ? $db->quote($referrerUrl) : 'NULL',
-                    $referrerDomain !== null ? $db->quote($referrerDomain) : 'NULL',
-                    $utmSource !== '' ? $db->quote(substr($utmSource, 0, 255)) : 'NULL',
-                    $utmMedium !== '' ? $db->quote(substr($utmMedium, 0, 255)) : 'NULL',
-                    $utmCampaign !== '' ? $db->quote(substr($utmCampaign, 0, 255)) : 'NULL',
-                    $db->quote($uaInfo['device']),
-                    $db->quote($uaInfo['browser']),
-                    $db->quote($uaInfo['os']),
-                    $language !== '' ? $db->quote($language) : 'NULL',
+                    ':eventtype',
+                    ':reftype',
+                    ':refurl',
+                    ':refdomain',
+                    ':utmsource',
+                    ':utmmedium',
+                    ':utmcampaign',
+                    ':device',
+                    ':browser',
+                    ':os',
+                    ':lang',
                     $app->getIdentity()?->guest ? 1 : 0,
-                    $sessionHash !== null ? $db->quote($sessionHash) : 'NULL',
-                    $db->quote($now),
+                    ':sessionhash',
+                    ':created',
                 ]));
+
+            // Locals, not expressions: bind() takes its value by reference,
+            // and a null local binds as SQL NULL — which is what every "or
+            // NULL" ternary above was spelling by hand.
+            $refType   = $refInfo['type'] !== '' ? $refInfo['type'] : null;
+            $utmSrc    = $utmSource !== '' ? substr($utmSource, 0, 255) : null;
+            $utmMed    = $utmMedium !== '' ? substr($utmMedium, 0, 255) : null;
+            $utmCamp   = $utmCampaign !== '' ? substr($utmCampaign, 0, 255) : null;
+            $langOrNul = $language !== '' ? $language : null;
+            $device    = $uaInfo['device'];
+            $browser   = $uaInfo['browser'];
+            $os        = $uaInfo['os'];
+
+            $query->bind(':eventtype', $type)
+                ->bind(':reftype', $refType)
+                ->bind(':refurl', $referrerUrl)
+                ->bind(':refdomain', $referrerDomain)
+                ->bind(':utmsource', $utmSrc)
+                ->bind(':utmmedium', $utmMed)
+                ->bind(':utmcampaign', $utmCamp)
+                ->bind(':device', $device)
+                ->bind(':browser', $browser)
+                ->bind(':os', $os)
+                ->bind(':lang', $langOrNul)
+                ->bind(':sessionhash', $sessionHash)
+                ->bind(':created', $now);
 
             $db->setQuery($query);
             $db->execute();
@@ -623,6 +649,11 @@ class CwmanalyticsHelper
                 'event_type', 'referrer_type', 'country_code', 'device_type',
             ];
 
+            // The rollup block builds plain-string SQL (the ON DUPLICATE KEY
+            // INSERT…SELECT and per-group NULL-aware deletes fight the
+            // builder), so $cutoff stays quote()d here: binding lives on the
+            // query builder, and a marker in a plain string ships to MySQL as
+            // literal text. $cutoff is computed internally, never user input.
             $pending = $db->setQuery(
                 'SELECT DISTINCT ' . implode(',', array_map([$db, 'quoteName'], $groupCols))
                 . ', YEAR(' . $db->quoteName('created') . ') AS y'
@@ -707,7 +738,8 @@ class CwmanalyticsHelper
             if ($purge) {
                 $purgeQuery = $db->createQuery()
                     ->delete($db->quoteName('#__bsms_analytics_events'))
-                    ->where($db->quoteName('created') . ' < ' . $db->quote($cutoff));
+                    ->where($db->quoteName('created') . ' < :cutoff')
+                    ->bind(':cutoff', $cutoff);
                 $db->setQuery($purgeQuery);
                 $db->execute();
                 $result['purged'] = $db->getAffectedRows();

--- a/admin/src/Helper/CwmcsvimportHelper.php
+++ b/admin/src/Helper/CwmcsvimportHelper.php
@@ -193,22 +193,30 @@ class CwmcsvimportHelper
             'created_by', 'ordering',
         ];
 
+        // Locals, not expressions: bind() takes its value by reference.
+        $language  = (string) ($rowData['language'] ?? '*');
+        $intro     = (string) ($rowData['studyintro'] ?? '');
+        $text      = (string) ($rowData['studytext'] ?? '');
+        $number    = (string) ($rowData['studynumber'] ?? '');
+        $thumbnail = (string) ($rowData['thumbnailm'] ?? '');
+        $byAlias   = (string) ($rowData['created_by_alias'] ?? '');
+
         $values = [
-            $db->quote($title),
-            $db->quote($alias),
-            $db->quote($studyDate),
+            ':title',
+            ':alias',
+            ':studydate',
             $published,
             1,
-            $db->quote($rowData['language'] ?? '*'),
+            ':language',
             0,
-            $db->quote($rowData['studyintro'] ?? ''),
-            $db->quote($rowData['studytext'] ?? ''),
-            $db->quote($rowData['studynumber'] ?? ''),
+            ':intro',
+            ':studytext',
+            ':studynumber',
             (int) $seriesId ?: 'NULL',
             (int) $locationId ?: 'NULL',
             (int) $messageTypeId ?: 'NULL',
-            $db->quote($rowData['thumbnailm'] ?? ''),
-            $db->quote($rowData['created_by_alias'] ?? ''),
+            ':thumbnail',
+            ':byalias',
             (int) ($user ? $user->id : 0),
             0,
         ];
@@ -216,7 +224,16 @@ class CwmcsvimportHelper
         $query = $db->createQuery()
             ->insert($db->quoteName('#__bsms_studies'))
             ->columns($db->quoteName($columns))
-            ->values(implode(', ', $values));
+            ->values(implode(', ', $values))
+            ->bind(':title', $title)
+            ->bind(':alias', $alias)
+            ->bind(':studydate', $studyDate)
+            ->bind(':language', $language)
+            ->bind(':intro', $intro)
+            ->bind(':studytext', $text)
+            ->bind(':studynumber', $number)
+            ->bind(':thumbnail', $thumbnail)
+            ->bind(':byalias', $byAlias);
         $db->setQuery($query);
         $db->execute();
 
@@ -265,18 +282,22 @@ class CwmcsvimportHelper
         $db         = Factory::getContainer()->get(DatabaseInterface::class);
         $user       = Factory::getApplication()->getIdentity();
 
-        $fields = [];
+        $fields   = [];
+        $bindings = [];
 
         if (!empty($rowData['studyintro'])) {
-            $fields[] = $db->quoteName('studyintro') . ' = ' . $db->quote($rowData['studyintro']);
+            $fields[]              = $db->quoteName('studyintro') . ' = :intro';
+            $bindings[':intro']    = (string) $rowData['studyintro'];
         }
 
         if (!empty($rowData['studytext'])) {
-            $fields[] = $db->quoteName('studytext') . ' = ' . $db->quote($rowData['studytext']);
+            $fields[]               = $db->quoteName('studytext') . ' = :studytext';
+            $bindings[':studytext'] = (string) $rowData['studytext'];
         }
 
         if (!empty($rowData['studynumber'])) {
-            $fields[] = $db->quoteName('studynumber') . ' = ' . $db->quote($rowData['studynumber']);
+            $fields[]                 = $db->quoteName('studynumber') . ' = :studynumber';
+            $bindings[':studynumber'] = (string) $rowData['studynumber'];
         }
 
         if (!empty($rowData['series'])) {
@@ -313,6 +334,14 @@ class CwmcsvimportHelper
                 ->update($db->quoteName('#__bsms_studies'))
                 ->set($fields)
                 ->where($db->quoteName('id') . ' = ' . $studyId);
+
+            // Bound through the array element, never the loop variable — bind()
+            // keeps a reference, and a foreach value would leave every marker
+            // pointing at the last field written.
+            foreach (array_keys($bindings) as $marker) {
+                $query->bind($marker, $bindings[$marker]);
+            }
+
             $db->setQuery($query);
             $db->execute();
         }
@@ -374,7 +403,8 @@ class CwmcsvimportHelper
         $query = $db->createQuery()
             ->select($db->quoteName('id'))
             ->from($db->quoteName('#__bsms_teachers'))
-            ->where('LOWER(' . $db->quoteName('teachername') . ') = LOWER(' . $db->quote($name) . ')')
+            ->where('LOWER(' . $db->quoteName('teachername') . ') = LOWER(:name)')
+            ->bind(':name', $name)
             ->setLimit(1);
         $db->setQuery($query);
         $id = (int) $db->loadResult();
@@ -392,10 +422,18 @@ class CwmcsvimportHelper
         // Auto-create
         $alias = OutputFilter::stringURLSafe($name);
 
-        $insert = $db->createQuery()
+        // ⚠️ Every NOT-NULL column with no default is supplied, because under
+        // strict-mode MySQL omitting any one of them fails the whole insert —
+        // auto-create never worked on such hosts. Surfaced by the write-path
+        // test; present since before the binding conversion.
+        $language = '*';
+        $insert   = $db->createQuery()
             ->insert($db->quoteName('#__bsms_teachers'))
-            ->columns($db->quoteName(['teachername', 'alias', 'published']))
-            ->values($db->quote($name) . ', ' . $db->quote($alias) . ', 1');
+            ->columns($db->quoteName(['teachername', 'alias', 'published', 'language', 'address']))
+            ->values(":name, :alias, 1, :language, ''")
+            ->bind(':name', $name)
+            ->bind(':alias', $alias)
+            ->bind(':language', $language);
         $db->setQuery($insert);
         $db->execute();
 
@@ -452,7 +490,8 @@ class CwmcsvimportHelper
         $query = $db->createQuery()
             ->select($db->quoteName('id'))
             ->from($db->quoteName('#__bsms_series'))
-            ->where('LOWER(' . $db->quoteName('series_text') . ') = LOWER(' . $db->quote($name) . ')')
+            ->where('LOWER(' . $db->quoteName('series_text') . ') = LOWER(:name)')
+            ->bind(':name', $name)
             ->setLimit(1);
         $db->setQuery($query);
         $id = (int) $db->loadResult();
@@ -469,10 +508,18 @@ class CwmcsvimportHelper
 
         $alias = OutputFilter::stringURLSafe($name);
 
-        $insert = $db->createQuery()
+        // ⚠️ Every NOT-NULL column with no default is supplied, because under
+        // strict-mode MySQL omitting any one of them fails the whole insert —
+        // auto-create never worked on such hosts. Surfaced by the write-path
+        // test; present since before the binding conversion.
+        $language = '*';
+        $insert   = $db->createQuery()
             ->insert($db->quoteName('#__bsms_series'))
-            ->columns($db->quoteName(['series_text', 'alias', 'published']))
-            ->values($db->quote($name) . ', ' . $db->quote($alias) . ', 1');
+            ->columns($db->quoteName(['series_text', 'alias', 'published', 'language']))
+            ->values(':name, :alias, 1, :language')
+            ->bind(':name', $name)
+            ->bind(':alias', $alias)
+            ->bind(':language', $language);
         $db->setQuery($insert);
         $db->execute();
 
@@ -520,7 +567,8 @@ class CwmcsvimportHelper
         $query = $db->createQuery()
             ->select($db->quoteName('id'))
             ->from($db->quoteName('#__bsms_locations'))
-            ->where('LOWER(' . $db->quoteName('location_text') . ') = LOWER(' . $db->quote($name) . ')')
+            ->where('LOWER(' . $db->quoteName('location_text') . ') = LOWER(:name)')
+            ->bind(':name', $name)
             ->setLimit(1);
         $db->setQuery($query);
         $id = (int) $db->loadResult();
@@ -537,10 +585,23 @@ class CwmcsvimportHelper
 
         $alias = OutputFilter::stringURLSafe($name);
 
-        $insert = $db->createQuery()
+        // ⚠️ #__bsms_locations has no alias column, so the insert this
+        // replaces failed with "Unknown column" on every database — location
+        // auto-create from a CSV has never worked. The NOT-NULL companions
+        // are supplied for strict-mode MySQL, where omitting any one of them
+        // fails the whole insert. Surfaced by the write-path test; both
+        // present since before the binding conversion.
+        $language = '*';
+        $insert   = $db->createQuery()
             ->insert($db->quoteName('#__bsms_locations'))
-            ->columns($db->quoteName(['location_text', 'alias', 'published']))
-            ->values($db->quote($name) . ', ' . $db->quote($alias) . ', 1');
+            ->columns($db->quoteName([
+                'location_text', 'published', 'language',
+                'params', 'sortname1', 'sortname2', 'sortname3',
+                'metakey', 'metadesc', 'metadata', 'xreference',
+            ]))
+            ->values(":name, 1, :language, '{}', '', '', '', '', '', '', ''")
+            ->bind(':name', $name)
+            ->bind(':language', $language);
         $db->setQuery($insert);
         $db->execute();
 
@@ -588,7 +649,8 @@ class CwmcsvimportHelper
         $query = $db->createQuery()
             ->select($db->quoteName('id'))
             ->from($db->quoteName('#__bsms_message_type'))
-            ->where('LOWER(' . $db->quoteName('message_type') . ') = LOWER(' . $db->quote($name) . ')')
+            ->where('LOWER(' . $db->quoteName('message_type') . ') = LOWER(:name)')
+            ->bind(':name', $name)
             ->setLimit(1);
         $db->setQuery($query);
         $id = (int) $db->loadResult();
@@ -608,7 +670,9 @@ class CwmcsvimportHelper
         $insert = $db->createQuery()
             ->insert($db->quoteName('#__bsms_message_type'))
             ->columns($db->quoteName(['message_type', 'alias', 'published']))
-            ->values($db->quote($name) . ', ' . $db->quote($alias) . ', 1');
+            ->values(':name, :alias, 1')
+            ->bind(':name', $name)
+            ->bind(':alias', $alias);
         $db->setQuery($insert);
         $db->execute();
 
@@ -656,7 +720,8 @@ class CwmcsvimportHelper
         $query = $db->createQuery()
             ->select($db->quoteName('id'))
             ->from($db->quoteName('#__bsms_topics'))
-            ->where('LOWER(' . $db->quoteName('topic_text') . ') = LOWER(' . $db->quote($name) . ')')
+            ->where('LOWER(' . $db->quoteName('topic_text') . ') = LOWER(:name)')
+            ->bind(':name', $name)
             ->setLimit(1);
         $db->setQuery($query);
         $id = (int) $db->loadResult();
@@ -673,10 +738,15 @@ class CwmcsvimportHelper
 
         $alias = OutputFilter::stringURLSafe($name);
 
+        // ⚠️ #__bsms_topics has no alias column, so the insert this replaces —
+        // topic_text, alias, published — failed with "Unknown column" on every
+        // database, strict mode or not: auto-creating a topic from a CSV has
+        // never worked. Surfaced by the write-path test.
         $insert = $db->createQuery()
             ->insert($db->quoteName('#__bsms_topics'))
-            ->columns($db->quoteName(['topic_text', 'alias', 'published']))
-            ->values($db->quote($name) . ', ' . $db->quote($alias) . ', 1');
+            ->columns($db->quoteName(['topic_text', 'published', 'language']))
+            ->values(":name, 1, '*'")
+            ->bind(':name', $name);
         $db->setQuery($insert);
         $db->execute();
 
@@ -841,8 +911,10 @@ class CwmcsvimportHelper
         $query = $db->createQuery()
             ->select($db->quoteName('id'))
             ->from($db->quoteName('#__bsms_studies'))
-            ->where('LOWER(' . $db->quoteName('studytitle') . ') = LOWER(' . $db->quote($title) . ')')
-            ->where($db->quoteName('studydate') . ' = ' . $db->quote($date))
+            ->where('LOWER(' . $db->quoteName('studytitle') . ') = LOWER(:title)')
+            ->where($db->quoteName('studydate') . ' = :studydate')
+            ->bind(':title', $title)
+            ->bind(':studydate', $date)
             ->setLimit(1);
         $db->setQuery($query);
 
@@ -1046,7 +1118,8 @@ class CwmcsvimportHelper
         $query = $db->createQuery()
             ->select($db->quoteName('id'))
             ->from($db->quoteName('#__bsms_locations'))
-            ->where('LOWER(' . $db->quoteName('location_text') . ') = LOWER(' . $db->quote($name) . ')')
+            ->where('LOWER(' . $db->quoteName('location_text') . ') = LOWER(:name)')
+            ->bind(':name', $name)
             ->setLimit(1);
         $db->setQuery($query);
 

--- a/admin/src/Helper/CwmmigrationHelper.php
+++ b/admin/src/Helper/CwmmigrationHelper.php
@@ -598,6 +598,10 @@ class CwmmigrationHelper
 
         $inserted = 0;
 
+        // Plain-string SQL on purpose: the builder has no INSERT IGNORE, and
+        // idempotence is the whole point of the seed. The values stay
+        // quote()d — binding lives on the builder — and every row is this
+        // file's own catalogue, not input.
         foreach ($translations as $row) {
             $values = $db->quote($row[0]) . ', '
                 . $db->quote($row[1]) . ', '
@@ -628,9 +632,12 @@ class CwmmigrationHelper
         foreach ($renames as $oldAbbr => [$newAbbr, $newName]) {
             $query = $db->createQuery()
                 ->update($db->quoteName('#__bsms_bible_translations'))
-                ->set($db->quoteName('abbreviation') . ' = ' . $db->quote($newAbbr))
-                ->set($db->quoteName('name') . ' = ' . $db->quote($newName))
-                ->where($db->quoteName('abbreviation') . ' = ' . $db->quote($oldAbbr));
+                ->set($db->quoteName('abbreviation') . ' = :newabbr')
+                ->set($db->quoteName('name') . ' = :newname')
+                ->where($db->quoteName('abbreviation') . ' = :oldabbr')
+                ->bind(':newabbr', $newAbbr)
+                ->bind(':newname', $newName)
+                ->bind(':oldabbr', $oldAbbr);
             $db->setQuery($query);
             $db->execute();
         }
@@ -711,7 +718,8 @@ class CwmmigrationHelper
                 ->update($db->quoteName('#__bsms_bible_translations'))
                 ->set($db->quoteName('installed') . ' = 1')
                 ->set($db->quoteName('verse_count') . ' = ' . (int) $row->cnt)
-                ->where($db->quoteName('abbreviation') . ' = ' . $db->quote($abbr));
+                ->where($db->quoteName('abbreviation') . ' = :abbr')
+                ->bind(':abbr', $abbr);
             $db->setQuery($query);
             $db->execute();
         }
@@ -757,15 +765,23 @@ class CwmmigrationHelper
         $updated = 0;
 
         foreach ($replacements as $search => $replace) {
+            // ⚠️ Backslash is LIKE's escape character, so the JSON-escaped
+            // search term needs its backslashes doubled for the pattern —
+            // "\/" in a LIKE means an escaped slash and matches a plain "/",
+            // never the literal "\/" the JSON actually stores. Without this
+            // the WHERE matched nothing and the fixer has been a silent no-op
+            // since it shipped: REPLACE was right, the row filter never was.
+            $like  = '%' . str_replace('\\', '\\\\', $search) . '%';
             $query = $db->createQuery()
                 ->update($db->quoteName('#__bsms_mediafiles'))
                 ->set(
                     $db->quoteName('params') . ' = REPLACE('
-                    . $db->quoteName('params') . ', '
-                    . $db->quote($search) . ', '
-                    . $db->quote($replace) . ')'
+                    . $db->quoteName('params') . ', :search, :replace)'
                 )
-                ->where($db->quoteName('params') . ' LIKE ' . $db->quote('%' . $search . '%'));
+                ->where($db->quoteName('params') . ' LIKE :like')
+                ->bind(':search', $search)
+                ->bind(':replace', $replace)
+                ->bind(':like', $like);
             $db->setQuery($query);
             $db->execute();
             $updated += $db->getAffectedRows();
@@ -979,7 +995,8 @@ class CwmmigrationHelper
         $query = $db->createQuery()
             ->select($db->quoteName('id'))
             ->from($db->quoteName('#__bsms_locations'))
-            ->where($db->quoteName('location_text') . ' = ' . $db->quote($name));
+            ->where($db->quoteName('location_text') . ' = :name')
+            ->bind(':name', $name);
         $db->setQuery($query);
         $existing = (int) $db->loadResult();
 
@@ -987,13 +1004,28 @@ class CwmmigrationHelper
             return $existing;
         }
 
-        // Insert new location
-        $alias              = \Joomla\CMS\Application\ApplicationHelper::stringURLSafe($name);
+        // Insert new location.
+        //
+        // ⚠️ #__bsms_locations has no alias column — the row this replaces set
+        // one, which insertObject() turned into an unknown-column INSERT. The
+        // NOT-NULL companions (params, sortnames, meta fields, xreference,
+        // language) are supplied because under strict-mode MySQL omitting any
+        // one of them fails the whole insert: creating a location from an
+        // access level never worked on such hosts. Surfaced by the
+        // migration-bindings test.
         $row                = new \stdClass();
         $row->location_text = $name;
-        $row->alias         = $alias ?: 'location-' . (int) $accessLevel->id;
         $row->published     = 1;
         $row->access        = 1; // Public
+        $row->language      = '*';
+        $row->params        = '{}';
+        $row->sortname1     = '';
+        $row->sortname2     = '';
+        $row->sortname3     = '';
+        $row->metakey       = '';
+        $row->metadesc      = '';
+        $row->metadata      = '';
+        $row->xreference    = '';
         $db->insertObject('#__bsms_locations', $row);
 
         $newId = (int) $db->insertid();

--- a/admin/src/Model/CwmanalyticsModel.php
+++ b/admin/src/Model/CwmanalyticsModel.php
@@ -21,6 +21,7 @@ use CWM\Component\Proclaim\Administrator\Helper\CwmlocationHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\MVC\Model\BaseDatabaseModel;
 use Joomla\Database\DatabaseInterface;
+use Joomla\Database\ParameterType;
 use Joomla\Database\QueryInterface;
 
 /**
@@ -35,6 +36,37 @@ use Joomla\Database\QueryInterface;
  */
 class CwmanalyticsModel extends BaseDatabaseModel
 {
+    /**
+     * Bind the inclusive day window the dashboard asked for.
+     *
+     * One definition of the window instead of twenty-six: the day expansion
+     * and the binding belong together, so a caller cannot bind the date while
+     * hand-appending the time. The :windowStart / :windowEnd markers work
+     * anywhere in the statement — WHERE or a hand-assembled JOIN condition —
+     * because binding is per query, not per clause.
+     *
+     * ⚠️ bind() takes its value by reference, which is why the expanded
+     * strings are assigned to locals first — binding the concatenation
+     * expression directly is a fatal, and each call needs fresh locals so an
+     * earlier query is never silently rebound.
+     *
+     * @param   QueryInterface  $query  The query being built.
+     * @param   string          $start  Window start date, Y-m-d.
+     * @param   string          $end    Window end date, Y-m-d.
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function bindCreatedWindow(QueryInterface $query, string $start, string $end): void
+    {
+        $windowStart = $start . ' 00:00:00';
+        $windowEnd   = $end . ' 23:59:59';
+
+        $query->bind(':windowStart', $windowStart, ParameterType::STRING)
+            ->bind(':windowEnd', $windowEnd, ParameterType::STRING);
+    }
+
     /**
      * Load all published locations, optionally restricted to specific view levels.
      *
@@ -215,8 +247,9 @@ class CwmanalyticsModel extends BaseDatabaseModel
                     'COUNT(DISTINCT ' . $db->quoteName('session_hash') . ') AS sessions',
                 ])
                 ->from($db->quoteName('#__bsms_analytics_events'))
-                ->where($db->quoteName('created') . ' >= ' . $db->quote($start . ' 00:00:00'))
-                ->where($db->quoteName('created') . ' <= ' . $db->quote($end . ' 23:59:59'));
+                ->where($db->quoteName('created') . ' >= :windowStart')
+                ->where($db->quoteName('created') . ' <= :windowEnd');
+            $this->bindCreatedWindow($query, $start, $end);
 
             if ($locationId > 0) {
                 $query->where($db->quoteName('location_id') . ' = ' . (int) $locationId);
@@ -282,16 +315,18 @@ class CwmanalyticsModel extends BaseDatabaseModel
 
             $query = $db->createQuery()
                 ->select([
-                    'DATE_FORMAT(' . $db->quoteName('created') . ', ' . $db->quote($format) . ') AS period',
+                    'DATE_FORMAT(' . $db->quoteName('created') . ', :bucketFormat) AS period',
                     'SUM(CASE WHEN ' . $db->quoteName('event_type') . ' = ' . $db->quote('page_view') . ' THEN 1 ELSE 0 END) AS views',
                     'SUM(CASE WHEN ' . $db->quoteName('event_type') . ' = ' . $db->quote('play') . ' THEN 1 ELSE 0 END) AS plays',
                     'SUM(CASE WHEN ' . $db->quoteName('event_type') . ' = ' . $db->quote('download') . ' THEN 1 ELSE 0 END) AS downloads',
                 ])
                 ->from($db->quoteName('#__bsms_analytics_events'))
-                ->where($db->quoteName('created') . ' >= ' . $db->quote($start . ' 00:00:00'))
-                ->where($db->quoteName('created') . ' <= ' . $db->quote($end . ' 23:59:59'))
+                ->where($db->quoteName('created') . ' >= :windowStart')
+                ->where($db->quoteName('created') . ' <= :windowEnd')
                 ->group('period')
                 ->order('period ASC');
+            $this->bindCreatedWindow($query, $start, $end);
+            $query->bind(':bucketFormat', $format, ParameterType::STRING);
 
             if ($locationId > 0) {
                 $query->where($db->quoteName('location_id') . ' = ' . (int) $locationId);
@@ -334,9 +369,10 @@ class CwmanalyticsModel extends BaseDatabaseModel
                     $db->quoteName('#__bsms_studies', 's') .
                     ' ON ' . $db->quoteName('s.id') . ' = ' . $db->quoteName('e.study_id')
                 )
-                ->where($db->quoteName('e.created') . ' >= ' . $db->quote($start . ' 00:00:00'))
-                ->where($db->quoteName('e.created') . ' <= ' . $db->quote($end . ' 23:59:59'))
+                ->where($db->quoteName('e.created') . ' >= :windowStart')
+                ->where($db->quoteName('e.created') . ' <= :windowEnd')
                 ->where($db->quoteName('e.study_id') . ' IS NOT NULL');
+            $this->bindCreatedWindow($query, $start, $end);
 
             if ($locationId > 0) {
                 $query->where($db->quoteName('e.location_id') . ' = ' . (int) $locationId);
@@ -390,8 +426,8 @@ class CwmanalyticsModel extends BaseDatabaseModel
                     'COUNT(*) AS local_total',
                 ])
                 ->from($db->quoteName('#__bsms_analytics_events', 'e'))
-                ->where($db->quoteName('e.created') . ' >= ' . $db->quote($start . ' 00:00:00'))
-                ->where($db->quoteName('e.created') . ' <= ' . $db->quote($end . ' 23:59:59'))
+                ->where($db->quoteName('e.created') . ' >= :windowStart')
+                ->where($db->quoteName('e.created') . ' <= :windowEnd')
                 ->where($db->quoteName('e.study_id') . ' IS NOT NULL');
 
             if ($locationId > 0) {
@@ -430,6 +466,12 @@ class CwmanalyticsModel extends BaseDatabaseModel
                 ->leftJoin('(' . $platSub . ') AS plat ON plat.study_id = ' . $db->quoteName('s.id'))
                 ->where('(COALESCE(loc.local_total, 0) + COALESCE(plat.platform_plays, 0)) > 0')
                 ->order('total DESC');
+
+            // ⚠️ Bound on the OUTER query. $localSub is rendered to a string
+            // when embedded in the leftJoin, and a string carries no bindings —
+            // the markers live in this query's SQL, so this is where their
+            // values must attach.
+            $this->bindCreatedWindow($query, $start, $end);
 
             $db->setQuery($query, 0, (int) $limit);
 
@@ -558,11 +600,12 @@ class CwmanalyticsModel extends BaseDatabaseModel
                     'COUNT(*) AS count',
                 ])
                 ->from($db->quoteName('#__bsms_analytics_events'))
-                ->where($db->quoteName('created') . ' >= ' . $db->quote($start . ' 00:00:00'))
-                ->where($db->quoteName('created') . ' <= ' . $db->quote($end . ' 23:59:59'))
+                ->where($db->quoteName('created') . ' >= :windowStart')
+                ->where($db->quoteName('created') . ' <= :windowEnd')
                 ->where($db->quoteName('utm_source') . ' IS NOT NULL')
                 ->group([$db->quoteName('utm_source'), $db->quoteName('utm_medium'), $db->quoteName('utm_campaign')])
                 ->order('count DESC');
+            $this->bindCreatedWindow($query, $start, $end);
 
             if ($locationId > 0) {
                 $query->where($db->quoteName('location_id') . ' = ' . (int) $locationId);
@@ -771,9 +814,10 @@ class CwmanalyticsModel extends BaseDatabaseModel
         $query = $db->createQuery()
             ->select('*')
             ->from($db->quoteName('#__bsms_analytics_events'))
-            ->where($db->quoteName('created') . ' >= ' . $db->quote($start . ' 00:00:00'))
-            ->where($db->quoteName('created') . ' <= ' . $db->quote($end . ' 23:59:59'))
+            ->where($db->quoteName('created') . ' >= :windowStart')
+            ->where($db->quoteName('created') . ' <= :windowEnd')
             ->order($db->quoteName('created') . ' ASC');
+        $this->bindCreatedWindow($query, $start, $end);
 
         if ($locationId > 0) {
             $query->where($db->quoteName('location_id') . ' = ' . (int) $locationId);
@@ -787,10 +831,11 @@ class CwmanalyticsModel extends BaseDatabaseModel
         $tmp = fopen('php://temp', 'w');
 
         if (!empty($rows)) {
-            fputcsv($tmp, array_keys($rows[0]));
+            // Explicit escape: PHP 8.5 deprecates relying on the default.
+            fputcsv($tmp, array_keys($rows[0]), ',', '"', '\\');
 
             foreach ($rows as $row) {
-                fputcsv($tmp, $row);
+                fputcsv($tmp, $row, ',', '"', '\\');
             }
         }
 
@@ -831,11 +876,12 @@ class CwmanalyticsModel extends BaseDatabaseModel
                     'COUNT(*) AS count',
                 ])
                 ->from($db->quoteName('#__bsms_analytics_events'))
-                ->where($db->quoteName('created') . ' >= ' . $db->quote($start . ' 00:00:00'))
-                ->where($db->quoteName('created') . ' <= ' . $db->quote($end . ' 23:59:59'))
+                ->where($db->quoteName('created') . ' >= :windowStart')
+                ->where($db->quoteName('created') . ' <= :windowEnd')
                 ->where($db->quoteName($column) . ' IS NOT NULL')
                 ->group($db->quoteName($column))
                 ->order('count DESC');
+            $this->bindCreatedWindow($query, $start, $end);
 
             if ($locationId > 0) {
                 $query->where($db->quoteName('location_id') . ' = ' . (int) $locationId);
@@ -916,6 +962,9 @@ class CwmanalyticsModel extends BaseDatabaseModel
             }
 
             // Raw SQL avoids query-builder quirks with correlated scalar subqueries.
+            // It also keeps the date window quote()d rather than bound: binding
+            // lives on the query builder, and a marker in a plain string ships
+            // to MySQL as literal text.
             // One LEFT JOIN on series_id (no study JOIN) prevents Cartesian product.
             $sql = 'SELECT'
                 . ' sr.' . $db->quoteName('id') . ' AS series_id,'
@@ -1010,13 +1059,14 @@ class CwmanalyticsModel extends BaseDatabaseModel
                 ->leftJoin(
                     $db->quoteName('#__bsms_analytics_events', 'e') .
                     ' ON ' . $db->quoteName('e.study_id') . ' = ' . $db->quoteName('s.id') .
-                    ' AND ' . $db->quoteName('e.created') . ' >= ' . $db->quote($start . ' 00:00:00') .
-                    ' AND ' . $db->quoteName('e.created') . ' <= ' . $db->quote($end . ' 23:59:59')
+                    ' AND ' . $db->quoteName('e.created') . ' >= :windowStart' .
+                    ' AND ' . $db->quoteName('e.created') . ' <= :windowEnd'
                 )
                 ->where($db->quoteName('s.series_id') . ' = ' . (int) $seriesId)
                 ->whereIn($db->quoteName('s.published'), [1, 2])
                 ->group($db->quoteName('s.id'))
                 ->order($db->quoteName('s.studydate') . ' DESC');
+            $this->bindCreatedWindow($query, $start, $end);
             $db->setQuery($query);
 
             return (array) ($db->loadAssocList() ?? []);
@@ -1077,8 +1127,9 @@ class CwmanalyticsModel extends BaseDatabaseModel
                 ])
                 ->from($db->quoteName('#__bsms_analytics_events'))
                 ->where($db->quoteName('study_id') . ' = ' . (int) $studyId)
-                ->where($db->quoteName('created') . ' >= ' . $db->quote($start . ' 00:00:00'))
-                ->where($db->quoteName('created') . ' <= ' . $db->quote($end . ' 23:59:59'));
+                ->where($db->quoteName('created') . ' >= :windowStart')
+                ->where($db->quoteName('created') . ' <= :windowEnd');
+            $this->bindCreatedWindow($query, $start, $end);
             $db->setQuery($query);
             $row = $db->loadAssoc() ?? [];
 
@@ -1105,17 +1156,19 @@ class CwmanalyticsModel extends BaseDatabaseModel
             $db     = $this->getDatabase();
             $query  = $db->createQuery()
                 ->select([
-                    'DATE_FORMAT(' . $db->quoteName('created') . ', ' . $db->quote($format) . ') AS period',
+                    'DATE_FORMAT(' . $db->quoteName('created') . ', :bucketFormat) AS period',
                     'SUM(CASE WHEN ' . $db->quoteName('event_type') . ' = ' . $db->quote('page_view') . ' THEN 1 ELSE 0 END) AS views',
                     'SUM(CASE WHEN ' . $db->quoteName('event_type') . ' = ' . $db->quote('play') . ' THEN 1 ELSE 0 END) AS plays',
                     'SUM(CASE WHEN ' . $db->quoteName('event_type') . ' = ' . $db->quote('download') . ' THEN 1 ELSE 0 END) AS downloads',
                 ])
                 ->from($db->quoteName('#__bsms_analytics_events'))
                 ->where($db->quoteName('study_id') . ' = ' . (int) $studyId)
-                ->where($db->quoteName('created') . ' >= ' . $db->quote($start . ' 00:00:00'))
-                ->where($db->quoteName('created') . ' <= ' . $db->quote($end . ' 23:59:59'))
+                ->where($db->quoteName('created') . ' >= :windowStart')
+                ->where($db->quoteName('created') . ' <= :windowEnd')
                 ->group('period')
                 ->order('period ASC');
+            $this->bindCreatedWindow($query, $start, $end);
+            $query->bind(':bucketFormat', $format, ParameterType::STRING);
             $db->setQuery($query);
 
             return (array) ($db->loadAssocList() ?? []);
@@ -1160,8 +1213,8 @@ class CwmanalyticsModel extends BaseDatabaseModel
                 ->leftJoin(
                     $db->quoteName('#__bsms_analytics_events', 'e') .
                     ' ON ' . $db->quoteName('e.media_id') . ' = ' . $db->quoteName('m.id') .
-                    ' AND ' . $db->quoteName('e.created') . ' >= ' . $db->quote($start . ' 00:00:00') .
-                    ' AND ' . $db->quoteName('e.created') . ' <= ' . $db->quote($end . ' 23:59:59')
+                    ' AND ' . $db->quoteName('e.created') . ' >= :windowStart' .
+                    ' AND ' . $db->quoteName('e.created') . ' <= :windowEnd'
                 )
                 ->leftJoin(
                     $db->quoteName('#__bsms_platform_stats', 'ps') .
@@ -1171,6 +1224,7 @@ class CwmanalyticsModel extends BaseDatabaseModel
                 ->whereIn($db->quoteName('m.published'), [1, 2])
                 ->group($db->quoteName('m.id'))
                 ->order($db->quoteName('m.ordering') . ' ASC');
+            $this->bindCreatedWindow($query, $start, $end);
             $db->setQuery($query);
 
             return (array) ($db->loadAssocList() ?? []);
@@ -1361,11 +1415,12 @@ class CwmanalyticsModel extends BaseDatabaseModel
                     $db->quoteName('#__bsms_servers', 'sv') .
                     ' ON ' . $db->quoteName('sv.id') . ' = ' . $db->quoteName('m.server_id')
                 )
-                ->where($db->quoteName('e.created') . ' >= ' . $db->quote($start . ' 00:00:00'))
-                ->where($db->quoteName('e.created') . ' <= ' . $db->quote($end . ' 23:59:59'))
+                ->where($db->quoteName('e.created') . ' >= :windowStart')
+                ->where($db->quoteName('e.created') . ' <= :windowEnd')
                 ->where($db->quoteName('e.media_id') . ' IS NOT NULL')
                 ->group(['COALESCE(' . $db->quoteName('sv.server_name') . ', ' . $db->quote('Unknown') . ')', 'COALESCE(' . $db->quoteName('sv.type') . ', ' . $db->quote('other') . ')'])
                 ->order('(SUM(CASE WHEN ' . $db->quoteName('e.event_type') . ' = ' . $db->quote('play') . ' THEN 1 ELSE 0 END) + SUM(CASE WHEN ' . $db->quoteName('e.event_type') . ' = ' . $db->quote('download') . ' THEN 1 ELSE 0 END)) DESC');
+            $this->bindCreatedWindow($query, $start, $end);
 
             if ($locationId > 0) {
                 $query->where($db->quoteName('e.location_id') . ' = ' . (int) $locationId);
@@ -1505,6 +1560,10 @@ class CwmanalyticsModel extends BaseDatabaseModel
             $db      = $this->getDatabase();
             $filters = $this->buildMessagesFilters($db, $locationId, $search, $status);
 
+            // Raw SQL for the same reason as getSeriesList: correlated scalar
+            // subqueries fight the builder. The date window stays quote()d —
+            // binding lives on the builder, and a marker in a plain string
+            // ships to MySQL as literal text.
             $sql = 'SELECT'
                 . ' st.' . $db->quoteName('id') . ' AS study_id,'
                 . ' st.' . $db->quoteName('studytitle') . ' AS title,'

--- a/tests/integration/Admin/Helper/AnalyticsEventInsertTest.php
+++ b/tests/integration/Admin/Helper/AnalyticsEventInsertTest.php
@@ -1,0 +1,112 @@
+<?php
+
+/**
+ * Integration test executing the analytics event INSERT.
+ *
+ * @package    Proclaim.IntegrationTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Proclaim\Tests\Integration\Admin\Helper;
+
+use CWM\Component\Proclaim\Administrator\Helper\CwmanalyticsHelper;
+use CWM\Component\Proclaim\Tests\Integration\IntegrationTestCase;
+use Joomla\CMS\Factory;
+use Joomla\Database\DatabaseDriver;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestDox;
+
+/**
+ * logEvent()'s INSERT moved to bound parameters, and none of the existing
+ * analytics tests reach it — proven by mutating a bind out and watching the
+ * suite stay green. logEvent() swallows every exception so a page is never
+ * broken by analytics, which means a bind mistake here is a silent end to
+ * event collection: the worst failure is the one nothing reports.
+ *
+ * So this drives the real thing and reads the row back, including the
+ * columns the old code spelled as "or NULL" ternaries — a null local must
+ * arrive as SQL NULL, not the string that PHP would coerce.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+#[CoversClass(CwmanalyticsHelper::class)]
+class AnalyticsEventInsertTest extends IntegrationTestCase
+{
+    private ?DatabaseDriver $db = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (!\defined('PROCLAIM_TEST_DB_AVAILABLE') || !PROCLAIM_TEST_DB_AVAILABLE) {
+            $this->markTestSkipped('Database not available for integration tests');
+        }
+
+        $this->db = Factory::getContainer()->get(DatabaseDriver::class);
+        $this->db->transactionStart(true);
+
+        // The classifier reads the request environment straight from
+        // superglobals; give it one with the characters quoting exists for.
+        $_SERVER['HTTP_USER_AGENT']      = "Mozilla/5.0 (Macintosh; Intel Mac OS X) Test's Agent";
+        $_SERVER['HTTP_REFERER']         = "https://search.example.org/find?q=o'brien";
+        $_SERVER['HTTP_ACCEPT_LANGUAGE'] = 'en-US,en;q=0.9';
+    }
+
+    protected function tearDown(): void
+    {
+        unset($_SERVER['HTTP_USER_AGENT'], $_SERVER['HTTP_REFERER'], $_SERVER['HTTP_ACCEPT_LANGUAGE']);
+
+        if ($this->db !== null) {
+            try {
+                $this->db->transactionRollback(true);
+            } catch (\Throwable) {
+                // Connection lost; nothing to roll back.
+            }
+        }
+
+        parent::tearDown();
+    }
+
+    #[TestDox('logEvent writes a row, and the nullable columns arrive as real NULLs')]
+    public function testEventRowLands(): void
+    {
+        $before = $this->eventCount();
+
+        CwmanalyticsHelper::logEvent('page_view', 987654);
+
+        $after = $this->eventCount();
+
+        // ⚠️ The assertion that cannot be argued with: logEvent swallows all
+        // exceptions, so "no new row" is the only visible symptom of a broken
+        // INSERT — which is precisely why it must be asserted rather than
+        // assumed. If this fails with no obvious cause, the gates at the top
+        // of logEvent (analytics_enabled, consent) are worth checking first.
+        $this->assertSame($before + 1, $after, 'logEvent() wrote nothing. Its INSERT died silently.');
+
+        $row = $this->db->setQuery(
+            $this->db->createQuery()
+                ->select('*')
+                ->from($this->db->quoteName('#__bsms_analytics_events'))
+                ->where($this->db->quoteName('study_id') . ' = 987654')
+        )->loadObject();
+
+        $this->assertNotNull($row);
+        $this->assertSame('page_view', $row->event_type);
+        $this->assertSame('desktop', $row->device_type);
+
+        // No UTM parameters in this request: the old ternaries wrote NULL and
+        // the binds must too — a PHP null coerced to '' would satisfy a
+        // looser assertion and silently change every UTM breakdown.
+        $this->assertNull($row->utm_source, 'An absent UTM value must land as SQL NULL.');
+        $this->assertNull($row->utm_campaign);
+    }
+
+    private function eventCount(): int
+    {
+        return (int) $this->db->setQuery(
+            $this->db->createQuery()->select('COUNT(*)')->from($this->db->quoteName('#__bsms_analytics_events'))
+        )->loadResult();
+    }
+}

--- a/tests/integration/Admin/Helper/CsvImportWritePathTest.php
+++ b/tests/integration/Admin/Helper/CsvImportWritePathTest.php
@@ -1,0 +1,159 @@
+<?php
+
+/**
+ * Integration tests executing the CSV importer's write path.
+ *
+ * @package    Proclaim.IntegrationTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Proclaim\Tests\Integration\Admin\Helper;
+
+use CWM\Component\Proclaim\Administrator\Helper\CwmcsvimportHelper;
+use CWM\Component\Proclaim\Tests\Integration\IntegrationTestCase;
+use Joomla\CMS\Factory;
+use Joomla\Database\DatabaseDriver;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestDox;
+
+/**
+ * The importer's INSERTs, UPDATEs and lookups are being moved from quote()d
+ * literals to bound parameters, and until now nothing executed them — the
+ * existing tests cover date parsing and a source-level rule. A conversion
+ * mistake here would surface on the next real import of somebody's data,
+ * which is the worst possible place.
+ *
+ * So the write path runs, against the real database, inside a rolled-back
+ * transaction: a full row import, the duplicate-then-update branch, and each
+ * resolve-or-create lookup both finding and creating. Values include quotes
+ * and commas on purpose — the characters quoting exists for are the ones a
+ * broken bind mangles first.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+#[CoversClass(CwmcsvimportHelper::class)]
+class CsvImportWritePathTest extends IntegrationTestCase
+{
+    private ?DatabaseDriver $db = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (!\defined('PROCLAIM_TEST_DB_AVAILABLE') || !PROCLAIM_TEST_DB_AVAILABLE) {
+            $this->markTestSkipped('Database not available for integration tests');
+        }
+
+        $this->db = Factory::getContainer()->get(DatabaseDriver::class);
+        $this->db->transactionStart(true);
+        CwmcsvimportHelper::resetState();
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->db !== null) {
+            try {
+                $this->db->transactionRollback(true);
+            } catch (\Throwable) {
+                // Connection lost; nothing to roll back.
+            }
+        }
+
+        CwmcsvimportHelper::resetState();
+
+        parent::tearDown();
+    }
+
+    /**
+     * A row whose values carry the characters quoting exists for.
+     *
+     * @return  array<string, string>
+     */
+    private static function row(): array
+    {
+        return [
+            'studytitle'  => "O'Brien's \"Test\", part 1",
+            'studydate'   => '2030-07-04',
+            'studyintro'  => "Intro with 'quotes', commas, and a\nnewline",
+            'studytext'   => 'Body text',
+            'studynumber' => '42',
+            'series'      => "Importer's Fixture Series",
+            'location'    => '',
+            'messagetype' => '',
+            'teacher'     => "D'Angelo Fixture",
+            'language'    => '*',
+        ];
+    }
+
+    #[TestDox('a new row imports, and every quoted character survives')]
+    public function testInsertNewRow(): void
+    {
+        $result = CwmcsvimportHelper::importRow(self::row(), ['auto_create' => true, 'default_published' => 0]);
+
+        $this->assertSame('imported', $result['status'] ?? '', json_encode($result));
+
+        $stored = $this->db->setQuery(
+            $this->db->createQuery()
+                ->select($this->db->quoteName(['id', 'studytitle', 'studyintro', 'series_id']))
+                ->from($this->db->quoteName('#__bsms_studies'))
+                ->where($this->db->quoteName('studydate') . ' = ' . $this->db->quote('2030-07-04 00:00:00'))
+        )->loadObject();
+
+        $this->assertNotNull($stored, 'The imported study is not in the table.');
+        $this->assertSame(self::row()['studytitle'], $stored->studytitle, 'Quoting mangled the title.');
+        $this->assertStringContainsString("'quotes', commas", $stored->studyintro);
+        $this->assertGreaterThan(0, (int) $stored->series_id, 'The auto-created series was not linked.');
+    }
+
+    #[TestDox('a duplicate row takes the update branch and the fields land')]
+    public function testUpdateExistingRow(): void
+    {
+        CwmcsvimportHelper::importRow(self::row(), ['auto_create' => true, 'default_published' => 0]);
+
+        $second               = self::row();
+        $second['studyintro'] = "Updated intro, still with 'quotes'";
+
+        // duplicate_handling defaults to skip; the update branch is opt-in,
+        // and it reports 'imported' — the caller-facing outcome, not the path.
+        $result = CwmcsvimportHelper::importRow(
+            $second,
+            ['auto_create' => true, 'default_published' => 0, 'duplicate_handling' => 'update']
+        );
+
+        $this->assertSame('imported', $result['status'] ?? '', json_encode($result));
+
+        $intro = $this->db->setQuery(
+            $this->db->createQuery()
+                ->select($this->db->quoteName('studyintro'))
+                ->from($this->db->quoteName('#__bsms_studies'))
+                ->where($this->db->quoteName('studydate') . ' = ' . $this->db->quote('2030-07-04 00:00:00'))
+        )->loadResult();
+
+        $this->assertSame($second['studyintro'], $intro);
+    }
+
+    #[TestDox('each lookup creates once and then finds what it created')]
+    public function testResolveOrCreateRoundTrips(): void
+    {
+        foreach (
+            [
+                'resolveOrCreateTeacher'     => "Rose O'Fixture",
+                'resolveOrCreateSeries'      => "Series with, comma and 'quote'",
+                'resolveOrCreateLocation'    => "St. Mary's Fixture Hall",
+                'resolveOrCreateMessageType' => "Q&A 'Fixture'",
+                'resolveOrCreateTopic'       => "Topic o' fixtures",
+            ] as $method => $name
+        ) {
+            $created = CwmcsvimportHelper::$method($name, true);
+            $this->assertGreaterThan(0, $created, "$method failed to create.");
+
+            // ⚠️ The round trip is the quoting test: a LOWER() lookup whose
+            // bind mangles the apostrophe creates a second row instead of
+            // finding the first.
+            $found = CwmcsvimportHelper::$method($name, false);
+            $this->assertSame($created, $found, "$method did not find the row it just created.");
+        }
+    }
+}

--- a/tests/integration/Admin/Helper/MigrationBindingsTest.php
+++ b/tests/integration/Admin/Helper/MigrationBindingsTest.php
@@ -1,0 +1,139 @@
+<?php
+
+/**
+ * Integration tests executing the converted migration-helper queries.
+ *
+ * @package    Proclaim.IntegrationTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Proclaim\Tests\Integration\Admin\Helper;
+
+use CWM\Component\Proclaim\Administrator\Helper\CwmmigrationHelper;
+use CWM\Component\Proclaim\Tests\Integration\IntegrationTestCase;
+use Joomla\CMS\Factory;
+use Joomla\Database\DatabaseDriver;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestDox;
+
+/**
+ * The migration helper's remaining quote($variable) sites became bound
+ * markers, and these routines run at exactly the moment a broken query is
+ * most expensive: during an update, on someone else's site. Each converted
+ * method executes here against the real database, inside a rolled-back
+ * transaction, and has to produce its observable effect — not merely return.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+#[CoversClass(CwmmigrationHelper::class)]
+class MigrationBindingsTest extends IntegrationTestCase
+{
+    private ?DatabaseDriver $db = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (!\defined('PROCLAIM_TEST_DB_AVAILABLE') || !PROCLAIM_TEST_DB_AVAILABLE) {
+            $this->markTestSkipped('Database not available for integration tests');
+        }
+
+        $this->db = Factory::getContainer()->get(DatabaseDriver::class);
+        $this->db->transactionStart(true);
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->db !== null) {
+            try {
+                $this->db->transactionRollback(true);
+            } catch (\Throwable) {
+                // Connection lost; nothing to roll back.
+            }
+        }
+
+        parent::tearDown();
+    }
+
+    #[TestDox('the translation seed and its bound renames run to completion')]
+    public function testSeedBibleTranslations(): void
+    {
+        // Idempotent by design (INSERT IGNORE + renames), so running it over
+        // an already-seeded table is the normal case, not a special one.
+        CwmmigrationHelper::seedBibleTranslations();
+
+        $count = (int) $this->db->setQuery(
+            $this->db->createQuery()
+                ->select('COUNT(*)')
+                ->from($this->db->quoteName('#__bsms_bible_translations'))
+        )->loadResult();
+
+        $this->assertGreaterThan(0, $count, 'The catalogue is empty after seeding.');
+    }
+
+    #[TestDox('reconciliation writes a bound verse count for an installed translation')]
+    public function testReconcileBibleTranslations(): void
+    {
+        CwmmigrationHelper::reconcileBibleTranslations();
+
+        $kjv = $this->db->setQuery(
+            $this->db->createQuery()
+                ->select($this->db->quoteName(['installed', 'verse_count']))
+                ->from($this->db->quoteName('#__bsms_bible_translations'))
+                ->where($this->db->quoteName('abbreviation') . ' = ' . $this->db->quote('kjv'))
+        )->loadObject();
+
+        $this->assertNotNull($kjv, 'kjv is missing from the catalogue.');
+        $this->assertSame(1, (int) $kjv->installed);
+        $this->assertGreaterThan(30000, (int) $kjv->verse_count, 'The bound verse count did not land.');
+    }
+
+    #[TestDox('the legacy-path fixer rewrites through its bound REPLACE')]
+    public function testFixMediafileLegacyPaths(): void
+    {
+        // The path the fixer actually maps — media/com_biblestudy, stored the
+        // way json_encode stores it, escaped slashes and all. (It deliberately
+        // does not touch images/biblestudy/, which still exists on disk.)
+        $params = json_encode(['filename' => 'media/com_biblestudy/zz-legacy.mp3']);
+        $media  = (object) [
+            'study_id'  => 0,
+            'server_id' => 0,
+            'published' => 1,
+            'access'    => 1,
+            'params'    => $params,
+            'metadata'  => '',
+            'language'  => '*',
+        ];
+        $this->db->insertObject('#__bsms_mediafiles', $media, 'id');
+        $id = (int) $this->db->insertid();
+
+        CwmmigrationHelper::fixMediafileLegacyPaths();
+
+        $stored = (string) $this->db->setQuery(
+            $this->db->createQuery()
+                ->select($this->db->quoteName('params'))
+                ->from($this->db->quoteName('#__bsms_mediafiles'))
+                ->where($this->db->quoteName('id') . ' = ' . $id)
+        )->loadResult();
+
+        // Whatever mapping the fixer applies, a row seeded with a legacy
+        // path must come out changed — an inert REPLACE means the binds died.
+        $this->assertNotSame($params, $stored, 'The seeded legacy path was not rewritten.');
+        $this->assertStringContainsString('com_proclaim', $stored);
+    }
+
+    #[TestDox('a location created from an access level is found again by its bound name')]
+    public function testCreateLocationFromAccess(): void
+    {
+        $level = (object) ['id' => 999, 'title' => "St. Migration's Fixture"];
+
+        $created = CwmmigrationHelper::createLocationFromAccess($level);
+        $this->assertGreaterThan(0, $created);
+
+        // The round trip is the binding test: a lookup whose bind mangles the
+        // apostrophe creates a duplicate instead of finding the original.
+        $this->assertSame($created, CwmmigrationHelper::createLocationFromAccess($level));
+    }
+}

--- a/tests/integration/Admin/Helper/MigrationBindingsTest.php
+++ b/tests/integration/Admin/Helper/MigrationBindingsTest.php
@@ -76,6 +76,25 @@ class MigrationBindingsTest extends IntegrationTestCase
     #[TestDox('reconciliation writes a bound verse count for an installed translation')]
     public function testReconcileBibleTranslations(): void
     {
+        // Self-sufficient on purpose: a first draft asserted on kjv's real
+        // verse text, which exists on a dev database and not on CI's clean
+        // one — the same environment-dependence this suite exists to keep out
+        // of the queries themselves. Three seeded verses are the whole world.
+        CwmmigrationHelper::seedBibleTranslations();
+
+        foreach ([1, 2, 3] as $verse) {
+            // Book 99: no Bible has one, so the unique key cannot collide
+            // with real verse data on a dev database that carries the KJV.
+            $row = (object) [
+                'translation' => 'kjv',
+                'book'        => 99,
+                'chapter'     => 1,
+                'verse'       => $verse,
+                'text'        => 'Fixture verse ' . $verse,
+            ];
+            $this->db->insertObject('#__bsms_bible_verses', $row);
+        }
+
         CwmmigrationHelper::reconcileBibleTranslations();
 
         $kjv = $this->db->setQuery(
@@ -86,8 +105,8 @@ class MigrationBindingsTest extends IntegrationTestCase
         )->loadObject();
 
         $this->assertNotNull($kjv, 'kjv is missing from the catalogue.');
-        $this->assertSame(1, (int) $kjv->installed);
-        $this->assertGreaterThan(30000, (int) $kjv->verse_count, 'The bound verse count did not land.');
+        $this->assertSame(1, (int) $kjv->installed, 'A translation with verses was not marked installed.');
+        $this->assertGreaterThanOrEqual(3, (int) $kjv->verse_count, 'The bound verse count did not land.');
     }
 
     #[TestDox('the legacy-path fixer rewrites through its bound REPLACE')]

--- a/tests/integration/Admin/Model/AnalyticsQueriesExecuteTest.php
+++ b/tests/integration/Admin/Model/AnalyticsQueriesExecuteTest.php
@@ -1,0 +1,251 @@
+<?php
+
+/**
+ * Integration tests executing every date-windowed analytics query.
+ *
+ * @package    Proclaim.IntegrationTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Proclaim\Tests\Integration\Admin\Model;
+
+use CWM\Component\Proclaim\Administrator\Model\CwmanalyticsModel;
+use CWM\Component\Proclaim\Tests\Integration\IntegrationTestCase;
+use Joomla\CMS\Factory;
+use Joomla\Database\DatabaseDriver;
+use Joomla\Database\DatabaseInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestDox;
+
+/**
+ * The analytics date windows moved from quote()d literals to bound markers,
+ * and a bound marker has a failure mode a literal does not: text that never
+ * meets its bind() ships ":windowStart" to MySQL as literal SQL and dies at
+ * execution. That exact mistake was made twice mid-conversion — in the two
+ * raw-string methods, and in a subquery whose bindings were lost when it was
+ * rendered into its outer query's JOIN.
+ *
+ * ⚠️ Asserting "returns an array" catches none of that here: every one of
+ * these methods swallows exceptions and returns an empty default, so a query
+ * dying at prepare is indistinguishable from an empty table. Hence the seed —
+ * one series, one message, one media file and three events inside the window,
+ * every breakdown column populated. A query that executes must find them; a
+ * query that died cannot.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+#[CoversClass(CwmanalyticsModel::class)]
+class AnalyticsQueriesExecuteTest extends IntegrationTestCase
+{
+    private const START = '2030-06-01';
+
+    private const END = '2030-06-30';
+
+    private ?DatabaseDriver $db = null;
+
+    private ?CwmanalyticsModel $model = null;
+
+    private int $seriesId = 0;
+
+    private int $studyId = 0;
+
+    private int $mediaId = 0;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (!\defined('PROCLAIM_TEST_DB_AVAILABLE') || !PROCLAIM_TEST_DB_AVAILABLE) {
+            $this->markTestSkipped('Database not available for integration tests');
+        }
+
+        $this->db = Factory::getContainer()->get(DatabaseDriver::class);
+        $this->db->transactionStart(true);
+
+        // Constructed directly: the MVCFactory route returns false under the
+        // test bootstrap, and what this class exercises is the model's SQL,
+        // not the factory wiring the admin app does for real requests.
+        $this->model = new CwmanalyticsModel(['ignore_request' => true]);
+        $this->model->setDatabase(Factory::getContainer()->get(DatabaseInterface::class));
+
+        $this->seed();
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->db !== null) {
+            try {
+                $this->db->transactionRollback(true);
+            } catch (\Throwable) {
+                // Connection lost; nothing to roll back.
+            }
+        }
+
+        parent::tearDown();
+    }
+
+    /**
+     * One of everything the windowed queries join, dated inside the window.
+     *
+     * A far-future window (2030) rather than a slice of real time, so rows
+     * already in the table cannot satisfy an assertion the seed was meant to.
+     *
+     * @return  void
+     */
+    private function seed(): void
+    {
+        $series = (object) [
+            'series_text' => 'analytics fixture series',
+            'published'   => 1,
+            'access'      => 1,
+            'language'    => '*',
+        ];
+        $this->db->insertObject('#__bsms_series', $series, 'id');
+        $this->seriesId = (int) $this->db->insertid();
+
+        $study = (object) [
+            'studytitle' => 'analytics fixture message',
+            'series_id'  => $this->seriesId,
+            'studydate'  => self::START . ' 09:00:00',
+            'published'  => 1,
+            'access'     => 1,
+            'language'   => '*',
+        ];
+        $this->db->insertObject('#__bsms_studies', $study, 'id');
+        $this->studyId = (int) $this->db->insertid();
+
+        $media = (object) [
+            'study_id'  => $this->studyId,
+            'server_id' => 0,
+            'published' => 1,
+            'access'    => 1,
+            'params'    => json_encode(['filename' => '/images/biblestudy/media/fixture.mp3', 'mime_type' => 'audio/mpeg']),
+            'metadata'  => '',
+            'language'  => '*',
+        ];
+        $this->db->insertObject('#__bsms_mediafiles', $media, 'id');
+        $this->mediaId = (int) $this->db->insertid();
+
+        foreach (['page_view', 'play', 'download'] as $i => $type) {
+            $event = (object) [
+                'study_id'        => $this->studyId,
+                'series_id'       => $this->seriesId,
+                'media_id'        => $this->mediaId,
+                'event_type'      => $type,
+                'referrer_type'   => 'organic',
+                'referrer_domain' => 'search.example.org',
+                'utm_source'      => 'newsletter',
+                'utm_medium'      => 'email',
+                'utm_campaign'    => 'june',
+                'country_code'    => 'US',
+                'device_type'     => 'desktop',
+                'browser'         => 'Firefox',
+                'os'              => 'macOS',
+                'language'        => 'en-US',
+                'is_guest'        => 1,
+                'session_hash'    => str_repeat((string) $i, 64),
+                'created'         => self::START . ' 10:0' . $i . ':00',
+            ];
+            $this->db->insertObject('#__bsms_analytics_events', $event);
+        }
+    }
+
+    #[TestDox('the KPI totals count the seeded events')]
+    public function testKpiTotals(): void
+    {
+        $kpi = $this->model->getKpiTotals(self::START, self::END);
+
+        $this->assertSame(1, (int) ($kpi['views'] ?? 0), 'The seeded page_view was not counted.');
+        $this->assertSame(1, (int) ($kpi['plays'] ?? 0));
+        $this->assertSame(1, (int) ($kpi['downloads'] ?? 0));
+    }
+
+    #[TestDox('the time series buckets the seeded day')]
+    public function testTimeSeries(): void
+    {
+        $this->assertNotSame(
+            [],
+            $this->model->getTimeSeries(self::START, self::END),
+            'A window holding three events produced no buckets — the query, or its :bucketFormat bind, died.'
+        );
+    }
+
+    #[TestDox('the study rankings find the seeded message')]
+    public function testTopStudies(): void
+    {
+        $ids = array_column($this->model->getTopStudies(self::START, self::END), 'study_id');
+        $this->assertContains((string) $this->studyId, array_map('strval', $ids));
+
+        // A high limit on purpose: platform_plays is all-time by documented
+        // caveat, so real platform-stats rows in the test database outrank a
+        // three-event seed inside any top-10.
+        $ids = array_column($this->model->getTopStudiesCombined(self::START, self::END, 10000), 'study_id');
+        $this->assertContains(
+            (string) $this->studyId,
+            array_map('strval', $ids),
+            'The combined ranking lost the seeded message — its window binds live on the OUTER query, '
+            . 'because the subquery is rendered to a string and a string carries no bindings.'
+        );
+    }
+
+    #[TestDox('every breakdown finds the seeded event')]
+    public function testBreakdowns(): void
+    {
+        foreach (
+            [
+                'getReferrerBreakdown',
+                'getCountryBreakdown',
+                'getDeviceBreakdown',
+                'getBrowserBreakdown',
+                'getOsBreakdown',
+                'getLanguageBreakdown',
+                'getUtmBreakdown',
+                'getMediaTypeBreakdown',
+            ] as $method
+        ) {
+            $this->assertNotSame(
+                [],
+                $this->model->$method(self::START, self::END),
+                "$method returned nothing over a window holding seeded events. These methods swallow "
+                . 'exceptions into empty defaults, so this usually means the query itself died.'
+            );
+        }
+    }
+
+    #[TestDox('the drill-down queries find the seeded rows')]
+    public function testDrillDowns(): void
+    {
+        $this->assertNotSame([], $this->model->getSeriesMessages($this->seriesId, self::START, self::END));
+        $this->assertNotSame([], $this->model->getStudyTimeSeries($this->studyId, self::START, self::END));
+        $this->assertNotSame([], $this->model->getStudyMediaFiles($this->studyId, self::START, self::END));
+
+        $kpi = $this->model->getStudyKpi($this->studyId, self::START, self::END);
+        $this->assertSame(1, (int) ($kpi['views'] ?? 0));
+    }
+
+    #[TestDox('the raw-SQL lists still find the seeded rows')]
+    public function testRawSqlLists(): void
+    {
+        // These two deliberately stayed quote()d — binding lives on the
+        // builder, and their SQL is a plain string. Executed here so the
+        // quote-vs-bind split cannot drift into one side silently breaking.
+        $series = array_column($this->model->getSeriesList(self::START, self::END), 'series_id');
+        $this->assertContains((string) $this->seriesId, array_map('strval', $series));
+
+        $studies = array_column($this->model->getMessagesList(self::START, self::END), 'study_id');
+        $this->assertContains((string) $this->studyId, array_map('strval', $studies));
+    }
+
+    #[TestDox('the CSV export carries the seeded rows')]
+    public function testCsvExport(): void
+    {
+        // The export is raw event rows, not joined titles — assert on a value
+        // only the seed writes.
+        $this->assertStringContainsString(
+            'search.example.org',
+            $this->model->exportCsvString(self::START, self::END)
+        );
+    }
+}


### PR DESCRIPTION
Phase 1 of #1994 (leaving it open — the issue tracks the remaining ~100 spread sites and phases 2–4). One commit per file, four files: `CwmanalyticsModel` (30 sites), `CwmcsvimportHelper` (30), `CwmanalyticsHelper` (14), `CwmmigrationHelper` (11).

**Not a security fix, per the issue's own scope note**: `quote()` escapes correctly. The wins are prepared-statement reuse, call sites that stop carrying escaping responsibility, and identical behaviour across drivers.

## The rule that emerged: a marker is a liability until its bind is proven

A `quote()`d literal cannot half-work. A bound marker can: text that never meets `bind()` ships `:windowStart` to MySQL as literal SQL — and in this codebase most failures are **swallowed into empty defaults**, so the symptom is silence. Every file therefore got an executing test *before or during* conversion, seeded so a query that runs must find something. Those tests caught **2 conversion mistakes and 7 pre-existing bugs**:

### Conversion mistakes (mine, caught in-branch)
- Window binds first attached to a **subquery** — which is rendered to a string inside the outer query's JOIN, and a string carries no bindings. They belong on the outer query.
- The revert of that misplacement removed **`getTopStudies`'s bind instead** (identical text, first match) — the seeded KPI assertions failed on exactly the query left unbound.

### Pre-existing, found by the new tests before converting anything
| | |
|---|---|
| `resolveOrCreateTopic` | inserted an `alias` column **`#__bsms_topics` does not have** — failed on every database, ever |
| `resolveOrCreateLocation` | same — no `alias` on `#__bsms_locations` |
| `createLocationFromAccess` | same missing-column insert, plus every NOT-NULL-no-default column omitted — the migration wizard's location creation failed under strict-mode MySQL |
| teacher/series/location auto-creates | NOT-NULL columns with no default omitted — worked only where the SQL mode forgave it |
| **`fixMediafileLegacyPaths`** | **a silent no-op since 10.1.0**: backslash is LIKE's escape character, so the JSON-escaped pattern's `\/` matched plain `/`, never the stored `\/`. Verified against the pre-conversion code and against MySQL directly. Zero rows ever rewritten; `media/com_biblestudy/` paths from the rename were never fixed and will be on the next run |
| `logEvent` coverage | a mutation test proved all 46 existing analytics tests leave the event INSERT unexecuted — a broken bind there is a silent end to data collection |
| `fputcsv` | PHP 8.5 deprecation, explicit escape now passed |

## What deliberately stayed `quote()`d, with the reason written at each site
The two raw-SQL analytics methods (correlated scalar subqueries fight the builder), the analytics rollup block (`INSERT…SELECT ON DUPLICATE KEY` + NULL-aware deletes), and the translation seed (`INSERT IGNORE`). Binding lives on the builder; a marker in a plain string ships as literal text.

## Tests added
4 seeded integration suites (analytics queries ×19, CSV write path, event insert, migration bindings), all in rolled-back transactions, all bait-checked — each detector was made to fail by reintroducing the class of bug it guards. NULL semantics pinned where they matter: absent UTM values must land as SQL NULL, not a coerced empty string that would reshape every breakdown.

Suite: **3605 tests / 11599 assertions**, four lint steps clean, admin analytics page renders live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)