### PR TITLE
feat(admin): swap server-type fields in place instead of reloading (#2037)

### DIFF
--- a/admin/language/en-GB/en-GB.com_proclaim.ini
+++ b/admin/language/en-GB/en-GB.com_proclaim.ini
@@ -2545,6 +2545,7 @@ JBS_STYLE_RESTRICED_FILE_NAME = "File cannot be named 'main' or 'custom'"
 
 ;; SVR Server
 JBS_SVR_MEDIA_SETTINGS = "Media Settings"
+JBS_SVR_TYPE_SWAP_FAILED="That server type could not be loaded. Nothing on the form was changed — try choosing it again."
 JBS_SVR_TYPE_NOT_RECOGNISED="No server type was chosen, or the form was submitted with a type Proclaim could not read. Nothing was changed — open the server again and pick a type."
 JBS_SVR_PROTECTED_STORAGE="Offer protected storage"
 JBS_SVR_PROTECTED_STORAGE_DESC="Offers a Move to Protected Storage action for this server's media. Files already in the protected folder are always served through Proclaim regardless of this setting — it governs only whether the move is offered here. Off by default, nothing moves on its own, and media referenced by a podcast is never offered the move at all."

--- a/admin/src/Controller/CwmserverController.php
+++ b/admin/src/Controller/CwmserverController.php
@@ -134,6 +134,54 @@ class CwmserverController extends FormController
      * @throws \Exception
      * @since   9.0.0
      */
+    /**
+     * Render the tab-set region for a chosen server type, for the in-place swap.
+     *
+     * The other half of the picker: types.php calls submitbutton with the
+     * chosen key, and instead of submitting the whole form — losing whatever
+     * was typed, turning every failure into a navigation — the edit screen
+     * fetches this fragment and swaps it in. The type lands in user state
+     * exactly as setType() put it, so the model renders the same form either
+     * way and a subsequent save reads the same state it always has.
+     *
+     * @return  void
+     *
+     * @throws  \Exception
+     * @since   __DEPLOY_VERSION__
+     */
+    public function typeFields(): void
+    {
+        $app = Factory::getApplication();
+
+        if (!Session::checkToken('get') && !Session::checkToken()) {
+            $app->setHeader('status', '403 Forbidden');
+            $app->sendHeaders();
+            echo Text::_('JINVALID_TOKEN');
+            $app->close();
+        }
+
+        // Same rule as setType(): a plain key, or nothing happens.
+        $typeKey = strtolower(trim($this->input->getString('type', '')));
+
+        if ($typeKey === '' || !preg_match('/^[a-z0-9_-]+$/', $typeKey)) {
+            $app->setHeader('status', '400 Bad Request');
+            $app->sendHeaders();
+            echo Text::_('JBS_SVR_TYPE_NOT_RECOGNISED');
+            $app->close();
+        }
+
+        $app->setUserState('com_proclaim.edit.cwmserver.type', $typeKey);
+
+        $model = $this->getModel('Cwmserver', 'Administrator', []);
+        $view  = $this->getView('Cwmserver', 'html');
+        $view->setModel($model, true);
+        $view->setLayout('tabs');
+        $view->document = $app->getDocument();
+
+        $view->display();
+        $app->close();
+    }
+
     public function setType(): void
     {
         $app   = Factory::getApplication();

--- a/admin/src/View/Cwmserver/HtmlView.php
+++ b/admin/src/View/Cwmserver/HtmlView.php
@@ -106,8 +106,9 @@ class HtmlView extends BaseHtmlView
         $this->canDo       = ContentHelper::getActions('com_proclaim', 'server', (int)$this->item->id);
         $this->server_form = $model->getAddonServerForm();
 
-        // For modalreturn layout, just load item data and render (no toolbar, no extras)
-        if ($this->getLayout() === 'modalreturn') {
+        // Bare renders: modalreturn for the association flow, tabs for the
+        // in-place type swap — data loaded, no toolbar, no chrome.
+        if (\in_array($this->getLayout(), ['modalreturn', 'tabs'], true)) {
             parent::display($tpl);
 
             return;

--- a/admin/tmpl/cwmserver/edit.php
+++ b/admin/tmpl/cwmserver/edit.php
@@ -32,6 +32,13 @@ $isNewRecord = ((int)$this->item->id === 0 && empty($this->item->type));
 $wa = $this->getDocument()->getWebAssetManager();
 $wa->useScript('keepalive')
     ->useScript('form.validate')
+    // The in-place type swap injects another addon's fields without a reload,
+    // but a fragment cannot bring core field scripts with it. Load the two
+    // that addon fields lean on up front — conditional display (showon) and the
+    // media picker — so whatever type is swapped in finds them already present
+    // and wires up on the joomla:updated event the swap fires.
+    ->useScript('showon')
+    ->useScript('webcomponent.field-media')
     ->addInlineScript(
         "
 	/* Choosing a type must not submit the form: whatever was typed would ride
@@ -103,12 +110,26 @@ $wa->useScript('keepalive')
 					el.value = value;
 				});
 
+				/* Some addon fields (e.g. YouTube's Test API button) ship their
+				   own <script> inline in the field markup. It rode in with the
+				   fragment but a script inserted via innerHTML never runs, so it
+				   is re-created here to execute against the now-live nodes. */
+				fresh.querySelectorAll('script').forEach(function (old) {
+					var copy = document.createElement('script');
+					if (old.src) { copy.src = old.src; } else { copy.textContent = old.textContent; }
+					if (old.type) { copy.type = old.type; }
+					old.replaceWith(copy);
+				});
+
 				/* Joomla widgets in the fresh region bound their listeners to
 				   the OLD nodes at page load. Core scripts (the modal-select
-				   type field, chosen selects, etc.) re-initialise whatever is
-				   inside the target of a joomla:updated event — the same signal
-				   Joomla fires after its own AJAX form swaps. Without this the
-				   type field's own Select/Clear buttons are dead after a swap. */
+				   type field, chosen selects, showon, the media picker)
+				   re-initialise whatever is inside the target of a
+				   joomla:updated event — the same signal Joomla fires after its
+				   own AJAX form swaps. Without this the type field's own
+				   Select/Clear buttons are dead after a swap. The core scripts
+				   themselves are pre-loaded on this page (see the view) so they
+				   exist to answer the event whatever type is swapped in. */
 				fresh.dispatchEvent(new CustomEvent('joomla:updated', { bubbles: true }));
 
 				/* The calendar and validator do not listen for joomla:updated,

--- a/admin/tmpl/cwmserver/edit.php
+++ b/admin/tmpl/cwmserver/edit.php
@@ -46,9 +46,14 @@ $wa->useScript('keepalive')
 		   hidden value input SHARE the name jform[type], so
 		   elements['jform[type]'] is a RadioNodeList and assigning .value to
 		   it does nothing at all. Write to the hidden value input by id, and
-		   mirror it into the visible one so the choice shows immediately. */
+		   mirror it into the visible one so the choice shows immediately.
+		   Remember the prior pair: if the fetch fails we must put them back,
+		   or the form would carry the new type over the old type's fields —
+		   a Save then would persist a mismatched server. */
 		var typeValue = document.getElementById('jform_type_id');
 		var typeTitle = document.getElementById('jform_type');
+		var prevValue = typeValue ? typeValue.value : '';
+		var prevTitle = typeTitle ? typeTitle.value : '';
 		if (typeValue) { typeValue.value = type; }
 		if (typeTitle) { typeTitle.value = type; }
 
@@ -118,6 +123,11 @@ $wa->useScript('keepalive')
 				}
 			})
 			.catch(function () {
+				/* Only the newest request restores; a superseded one must not
+				   clobber a later choice that already applied. */
+				if (seq !== Joomla.cwmSwapServerType._seq) { return; }
+				if (typeValue) { typeValue.value = prevValue; }
+				if (typeTitle) { typeTitle.value = prevTitle; }
 				Joomla.renderMessages({ error: ['" . $this->escape(Text::_('JBS_SVR_TYPE_SWAP_FAILED')) . "'] });
 			});
 	};

--- a/admin/tmpl/cwmserver/edit.php
+++ b/admin/tmpl/cwmserver/edit.php
@@ -14,10 +14,10 @@
 
 // phpcs:enable PSR1.Files.SideEffects
 
-use CWM\Component\Proclaim\Administrator\Helper\Cwmhelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Session\Session;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 
@@ -29,26 +29,102 @@ $input = $app->getInput();
 
 $isNewRecord = ((int)$this->item->id === 0 && empty($this->item->type));
 
-// Addons declare their own advanced settings; see the simplemode checks below.
-$simple = Cwmhelper::getSimpleView();
-
 $wa = $this->getDocument()->getWebAssetManager();
 $wa->useScript('keepalive')
     ->useScript('form.validate')
     ->addInlineScript(
         "
+	/* Choosing a type must not submit the form: whatever was typed would ride
+	   through a submit never meant to save, and every failure would become a
+	   navigation. Instead the tab region is re-rendered server-side for the
+	   chosen type and swapped in place, then the typed values are put back. */
+	Joomla.cwmSwapServerType = function (type) {
+		var form   = document.getElementById('item-form');
+		var region = document.getElementById('server-tabset-region');
+
+		/* The type field is a ModalSelectField: a readonly title input and a
+		   hidden value input SHARE the name jform[type], so
+		   elements['jform[type]'] is a RadioNodeList and assigning .value to
+		   it does nothing at all. Write to the hidden value input by id, and
+		   mirror it into the visible one so the choice shows immediately. */
+		var typeValue = document.getElementById('jform_type_id');
+		var typeTitle = document.getElementById('jform_type');
+		if (typeValue) { typeValue.value = type; }
+		if (typeTitle) { typeTitle.value = type; }
+
+		if (!region) {
+			/* No region to swap (unexpected markup): fall back to the old
+			   round trip rather than doing nothing. */
+			Joomla.submitform('cwmserver.setType', form);
+			return;
+		}
+
+		var snapshot = new FormData(form);
+		var recordId = (document.getElementById('jform_id') || { value: 0 }).value || 0;
+		var url = 'index.php?option=com_proclaim&task=cwmserver.typeFields&tmpl=component'
+			+ '&type=' + encodeURIComponent(type) + '&id=' + encodeURIComponent(recordId)
+			+ '&' + " . json_encode(Session::getFormToken()) . " + '=1';
+
+		/* A quick change of mind can start a second swap before the first
+		   response lands; whichever arrives LAST would win regardless of
+		   which was chosen last. Only the newest request may apply. */
+		var seq = Joomla.cwmSwapServerType._seq = (Joomla.cwmSwapServerType._seq || 0) + 1;
+
+		fetch(url, { headers: { 'X-Requested-With': 'XMLHttpRequest' } })
+			.then(function (response) {
+				if (!response.ok) { throw new Error(String(response.status)); }
+				return response.text();
+			})
+			.then(function (html) {
+				if (seq !== Joomla.cwmSwapServerType._seq) { return; }
+				var tpl = document.createElement('template');
+				tpl.innerHTML = html.trim();
+				var fresh = tpl.content.getElementById('server-tabset-region');
+				if (!fresh) { throw new Error('fragment'); }
+				/* Re-query rather than trust the closure: an earlier swap may
+				   have replaced the node this call started from. */
+				document.getElementById('server-tabset-region').replaceWith(fresh);
+
+				/* Put back what was typed. The swap replaced empty fields with
+				   empty fields; the person's work is the part that must not be
+				   collateral. Old addon fields simply no longer exist. */
+				snapshot.forEach(function (value, name) {
+					if (name === 'task' || name === 'return' || name.indexOf('jform[type]') === 0) { return; }
+					var el = form.elements[name];
+					if (!el) { return; }
+					if (el instanceof RadioNodeList) { el.value = value; return; }
+					if (el.type === 'file') { return; }
+					if (el.type === 'checkbox') { el.checked = value === '1' || value === 'on'; return; }
+					el.value = value;
+				});
+
+				/* Joomla widgets in the fresh region bound their listeners to
+				   the OLD nodes at page load. Core scripts (the modal-select
+				   type field, chosen selects, etc.) re-initialise whatever is
+				   inside the target of a joomla:updated event — the same signal
+				   Joomla fires after its own AJAX form swaps. Without this the
+				   type field's own Select/Clear buttons are dead after a swap. */
+				fresh.dispatchEvent(new CustomEvent('joomla:updated', { bubbles: true }));
+
+				/* The calendar and validator do not listen for joomla:updated,
+				   so they are re-attached by hand. */
+				if (window.JoomlaCalendar) {
+					fresh.querySelectorAll('.field-calendar').forEach(function (el) {
+						try { JoomlaCalendar.init(el); } catch (e) { /* cosmetic */ }
+					});
+				}
+				if (document.formvalidator && document.formvalidator.attachToForm) {
+					try { document.formvalidator.attachToForm(form); } catch (e) { /* cosmetic */ }
+				}
+			})
+			.catch(function () {
+				Joomla.renderMessages({ error: ['" . $this->escape(Text::_('JBS_SVR_TYPE_SWAP_FAILED')) . "'] });
+			});
+	};
+
 	Joomla.submitbutton = function (task, type) {
 		if (task == 'cwmserver.setType') {
-			/* The type field is a ModalSelectField: a readonly title input and a
-			   hidden value input SHARE the name jform[type], so
-			   elements['jform[type]'] is a RadioNodeList and assigning .value to
-			   it does nothing at all. Write to the hidden value input by id, and
-			   mirror it into the visible one so the choice shows immediately. */
-			var typeValue = document.getElementById('jform_type_id');
-			var typeTitle = document.getElementById('jform_type');
-			if (typeValue) { typeValue.value = type; }
-			if (typeTitle) { typeTitle.value = type; }
-			Joomla.submitform(task, document.getElementById('item-form'));
+			Joomla.cwmSwapServerType(type);
 		} else if (task == 'cwmserver.cancel') {
 			Joomla.submitform(task, document.getElementById('item-form'));
 		} else if (task == 'cwmserver.apply' || document.formvalidator.isValid(document.getElementById('item-form'))) {
@@ -61,8 +137,10 @@ $wa->useScript('keepalive')
 
 if ($isNewRecord) {
     $wa->addInlineScript(
-        "document.addEventListener('DOMContentLoaded', function () {
-            var btn = document.getElementById('jform_type_select');
+        "window.addEventListener('load', function () {
+            var value = document.getElementById('jform_type_id');
+            var wrap  = value && value.closest('.js-modal-content-select-field');
+            var btn   = wrap && wrap.querySelector('[data-button-action=\"select\"]');
             if (btn) { btn.click(); }
         });"
     );
@@ -76,137 +154,7 @@ echo Route::_('index.php?option=com_proclaim&view=cwmserver&layout=' . $currentL
         echo Text::_('JBS_CMN_' . ((int)$this->item->id === 0 ? 'NEW' : 'EDIT'), true); ?>"
       class="form-validate" enctype="multipart/form-data">
     <div class="main-card">
-        <?php
-        echo HTMLHelper::_('uitab.startTabSet', 'myTab', ['active' => 'general']); ?>
-
-        <?php
-        echo HTMLHelper::_('uitab.addTab', 'myTab', 'general', Text::_('JBS_CMN_GENERAL')); ?>
-        <div class="row">
-            <div class="col-lg-9">
-                <?php echo $this->form->renderField('server_name'); ?>
-                <?php echo $this->form->renderField('type'); ?>
-            </div>
-            <div class="col-lg-3">
-                <?php
-                echo LayoutHelper::render('joomla.edit.publishingdata', $this); ?>
-                <?php
-                if (isset($this->item->id, $this->item->addon)) : ?>
-                    <span style="font-weight:bold">
-                        <?php
-                        echo $this->escape($this->item->addon->name); ?>
-                    </span>
-                    <?php
-                endif; ?>
-                <?php
-                if (isset($this->item->id, $this->item->addon)) : ?>
-                    <p><?php
-                        echo $this->escape($this->item->addon->description); ?></p>
-                    <?php
-                endif; ?>
-                <?php
-                echo LayoutHelper::render('joomla.edit.global', $this); ?>
-            </div>
-        </div>
-        <?php
-        echo HTMLHelper::_('uitab.endTab'); ?>
-        <?php
-        if ($this->server_form !== null) : ?>
-            <?php
-            if ($this->server_form->getFieldsets('params')) : ?>
-                <?php
-                foreach ($this->server_form->getFieldsets('params') as $fieldsets) : ?>
-                    <?php
-                    // An addon marks its own advanced settings with
-                    // simplemode="hide", on the fieldset or on a single field.
-                    // The addon knows what is advanced about itself, and a
-                    // third-party one gets the same treatment without this
-                    // template knowing it exists.
-                    if ($simple->mode && ($fieldsets->simplemode ?? '') === 'hide') {
-                        continue;
-                    }
-                    ?>
-                    <?php
-                    echo HTMLHelper::_(
-                        'uitab.addTab',
-                        'myTab',
-                        strtolower(Text::_($fieldsets->label)),
-                        Text::_($fieldsets->label)
-                    ); ?>
-                    <div class="row">
-                        <div class="col-12 col-lg-12">
-                            <?php
-                            foreach ($this->server_form->getFieldset($fieldsets->name) as $field) : ?>
-                                <?php
-                                if ($simple->mode && $field->getAttribute('simplemode') === 'hide') {
-                                    continue;
-                                }
-                                ?>
-                                <?php echo $field->renderField(); ?>
-                                <?php
-                            endforeach; ?>
-                        </div>
-                    </div>
-                    <?php
-                    echo HTMLHelper::_('uitab.endTab'); ?>
-                    <?php
-                endforeach; ?>
-                <?php
-            endif; ?>
-            <?php
-            if ($this->server_form->getFieldsets('media')) : ?>
-                <?php
-                echo HTMLHelper::_('uitab.addTab', 'myTab', 'media_settings', Text::_('JBS_SVR_MEDIA_SETTINGS')); ?>
-                <div class="row">
-                    <div class="accordion" id="accordionlist">
-                        <?php
-                foreach ($this->server_form->getFieldsets('media') as $name => $fieldset) : ?>
-                    <?php
-                    if ($simple->mode && ($fieldset->simplemode ?? '') === 'hide') {
-                        continue;
-                    }
-                    ?>
-                            <div class="accordion-item">
-                                <h2 class="accordion-heading" id="<?php
-                        echo Text::_($name) ?>">
-                                    <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse"
-                                            data-bs-target="#collapse<?php
-                                    echo Text::_($name) ?>" aria-expanded="false"
-                                            aria-controls="collapse<?php
-                                    echo Text::_($name) ?>">
-                                        <?php
-                                echo Text::_($fieldset->label); ?>
-                                    </button>
-                                </h2>
-                                <div id="collapse<?php
-                        echo Text::_($name) ?>" class="accordion-collapse collapse"
-                                     aria-labelledby="heading<?php
-                                echo $name; ?>"
-                                     data-bs-parent="#accordionlist">
-                                    <div class="accordion-body">
-                                        <?php
-                                foreach ($this->server_form->getFieldset($name) as $field) : ?>
-                                    <?php
-                                    if ($simple->mode && $field->getAttribute('simplemode') === 'hide') {
-                                        continue;
-                                    }
-                                    ?>
-                                            <?php echo $field->renderField(); ?>
-                                            <?php
-                                endforeach; ?>
-                                    </div>
-                                </div>
-                            </div>
-                            <?php
-                endforeach; ?>
-                    </div>
-                </div>
-                <?php
-                echo HTMLHelper::_('uitab.endTab'); ?>
-                <?php
-            endif; ?>
-            <?php
-        endif; ?>
-        <?php echo LayoutHelper::render('edit.permissions_tab', ['form' => $this->form, 'canDo' => $this->canDo, 'tabName' => 'myTab']); ?>
+        <?php echo $this->loadTemplate('tabset'); ?>
         <input type="hidden" name="task" value=""/>
         <input type="hidden" name="return" value="<?php
         echo $input->getBase64('return'); ?>"/>

--- a/admin/tmpl/cwmserver/edit_tabset.php
+++ b/admin/tmpl/cwmserver/edit_tabset.php
@@ -1,0 +1,162 @@
+<?php
+
+/**
+ * The server edit form's tab set — every tab, including the addon-driven ones.
+ *
+ * A sub-template on purpose: the in-place type swap re-renders exactly this
+ * region (layout=tabs serves it alone), so the picker never has to submit the
+ * form to show a different addon's fields. One source for both renders, or the
+ * two drift.
+ *
+ * @package    Proclaim.Admin
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+
+// phpcs:enable PSR1.Files.SideEffects
+
+use CWM\Component\Proclaim\Administrator\Helper\Cwmhelper;
+use Joomla\CMS\HTML\HTMLHelper;
+use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
+
+$simple = Cwmhelper::getSimpleView();
+?>
+<div id="server-tabset-region">
+        <?php
+        echo HTMLHelper::_('uitab.startTabSet', 'myTab', ['active' => 'general']); ?>
+
+        <?php
+        echo HTMLHelper::_('uitab.addTab', 'myTab', 'general', Text::_('JBS_CMN_GENERAL')); ?>
+        <div class="row">
+            <div class="col-lg-9">
+                <?php echo $this->form->renderField('server_name'); ?>
+                <?php echo $this->form->renderField('type'); ?>
+            </div>
+            <div class="col-lg-3">
+                <?php
+                echo LayoutHelper::render('joomla.edit.publishingdata', $this); ?>
+                <?php
+                if (isset($this->item->id, $this->item->addon)) : ?>
+                    <span style="font-weight:bold">
+                        <?php
+                        echo $this->escape($this->item->addon->name); ?>
+                    </span>
+                    <?php
+                endif; ?>
+                <?php
+                if (isset($this->item->id, $this->item->addon)) : ?>
+                    <p><?php
+                        echo $this->escape($this->item->addon->description); ?></p>
+                    <?php
+                endif; ?>
+                <?php
+                echo LayoutHelper::render('joomla.edit.global', $this); ?>
+            </div>
+        </div>
+        <?php
+        echo HTMLHelper::_('uitab.endTab'); ?>
+        <?php
+        if ($this->server_form !== null) : ?>
+            <?php
+            if ($this->server_form->getFieldsets('params')) : ?>
+                <?php
+                foreach ($this->server_form->getFieldsets('params') as $fieldsets) : ?>
+                    <?php
+                    // An addon marks its own advanced settings with
+                    // simplemode="hide", on the fieldset or on a single field.
+                    // The addon knows what is advanced about itself, and a
+                    // third-party one gets the same treatment without this
+                    // template knowing it exists.
+                    if ($simple->mode && ($fieldsets->simplemode ?? '') === 'hide') {
+                        continue;
+                    }
+                    ?>
+                    <?php
+                    echo HTMLHelper::_(
+                        'uitab.addTab',
+                        'myTab',
+                        strtolower(Text::_($fieldsets->label)),
+                        Text::_($fieldsets->label)
+                    ); ?>
+                    <div class="row">
+                        <div class="col-12 col-lg-12">
+                            <?php
+                            foreach ($this->server_form->getFieldset($fieldsets->name) as $field) : ?>
+                                <?php
+                                if ($simple->mode && $field->getAttribute('simplemode') === 'hide') {
+                                    continue;
+                                }
+                                ?>
+                                <?php echo $field->renderField(); ?>
+                                <?php
+                            endforeach; ?>
+                        </div>
+                    </div>
+                    <?php
+                    echo HTMLHelper::_('uitab.endTab'); ?>
+                    <?php
+                endforeach; ?>
+                <?php
+            endif; ?>
+            <?php
+            if ($this->server_form->getFieldsets('media')) : ?>
+                <?php
+                echo HTMLHelper::_('uitab.addTab', 'myTab', 'media_settings', Text::_('JBS_SVR_MEDIA_SETTINGS')); ?>
+                <div class="row">
+                    <div class="accordion" id="accordionlist">
+                        <?php
+                foreach ($this->server_form->getFieldsets('media') as $name => $fieldset) : ?>
+                    <?php
+                    if ($simple->mode && ($fieldset->simplemode ?? '') === 'hide') {
+                        continue;
+                    }
+                    ?>
+                            <div class="accordion-item">
+                                <h2 class="accordion-heading" id="<?php
+                        echo Text::_($name) ?>">
+                                    <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse"
+                                            data-bs-target="#collapse<?php
+                                    echo Text::_($name) ?>" aria-expanded="false"
+                                            aria-controls="collapse<?php
+                                    echo Text::_($name) ?>">
+                                        <?php
+                                echo Text::_($fieldset->label); ?>
+                                    </button>
+                                </h2>
+                                <div id="collapse<?php
+                        echo Text::_($name) ?>" class="accordion-collapse collapse"
+                                     aria-labelledby="heading<?php
+                                echo $name; ?>"
+                                     data-bs-parent="#accordionlist">
+                                    <div class="accordion-body">
+                                        <?php
+                                foreach ($this->server_form->getFieldset($name) as $field) : ?>
+                                    <?php
+                                    if ($simple->mode && $field->getAttribute('simplemode') === 'hide') {
+                                        continue;
+                                    }
+                                    ?>
+                                            <?php echo $field->renderField(); ?>
+                                            <?php
+                                endforeach; ?>
+                                    </div>
+                                </div>
+                            </div>
+                            <?php
+                endforeach; ?>
+                    </div>
+                </div>
+                <?php
+                echo HTMLHelper::_('uitab.endTab'); ?>
+                <?php
+            endif; ?>
+            <?php
+        endif; ?>
+        <?php echo LayoutHelper::render('edit.permissions_tab', ['form' => $this->form, 'canDo' => $this->canDo, 'tabName' => 'myTab']); ?>
+        <?php echo HTMLHelper::_('uitab.endTabSet'); ?>
+</div>

--- a/admin/tmpl/cwmserver/tabs.php
+++ b/admin/tmpl/cwmserver/tabs.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * Fragment render: the tab-set region alone, for the in-place type swap.
+ *
+ * Served by cwmserver.typeFields with tmpl=component, consumed by the edit
+ * screen's picker, which replaces #server-tabset-region with this output.
+ *
+ * @package    Proclaim.Admin
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+
+// phpcs:enable PSR1.Files.SideEffects
+
+require __DIR__ . '/edit_tabset.php';

--- a/admin/tmpl/cwmservers/types.php
+++ b/admin/tmpl/cwmservers/types.php
@@ -37,7 +37,7 @@ $wa->useScript('core')
             // so it must close the dialog itself — the parent no longer navigates.
             var choose = function (type) {
                 window.parent.Joomla.submitbutton('cwmserver.setType', type);
-                var dialog = window.parent.document.querySelector('joomla-dialog');
+                var dialog = window.parent.document.querySelector('joomla-dialog.joomla-dialog-content-select-field');
                 if (dialog && dialog.close) { dialog.close(); }
             };
             document.addEventListener('click', function(e) {

--- a/admin/tmpl/cwmservers/types.php
+++ b/admin/tmpl/cwmservers/types.php
@@ -33,21 +33,24 @@ $wa->useScript('core')
     ->useStyle('com_proclaim.server-types')
     ->addInlineScript(
         "document.addEventListener('DOMContentLoaded', function() {
+            // This layout renders inside a joomla-dialog iframe (ModalSelectField),
+            // so it must close the dialog itself — the parent no longer navigates.
+            var choose = function (type) {
+                window.parent.Joomla.submitbutton('cwmserver.setType', type);
+                var dialog = window.parent.document.querySelector('joomla-dialog');
+                if (dialog && dialog.close) { dialog.close(); }
+            };
             document.addEventListener('click', function(e) {
                 var card = e.target.closest('[data-type-payload]');
                 if (!card) return;
-                var type = card.getAttribute('data-type-payload');
-                window.parent.Joomla.submitbutton('cwmserver.setType', type);
-                window.parent.Joomla.Modal.getCurrent().close();
+                choose(card.getAttribute('data-type-payload'));
             });
             document.addEventListener('keydown', function(e) {
                 if (e.key !== 'Enter' && e.key !== ' ') return;
                 var card = e.target.closest('[data-type-payload]');
                 if (!card) return;
                 e.preventDefault();
-                var type = card.getAttribute('data-type-payload');
-                window.parent.Joomla.submitbutton('cwmserver.setType', type);
-                window.parent.Joomla.Modal.getCurrent().close();
+                choose(card.getAttribute('data-type-payload'));
             });
         });"
     );

--- a/tests/e2e/admin/servertype.spec.js
+++ b/tests/e2e/admin/servertype.spec.js
@@ -55,35 +55,54 @@ test('picking a type swaps fields in place and preserves typed work', async ({ p
     expect(page.url()).toContain('cwmserver');
 });
 
+test('a failed swap rolls back and says nothing changed', async ({ page }) => {
+    await page.goto(ADD, { waitUntil: 'domcontentloaded' });
+    await expect(page.locator('joomla-dialog iframe')).toBeVisible();
+
+    // Make the type fetch fail outright.
+    await page.route('**/*cwmserver.typeFields*', (r) => r.fulfill({ status: 500, body: '' }));
+
+    const frame = page.frameLocator('joomla-dialog iframe');
+    await frame.locator('[data-type-payload="local"]').first().click();
+    await expect(page.locator('joomla-dialog')).toHaveCount(0);
+
+    // The message admits nothing changed — and nothing did: the optimistic
+    // type is rolled back and no addon fields were injected, so a Save here
+    // cannot persist a half-applied server (#2037 failure contract).
+    await expect(page.locator('#system-message-container')).toContainText(/could not be loaded/i);
+    await expect(page.locator('#jform_type_id')).toHaveValue('');
+    await expect(page.locator('#server-tabset-region [name="jform[params][delete_files]"]')).toHaveCount(0);
+});
+
 test('the chosen type persists on save, then clean up', async ({ page }) => {
     await page.goto(ADD, { waitUntil: 'domcontentloaded' });
     await expect(page.locator('joomla-dialog iframe')).toBeVisible();
     await pickType(page, 'local', 'jform[params][delete_files]');
     await page.fill('#jform_server_name', NAME);
     await page.evaluate(() => Joomla.submitbutton('cwmserver.save'));
-    await page.waitForLoadState('domcontentloaded');
-    await expect(page.locator('joomla-alert')).toContainText(/saved/i);
+    await page.waitForLoadState('networkidle');
+    await expect(page.locator('#system-message-container')).toContainText(/saved/i);
 
     // Reopen the saved record: the type reached the model via the swap path.
-    await page.goto(LIST + '&filter[search]=' + encodeURIComponent(NAME), { waitUntil: 'domcontentloaded' });
+    await page.goto(LIST + "&filter[published]=&filter[search]=" + encodeURIComponent(NAME), { waitUntil: 'networkidle' });
     await page.locator('tbody tr', { hasText: NAME }).locator('a[href*="cwmserver.edit"]').first().click();
-    await page.waitForLoadState('domcontentloaded');
+    await page.waitForLoadState('networkidle');
     await expect(page.locator('#jform_type_id')).toHaveValue('local');
     await page.evaluate(() => Joomla.submitbutton('cwmserver.cancel'));
-    await page.waitForLoadState('domcontentloaded');
+    await page.waitForLoadState('networkidle');
 
     // Trash, then delete permanently, so the fixture never outlives the test.
-    const row = page.locator('tbody tr', { hasText: NAME });
-    await row.locator('input[name="cid[]"]').check();
+    await page.goto(LIST + "&filter[published]=&filter[search]=" + encodeURIComponent(NAME), { waitUntil: 'networkidle' });
+    await page.locator('tbody tr', { hasText: NAME }).locator('input[name="cid[]"]').check();
     await page.evaluate(() => Joomla.submitform('cwmservers.trash', document.getElementById('adminForm')));
-    await page.waitForLoadState('domcontentloaded');
+    await page.waitForLoadState('networkidle');
 
-    await page.goto(LIST + '&filter[published]=-2&filter[search]=' + encodeURIComponent(NAME), { waitUntil: 'domcontentloaded' });
+    await page.goto(LIST + '&filter[published]=-2&filter[search]=' + encodeURIComponent(NAME), { waitUntil: 'networkidle' });
     await page.locator('tbody tr', { hasText: NAME }).locator('input[name="cid[]"]').check();
     page.once('dialog', (d) => d.accept());
     await page.evaluate(() => Joomla.submitform('cwmservers.delete', document.getElementById('adminForm')));
-    await page.waitForLoadState('domcontentloaded');
+    await page.waitForLoadState('networkidle');
 
-    await page.goto(LIST + '&filter[published]=-2&filter[search]=' + encodeURIComponent(NAME), { waitUntil: 'domcontentloaded' });
+    await page.goto(LIST + '&filter[published]=-2&filter[search]=' + encodeURIComponent(NAME), { waitUntil: 'networkidle' });
     await expect(page.locator('tbody tr', { hasText: NAME })).toHaveCount(0);
 });

--- a/tests/e2e/admin/servertype.spec.js
+++ b/tests/e2e/admin/servertype.spec.js
@@ -1,0 +1,89 @@
+// Choosing a server type must not submit the form or reload the page (#2037).
+//
+// The old flow submitted the whole edit form to change type: typed work rode
+// through a submit never meant to save, and every failure became a navigation.
+// The picker now fetches the re-rendered tab region and swaps it in place.
+// These tests drive the real picker end to end — the window sentinel below
+// dies on any navigation, so they fail against the old round-trip flow.
+const { test, expect } = require('@playwright/test');
+
+const ADD = '/administrator/index.php?option=com_proclaim&task=cwmserver.add';
+const LIST = '/administrator/index.php?option=com_proclaim&view=cwmservers';
+const NAME = 'zz e2e type-swap fixture';
+
+const FIELD = '.js-modal-content-select-field:has(#jform_type_id)';
+
+// Pick a type from the open dialog and wait for its addon fields to actually
+// land in the region — "region visible" alone is the empty shell before the
+// fetch resolves.
+async function pickType(page, key, addonField) {
+    const frame = page.frameLocator('joomla-dialog iframe');
+    await frame.locator(`[data-type-payload="${key}"]`).first().click();
+    await expect(page.locator('joomla-dialog')).toHaveCount(0);
+    await expect(page.locator(`#server-tabset-region [name="${addonField}"]`).first()).toBeAttached();
+    await expect(page.locator('#jform_type_id')).toHaveValue(key);
+}
+
+// Once a value is set the "Select" button hides behind "Clear"; changing the
+// choice is Clear-then-Select, exactly as a person would.
+async function reopenPicker(page) {
+    await page.locator(`${FIELD} [data-button-action="clear"]`).click();
+    await page.locator(`${FIELD} [data-button-action="select"]`).click();
+    await expect(page.locator('joomla-dialog iframe')).toBeVisible();
+}
+
+test('picking a type swaps fields in place and preserves typed work', async ({ page }) => {
+    await page.goto(ADD, { waitUntil: 'domcontentloaded' });
+    await page.evaluate(() => { window.__noReload = 'held'; });
+
+    // A new record auto-opens the picker.
+    await expect(page.locator('joomla-dialog iframe')).toBeVisible();
+    await pickType(page, 'local', 'jform[params][delete_files]');
+
+    await page.fill('#jform_server_name', NAME);
+
+    // Change of mind: reopen and pick a different type.
+    await reopenPicker(page);
+    await pickType(page, 'youtube', 'jform[params][api_key]');
+
+    // The typed name survived the swap…
+    await expect(page.locator('#jform_server_name')).toHaveValue(NAME);
+    // …the hidden value the model reads carries the choice…
+    await expect(page.locator('#jform_type_id')).toHaveValue('youtube');
+    // …and the page never navigated. This is the whole point of #2037.
+    expect(await page.evaluate(() => window.__noReload)).toBe('held');
+    expect(page.url()).toContain('cwmserver');
+});
+
+test('the chosen type persists on save, then clean up', async ({ page }) => {
+    await page.goto(ADD, { waitUntil: 'domcontentloaded' });
+    await expect(page.locator('joomla-dialog iframe')).toBeVisible();
+    await pickType(page, 'local', 'jform[params][delete_files]');
+    await page.fill('#jform_server_name', NAME);
+    await page.evaluate(() => Joomla.submitbutton('cwmserver.save'));
+    await page.waitForLoadState('domcontentloaded');
+    await expect(page.locator('joomla-alert')).toContainText(/saved/i);
+
+    // Reopen the saved record: the type reached the model via the swap path.
+    await page.goto(LIST + '&filter[search]=' + encodeURIComponent(NAME), { waitUntil: 'domcontentloaded' });
+    await page.locator('tbody tr', { hasText: NAME }).locator('a[href*="cwmserver.edit"]').first().click();
+    await page.waitForLoadState('domcontentloaded');
+    await expect(page.locator('#jform_type_id')).toHaveValue('local');
+    await page.evaluate(() => Joomla.submitbutton('cwmserver.cancel'));
+    await page.waitForLoadState('domcontentloaded');
+
+    // Trash, then delete permanently, so the fixture never outlives the test.
+    const row = page.locator('tbody tr', { hasText: NAME });
+    await row.locator('input[name="cid[]"]').check();
+    await page.evaluate(() => Joomla.submitform('cwmservers.trash', document.getElementById('adminForm')));
+    await page.waitForLoadState('domcontentloaded');
+
+    await page.goto(LIST + '&filter[published]=-2&filter[search]=' + encodeURIComponent(NAME), { waitUntil: 'domcontentloaded' });
+    await page.locator('tbody tr', { hasText: NAME }).locator('input[name="cid[]"]').check();
+    page.once('dialog', (d) => d.accept());
+    await page.evaluate(() => Joomla.submitform('cwmservers.delete', document.getElementById('adminForm')));
+    await page.waitForLoadState('domcontentloaded');
+
+    await page.goto(LIST + '&filter[published]=-2&filter[search]=' + encodeURIComponent(NAME), { waitUntil: 'domcontentloaded' });
+    await expect(page.locator('tbody tr', { hasText: NAME })).toHaveCount(0);
+});

--- a/tests/e2e/admin/servertype.spec.js
+++ b/tests/e2e/admin/servertype.spec.js
@@ -32,6 +32,20 @@ async function reopenPicker(page) {
     await expect(page.locator('joomla-dialog iframe')).toBeVisible();
 }
 
+// A form POST (trash/delete) navigates on its own; a goto fired into that
+// in-flight navigation aborts. Retry the goto until it settles.
+async function gotoList(page, url) {
+    for (let i = 0; i < 3; i++) {
+        try {
+            await page.goto(url, { waitUntil: 'domcontentloaded' });
+            return;
+        } catch (e) {
+            if (i === 2) throw e;
+            await page.waitForTimeout(500);
+        }
+    }
+}
+
 test('picking a type swaps fields in place and preserves typed work', async ({ page }) => {
     await page.goto(ADD, { waitUntil: 'domcontentloaded' });
     await page.evaluate(() => { window.__noReload = 'held'; });
@@ -74,6 +88,42 @@ test('a failed swap rolls back and says nothing changed', async ({ page }) => {
     await expect(page.locator('#server-tabset-region [name="jform[params][delete_files]"]')).toHaveCount(0);
 });
 
+test("a swapped-in type's own field widgets come alive without a reload", async ({ page }) => {
+    // showon (conditional fields), the media picker and an addon's inline
+    // script (YouTube's Test API) all bind at page load. After an in-place
+    // swap they must work anyway — see the view's asset pre-load and the
+    // fragment script re-execution.
+    await page.goto(ADD, { waitUntil: 'domcontentloaded' });
+    await expect(page.locator('joomla-dialog iframe')).toBeVisible();
+    await pickType(page, 'local', 'jform[params][delete_files]');
+    await reopenPicker(page);
+    await pickType(page, 'youtube', 'jform[params][api_key]');
+
+    const showon = '#server-tabset-region [data-showon]';
+    const groupDisplay = () => page.evaluate((s) => {
+        const el = document.querySelector(s);
+        return getComputedStyle(el.closest('.control-group') || el).display;
+    }, showon);
+
+    // A live-event field is hidden until stream_mode is 'direct' — proof
+    // showon.js loaded and wired the swapped-in markup.
+    await expect.poll(groupDisplay).toBe('none');
+    await page.evaluate(() => {
+        const sm = document.querySelector('#server-tabset-region [name="jform[params][stream_mode]"]');
+        sm.value = 'direct';
+        sm.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+    await expect.poll(groupDisplay).not.toBe('none');
+
+    // The media picker script is present for the swapped-in media field.
+    expect(await page.evaluate(() => [...document.scripts].some((s) => /joomla-field-media/.test(s.src)))).toBe(true);
+
+    // The addon's inline Test API handler was re-executed: clicking it writes
+    // into its result area instead of doing nothing.
+    await page.evaluate(() => document.getElementById('youtube-test-api-btn').click());
+    await expect(page.locator('#youtube-test-api-result')).not.toBeEmpty();
+});
+
 test('the chosen type persists on save, then clean up', async ({ page }) => {
     await page.goto(ADD, { waitUntil: 'domcontentloaded' });
     await expect(page.locator('joomla-dialog iframe')).toBeVisible();
@@ -84,7 +134,7 @@ test('the chosen type persists on save, then clean up', async ({ page }) => {
     await expect(page.locator('#system-message-container')).toContainText(/saved/i);
 
     // Reopen the saved record: the type reached the model via the swap path.
-    await page.goto(LIST + "&filter[published]=&filter[search]=" + encodeURIComponent(NAME), { waitUntil: 'networkidle' });
+    await gotoList(page, LIST + "&filter[published]=&filter[search]=" + encodeURIComponent(NAME));
     await page.locator('tbody tr', { hasText: NAME }).locator('a[href*="cwmserver.edit"]').first().click();
     await page.waitForLoadState('networkidle');
     await expect(page.locator('#jform_type_id')).toHaveValue('local');
@@ -92,17 +142,17 @@ test('the chosen type persists on save, then clean up', async ({ page }) => {
     await page.waitForLoadState('networkidle');
 
     // Trash, then delete permanently, so the fixture never outlives the test.
-    await page.goto(LIST + "&filter[published]=&filter[search]=" + encodeURIComponent(NAME), { waitUntil: 'networkidle' });
+    await gotoList(page, LIST + "&filter[published]=&filter[search]=" + encodeURIComponent(NAME));
     await page.locator('tbody tr', { hasText: NAME }).locator('input[name="cid[]"]').check();
     await page.evaluate(() => Joomla.submitform('cwmservers.trash', document.getElementById('adminForm')));
     await page.waitForLoadState('networkidle');
 
-    await page.goto(LIST + '&filter[published]=-2&filter[search]=' + encodeURIComponent(NAME), { waitUntil: 'networkidle' });
+    await gotoList(page, LIST + '&filter[published]=-2&filter[search]=' + encodeURIComponent(NAME));
     await page.locator('tbody tr', { hasText: NAME }).locator('input[name="cid[]"]').check();
     page.once('dialog', (d) => d.accept());
     await page.evaluate(() => Joomla.submitform('cwmservers.delete', document.getElementById('adminForm')));
     await page.waitForLoadState('networkidle');
 
-    await page.goto(LIST + '&filter[published]=-2&filter[search]=' + encodeURIComponent(NAME), { waitUntil: 'networkidle' });
+    await gotoList(page, LIST + '&filter[published]=-2&filter[search]=' + encodeURIComponent(NAME));
     await expect(page.locator('tbody tr', { hasText: NAME })).toHaveCount(0);
 });


### PR DESCRIPTION
Closes #2037.

Picking a server type used to submit the whole edit form: whatever was typed rode through a submit never meant to save, and every failure became a page navigation (that is how #2035 presented). Choosing a type now re-renders the tab region server-side for that type and swaps it in place — no submit, no reload, nothing lost, and a failure is a message beside the field.

## How it works
- A new bare `tabs` layout and a `cwmserver.typeFields` endpoint render the same tabset the full edit view does (shared `edit_tabset.php` partial), using the **same user state** the save path reads — so #2036's "type reaches the model on save" guarantee is untouched.
- The picker (`types.php`) closes its own dialog and calls the in-place swap.
- After the swap a `joomla:updated` event re-wires core widgets in the fresh region (without it the type field's own Select/Clear buttons were dead).
- Also adds the long-missing `uitab.endTabSet`.

## Edge cases handled (from review)
- **Failed swap rolls back.** The chosen key is written optimistically so the choice shows at once; if the fetch fails, the field is restored and the message honestly says nothing changed — a Save can't then persist a half-applied server.
- **A swapped-in type's widgets stay live.** `showon` (conditional fields) and the media picker are pre-loaded on the edit view, and an addon's own inline field scripts (e.g. YouTube's Test API) are re-executed after the swap — otherwise they were inert until save-and-reopen.
- **Concurrent swaps.** A request-sequence guard means a quick change of mind can't let an older response win.

## Testing
Permanent Playwright coverage (`tests/e2e/admin/servertype.spec.js`, admin-j6) drives the real picker end to end on j6-dev:
1. in-place swap preserving typed work with **no navigation** (a window sentinel proves it),
2. a failed swap rolling back and saying nothing changed,
3. a swapped-in type's showon / media / inline-script widgets coming alive,
4. the chosen type persisting through a full save round trip.

Full PHP suite green (3605 tests), lint + comment-lint clean, PhpStorm inspection clean on the changed PHP.

## Follow-up (not this PR)
`typeFields`/`setType` leave `com_proclaim.edit.cwmserver.type` in user state; navigating away via the menu after a swap can make the next server open with a stale type. Pre-existing `setType` behaviour — worth a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)