### PR TITLE
refactor(query): whitelist ORDER BY columns instead of a no-op escape (#1994 phase 3)

### DIFF
--- a/admin/src/Helper/CwmdbHelper.php
+++ b/admin/src/Helper/CwmdbHelper.php
@@ -21,6 +21,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Log\Log;
 use Joomla\Database\DatabaseInterface;
+use Joomla\Database\DatabaseQuery;
 use Joomla\Filesystem\Folder;
 
 /**
@@ -680,5 +681,61 @@ class CwmdbHelper
                 }
             }
         }
+    }
+
+    /**
+     * Apply a whitelisted ORDER BY to a list query.
+     *
+     * `ListModel::populateState()` already validates the incoming list ordering
+     * against the model's `filter_fields` and the direction against ASC/DESC,
+     * but the `$db->escape()` the call sites used to wrap these in did nothing:
+     * `escape()` is for a quoted string context, and an ORDER BY value is not
+     * quoted. This re-checks the column against the same whitelist at the point
+     * of use and quotes it as the identifier it is, so the guarantee is visible
+     * where the SQL is built.
+     *
+     * The column may arrive either as a plain name or, from `list.fullordering`,
+     * as a combined "column direction" pair — that form is split apart. An empty
+     * direction is preserved as ASC, which is exactly what the old unquoted
+     * `ORDER BY col ` left MySQL to apply implicitly; the caller keeps ownership
+     * of the *absent*-state default by passing it to `getState()` as it always
+     * has.
+     *
+     * @param   DatabaseQuery  $query          The query to add the ORDER BY to.
+     * @param   string[]       $filterFields   The model's whitelist of orderable columns.
+     * @param   ?string        $column         The requested order column (or a "column direction" pair).
+     * @param   ?string        $direction      The requested direction, or '' when $column carries it.
+     * @param   string         $defaultColumn  The column to fall back to when the request is not whitelisted.
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public static function orderByWhitelisted(
+        DatabaseQuery $query,
+        array $filterFields,
+        ?string $column,
+        ?string $direction,
+        string $defaultColumn
+    ): void {
+        $column    = trim((string) $column);
+        $direction = strtoupper(trim((string) $direction));
+
+        // A list.fullordering value arrives as "column direction" with no
+        // separate direction argument; pull the two apart before validating.
+        if ($direction === '' && preg_match('/^(.+?)\s+(ASC|DESC)$/i', $column, $matches)) {
+            $column    = trim($matches[1]);
+            $direction = strtoupper($matches[2]);
+        }
+
+        if (!\in_array($column, $filterFields, true)) {
+            $column = $defaultColumn;
+        }
+
+        // Anything that is not an explicit DESC becomes ASC — including the
+        // empty direction, which is what the previous unquoted clause did.
+        $direction = \in_array($direction, ['ASC', 'DESC'], true) ? $direction : 'ASC';
+
+        $query->order($query->quoteName($column) . ' ' . $direction);
     }
 }

--- a/admin/src/Model/CwmcommentsModel.php
+++ b/admin/src/Model/CwmcommentsModel.php
@@ -16,6 +16,7 @@ namespace CWM\Component\Proclaim\Administrator\Model;
 
 // phpcs:enable PSR1.Files.SideEffects
 
+use CWM\Component\Proclaim\Administrator\Helper\CwmdbHelper;
 use CWM\Component\Proclaim\Administrator\Helper\CwmlocationHelper;
 use CWM\Component\Proclaim\Administrator\Helper\CwmscriptureHelper;
 use Joomla\CMS\Factory;
@@ -306,9 +307,13 @@ class CwmcommentsModel extends ListModel
             ->join('LEFT', $db->quoteName('#__users', 'uc') . ' ON ' . $db->quoteName('uc.id') . ' = ' . $db->quoteName('comment.checked_out'));
 
         // Add the list ordering clause
-        $orderCol  = $this->state->get('list.ordering', 'study.studytitle');
-        $orderDirn = $this->state->get('list.direction', 'asc');
-        $query->order($db->escape($orderCol) . ' ' . $db->escape($orderDirn));
+        CwmdbHelper::orderByWhitelisted(
+            $query,
+            $this->filter_fields,
+            $this->state->get('list.ordering'),
+            $this->state->get('list.direction', 'asc'),
+            'study.studytitle'
+        );
 
         return $query;
     }

--- a/admin/src/Model/CwmlocationsModel.php
+++ b/admin/src/Model/CwmlocationsModel.php
@@ -16,6 +16,7 @@ namespace CWM\Component\Proclaim\Administrator\Model;
 
 // phpcs:enable PSR1.Files.SideEffects
 
+use CWM\Component\Proclaim\Administrator\Helper\CwmdbHelper;
 use CWM\Component\Proclaim\Administrator\Helper\CwmlocationHelper;
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
@@ -329,9 +330,13 @@ class CwmlocationsModel extends ListModel
         }
 
         // Add the list ordering clause
-        $orderCol  = $this->state->get('list.ordering', 'location.id');
-        $orderDirn = $this->state->get('list.direction', 'desc');
-        $query->order($db->escape($orderCol) . ' ' . $db->escape($orderDirn));
+        CwmdbHelper::orderByWhitelisted(
+            $query,
+            $this->filter_fields,
+            $this->state->get('list.ordering'),
+            $this->state->get('list.direction', 'desc'),
+            'location.id'
+        );
 
         return $query;
     }

--- a/admin/src/Model/CwmmediafilesModel.php
+++ b/admin/src/Model/CwmmediafilesModel.php
@@ -406,9 +406,14 @@ class CwmmediafilesModel extends ListModel
                 ->bind(':language', $language);
         }
 
-        // Add the list ordering clause
+        // Add the list ordering clause. list.ordering is whitelisted against
+        // filter_fields in populateState(), so $orderCol is a known column;
+        // the remaps below turn a few of them into the composite sort the grid
+        // needs, built only from constants. Only an explicit DESC stays
+        // descending — an empty direction sorts ascending, as the previous
+        // unquoted clause did implicitly.
         $orderCol  = $this->state->get('list.ordering', 'mediafile.createdate');
-        $orderDirn = $this->state->get('list.direction', 'DESC');
+        $orderDirn = strtoupper((string) $this->state->get('list.direction', 'DESC')) === 'DESC' ? 'DESC' : 'ASC';
 
         // Sqlsrv change
         if ($orderCol === 'study_id') {
@@ -431,7 +436,7 @@ class CwmmediafilesModel extends ListModel
             $orderCol = 'mediafile.study_id ' . $orderDirn . ', mediafile.ordering';
         }
 
-        $query->order($db->escape($orderCol) . ' ' . $db->escape($orderDirn));
+        $query->order($orderCol . ' ' . $orderDirn);
 
         return $query;
     }

--- a/admin/src/Model/CwmmessagesModel.php
+++ b/admin/src/Model/CwmmessagesModel.php
@@ -16,6 +16,7 @@ namespace CWM\Component\Proclaim\Administrator\Model;
 
 // phpcs:enable PSR1.Files.SideEffects
 
+use CWM\Component\Proclaim\Administrator\Helper\CwmdbHelper;
 use CWM\Component\Proclaim\Administrator\Helper\CwmDebug;
 use CWM\Component\Proclaim\Administrator\Helper\CwmlocationHelper;
 use Joomla\CMS\Component\ComponentHelper;
@@ -366,9 +367,13 @@ class CwmmessagesModel extends ListModel
         }
 
         // Add the list ordering clause
-        $orderCol  = $this->state->get('list.ordering', 'study.studydate');
-        $orderDirn = $this->state->get('list.direction', 'DESC');
-        $query->order($db->escape($orderCol) . ' ' . $db->escape($orderDirn));
+        CwmdbHelper::orderByWhitelisted(
+            $query,
+            $this->filter_fields,
+            $this->state->get('list.ordering'),
+            $this->state->get('list.direction', 'DESC'),
+            'study.studydate'
+        );
 
         CwmDebug::logQuery('messages.getListQuery', $query);
 

--- a/admin/src/Model/CwmmessagetypesModel.php
+++ b/admin/src/Model/CwmmessagetypesModel.php
@@ -16,6 +16,7 @@ namespace CWM\Component\Proclaim\Administrator\Model;
 
 // phpcs:enable PSR1.Files.SideEffects
 
+use CWM\Component\Proclaim\Administrator\Helper\CwmdbHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\MVC\Model\ListModel;
 use Joomla\Database\DatabaseInterface;
@@ -250,9 +251,13 @@ class CwmmessagetypesModel extends ListModel
         }
 
         // Add the list ordering clause.
-        $orderCol  = $this->state->get('list.ordering', 'messagetype.message_type');
-        $orderDirn = $this->state->get('list.direction', 'ASC');
-        $query->order($db->escape($orderCol) . ' ' . $db->escape($orderDirn));
+        CwmdbHelper::orderByWhitelisted(
+            $query,
+            $this->filter_fields,
+            $this->state->get('list.ordering'),
+            $this->state->get('list.direction', 'ASC'),
+            'messagetype.message_type'
+        );
 
         return $query;
     }

--- a/admin/src/Model/CwmplaylistsModel.php
+++ b/admin/src/Model/CwmplaylistsModel.php
@@ -16,6 +16,7 @@ namespace CWM\Component\Proclaim\Administrator\Model;
 
 // phpcs:enable PSR1.Files.SideEffects
 
+use CWM\Component\Proclaim\Administrator\Helper\CwmdbHelper;
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\MVC\Model\ListModel;
@@ -233,9 +234,13 @@ class CwmplaylistsModel extends ListModel
         }
 
         // Add the list ordering clause.
-        $orderCol  = $this->state->get('list.ordering', 'playlist.ordering');
-        $orderDirn = $this->state->get('list.direction', 'asc');
-        $query->order($db->escape($orderCol) . ' ' . $db->escape($orderDirn));
+        CwmdbHelper::orderByWhitelisted(
+            $query,
+            $this->filter_fields,
+            $this->state->get('list.ordering'),
+            $this->state->get('list.direction', 'asc'),
+            'playlist.ordering'
+        );
 
         return $query;
     }

--- a/admin/src/Model/CwmpodcastsModel.php
+++ b/admin/src/Model/CwmpodcastsModel.php
@@ -16,6 +16,7 @@ namespace CWM\Component\Proclaim\Administrator\Model;
 
 // phpcs:enable PSR1.Files.SideEffects
 
+use CWM\Component\Proclaim\Administrator\Helper\CwmdbHelper;
 use CWM\Component\Proclaim\Administrator\Helper\CwmlocationHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\MVC\Model\ListModel;
@@ -261,9 +262,13 @@ class CwmpodcastsModel extends ListModel
         }
 
         // Add the list ordering clause
-        $orderCol  = $this->state->get('list.ordering', 'podcast.id');
-        $orderDirn = $this->state->get('list.direction', 'desc');
-        $query->order($db->escape($orderCol) . ' ' . $db->escape($orderDirn));
+        CwmdbHelper::orderByWhitelisted(
+            $query,
+            $this->filter_fields,
+            $this->state->get('list.ordering'),
+            $this->state->get('list.direction', 'desc'),
+            'podcast.id'
+        );
 
         return $query;
     }

--- a/admin/src/Model/CwmseriesModel.php
+++ b/admin/src/Model/CwmseriesModel.php
@@ -16,6 +16,7 @@ namespace CWM\Component\Proclaim\Administrator\Model;
 
 // phpcs:enable PSR1.Files.SideEffects
 
+use CWM\Component\Proclaim\Administrator\Helper\CwmdbHelper;
 use CWM\Component\Proclaim\Administrator\Helper\CwmlocationHelper;
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
@@ -276,9 +277,13 @@ class CwmseriesModel extends ListModel
         }
 
         // Add the list ordering clause
-        $orderCol  = $this->state->get('list.ordering', 'series.series_text');
-        $orderDirn = $this->state->get('list.direction', 'asc');
-        $query->order($db->escape($orderCol) . ' ' . $db->escape($orderDirn));
+        CwmdbHelper::orderByWhitelisted(
+            $query,
+            $this->filter_fields,
+            $this->state->get('list.ordering'),
+            $this->state->get('list.direction', 'asc'),
+            'series.series_text'
+        );
 
         return $query;
     }

--- a/admin/src/Model/CwmteachersModel.php
+++ b/admin/src/Model/CwmteachersModel.php
@@ -16,6 +16,7 @@ namespace CWM\Component\Proclaim\Administrator\Model;
 
 // phpcs:enable PSR1.Files.SideEffects
 
+use CWM\Component\Proclaim\Administrator\Helper\CwmdbHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
 use Joomla\CMS\MVC\Model\ListModel;
@@ -207,9 +208,13 @@ class CwmteachersModel extends ListModel
         }
 
         // Add the list ordering clause
-        $orderCol  = $this->state->get('list.ordering', 'teacher.teachername');
-        $orderDirn = $this->state->get('list.direction', 'asc');
-        $query->order($db->escape($orderCol) . ' ' . $db->escape($orderDirn));
+        CwmdbHelper::orderByWhitelisted(
+            $query,
+            $this->filter_fields,
+            $this->state->get('list.ordering'),
+            $this->state->get('list.direction', 'asc'),
+            'teacher.teachername'
+        );
 
         return $query;
     }

--- a/admin/src/Model/CwmtemplatecodesModel.php
+++ b/admin/src/Model/CwmtemplatecodesModel.php
@@ -16,6 +16,7 @@ namespace CWM\Component\Proclaim\Administrator\Model;
 
 // phpcs:enable PSR1.Files.SideEffects
 
+use CWM\Component\Proclaim\Administrator\Helper\CwmdbHelper;
 use CWM\Component\Proclaim\Administrator\Helper\CwmlocationHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\MVC\Model\ListModel;
@@ -191,9 +192,13 @@ class CwmtemplatecodesModel extends ListModel
         }
 
         // Add the list ordering clause
-        $orderCol  = $this->state->get('list.ordering', 'templatecode.filename');
-        $orderDirn = $this->state->get('list.direction', 'ASC');
-        $query->order($db->quoteName($orderCol) . ' ' . $db->escape($orderDirn));
+        CwmdbHelper::orderByWhitelisted(
+            $query,
+            $this->filter_fields,
+            $this->state->get('list.ordering'),
+            $this->state->get('list.direction', 'ASC'),
+            'templatecode.filename'
+        );
 
         return $query;
     }

--- a/admin/src/Model/CwmtemplatesModel.php
+++ b/admin/src/Model/CwmtemplatesModel.php
@@ -16,6 +16,7 @@ namespace CWM\Component\Proclaim\Administrator\Model;
 
 // phpcs:enable PSR1.Files.SideEffects
 
+use CWM\Component\Proclaim\Administrator\Helper\CwmdbHelper;
 use CWM\Component\Proclaim\Administrator\Helper\CwmlocationHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\MVC\Model\ListModel;
@@ -223,9 +224,13 @@ class CwmtemplatesModel extends ListModel
         }
 
         // Add the list ordering clause
-        $orderCol  = $this->state->get('list.ordering', 'template.id');
-        $orderDirn = $this->state->get('list.direction', 'ASC');
-        $query->order($db->escape($orderCol) . ' ' . $db->escape($orderDirn));
+        CwmdbHelper::orderByWhitelisted(
+            $query,
+            $this->filter_fields,
+            $this->state->get('list.ordering'),
+            $this->state->get('list.direction', 'ASC'),
+            'template.id'
+        );
 
         return $query;
     }

--- a/admin/src/Model/CwmtopicsModel.php
+++ b/admin/src/Model/CwmtopicsModel.php
@@ -16,6 +16,7 @@ namespace CWM\Component\Proclaim\Administrator\Model;
 
 // phpcs:enable PSR1.Files.SideEffects
 
+use CWM\Component\Proclaim\Administrator\Helper\CwmdbHelper;
 use CWM\Component\Proclaim\Administrator\Helper\Cwmtranslated;
 use Joomla\CMS\Factory;
 use Joomla\CMS\MVC\Model\ListModel;
@@ -181,9 +182,13 @@ class CwmtopicsModel extends ListModel
         }
 
         // Add the list ordering clause
-        $orderCol  = $this->state->get('list.ordering', 'topic.topic_text');
-        $orderDirn = $this->state->get('list.direction', 'asc');
-        $query->order($db->escape($orderCol) . ' ' . $db->escape($orderDirn));
+        CwmdbHelper::orderByWhitelisted(
+            $query,
+            $this->filter_fields,
+            $this->state->get('list.ordering'),
+            $this->state->get('list.direction', 'asc'),
+            'topic.topic_text'
+        );
 
         return $query;
     }

--- a/site/src/Model/CwmseriesdisplaysModel.php
+++ b/site/src/Model/CwmseriesdisplaysModel.php
@@ -11,6 +11,7 @@
 
 namespace CWM\Component\Proclaim\Site\Model;
 
+use CWM\Component\Proclaim\Administrator\Helper\CwmdbHelper;
 use CWM\Component\Proclaim\Administrator\Helper\Cwmparams;
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Date\Date;
@@ -348,7 +349,7 @@ class CwmseriesdisplaysModel extends ListModel
             $orderDirn = $this->getState('list.direction', 'DESC');
         }
 
-        $query->order($db->escape($orderCol) . ' ' . $db->escape($orderDirn));
+        CwmdbHelper::orderByWhitelisted($query, $this->filter_fields, $orderCol, $orderDirn, 'se.series_text');
 
 
         return $query;

--- a/site/src/Model/CwmseriespodcastlistModel.php
+++ b/site/src/Model/CwmseriespodcastlistModel.php
@@ -16,6 +16,7 @@ namespace CWM\Component\Proclaim\Site\Model;
 
 // phpcs:enable PSR1.Files.SideEffects
 
+use CWM\Component\Proclaim\Administrator\Helper\CwmdbHelper;
 use CWM\Component\Proclaim\Administrator\Helper\Cwmparams;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Helper\TagsHelper;
@@ -257,9 +258,12 @@ class CwmseriespodcastlistModel extends ListModel
         }
 
         // Add the list ordering clause.
-        $query->order(
-            $db->escape($this->getState('list.ordering', 'a.id')) . ' ' .
-            $db->escape($this->getState('list.direction', 'ASC'))
+        CwmdbHelper::orderByWhitelisted(
+            $query,
+            $this->filter_fields,
+            $this->getState('list.ordering'),
+            $this->getState('list.direction', 'ASC'),
+            'a.id'
         );
 
         return $query;

--- a/site/src/Model/CwmsermonsModel.php
+++ b/site/src/Model/CwmsermonsModel.php
@@ -11,6 +11,7 @@
 
 namespace CWM\Component\Proclaim\Site\Model;
 
+use CWM\Component\Proclaim\Administrator\Helper\CwmdbHelper;
 use CWM\Component\Proclaim\Administrator\Helper\CwmDebug;
 use CWM\Component\Proclaim\Administrator\Helper\CwmlocationHelper;
 use CWM\Component\Proclaim\Administrator\Helper\Cwmparams;
@@ -718,7 +719,7 @@ class CwmsermonsModel extends ListModel
             $orderDirn = $this->getState('list.direction', 'DESC');
         }
 
-        $query->order($db->escape($orderCol) . ' ' . $db->escape($orderDirn));
+        CwmdbHelper::orderByWhitelisted($query, $this->filter_fields, $orderCol, $orderDirn, 'study.studydate');
 
         CwmDebug::logQuery('sermons.getListQuery', $query);
 

--- a/tests/unit/Query/OrderByWhitelistTest.php
+++ b/tests/unit/Query/OrderByWhitelistTest.php
@@ -1,0 +1,123 @@
+<?php
+
+/**
+ * Pins CwmdbHelper::orderByWhitelisted() — the whitelist the 14 list models
+ * lean on for their ORDER BY.
+ *
+ * @package    Proclaim.UnitTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ */
+
+namespace CWM\Component\Proclaim\Tests\Unit\Query;
+
+use CWM\Component\Proclaim\Administrator\Helper\CwmdbHelper;
+use CWM\Component\Proclaim\Tests\ProclaimTestCase;
+use Joomla\CMS\Factory;
+use Joomla\Database\DatabaseInterface;
+use PHPUnit\Framework\Attributes\TestDox;
+
+/**
+ * The `$db->escape()` these call sites used to wrap the ordering in did nothing
+ * — escape() is for a quoted string context, and an ORDER BY value is not
+ * quoted. The helper replaced it with a real whitelist + quoteName. The case
+ * that a green suite and a happy-path click both miss is an empty direction:
+ * core permits `list.direction = ''`, Registry returns it verbatim (not the
+ * default), and the old unquoted clause let MySQL apply ASC implicitly. A naive
+ * ASC/DESC check would fall back to the model's default instead and silently
+ * flip every descending list. This test nails that case by name.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class OrderByWhitelistTest extends ProclaimTestCase
+{
+    /**
+     * The columns a model would list in filter_fields.
+     *
+     * @var string[]
+     */
+    private const FIELDS = ['study.studydate', 'teacher.teachername', 'ordering'];
+
+    /**
+     * Build a query, apply the helper, return the normalised ORDER BY tail.
+     *
+     * @param   ?string  $column     The requested order column.
+     * @param   ?string  $direction  The requested direction.
+     * @param   string   $default    The fallback column.
+     *
+     * @return  string
+     */
+    private function orderOf(?string $column, ?string $direction, string $default = 'study.studydate'): string
+    {
+        $db    = Factory::getContainer()->get(DatabaseInterface::class);
+        $query = $db->createQuery()->select('1')->from('dual');
+
+        CwmdbHelper::orderByWhitelisted($query, self::FIELDS, $column, $direction, $default);
+
+        $sql = preg_replace('/\s+/', ' ', (string) $query);
+
+        return trim(substr($sql, strpos($sql, 'ORDER BY')));
+    }
+
+    /**
+     * The column quoted as the driver quotes identifiers.
+     *
+     * @param   string  $column  Column name.
+     *
+     * @return  string
+     */
+    private function q(string $column): string
+    {
+        return Factory::getContainer()->get(DatabaseInterface::class)->createQuery()->quoteName($column);
+    }
+
+    #[TestDox('A whitelisted column with DESC is quoted and kept descending')]
+    public function testWhitelistedColumnDesc(): void
+    {
+        $this->assertSame('ORDER BY ' . $this->q('teacher.teachername') . ' DESC', $this->orderOf('teacher.teachername', 'DESC'));
+    }
+
+    #[TestDox("An empty direction sorts ASC, not the model's default — the flip guard")]
+    public function testEmptyDirectionIsAscendingNotDefault(): void
+    {
+        // The discriminator: a descending-default list whose session holds an
+        // empty direction must still render ASC, exactly as the old unquoted
+        // clause left it implicitly.
+        $this->assertSame('ORDER BY ' . $this->q('study.studydate') . ' ASC', $this->orderOf('study.studydate', ''));
+    }
+
+    #[TestDox('A lowercase direction is honoured')]
+    public function testLowercaseDirection(): void
+    {
+        $this->assertSame('ORDER BY ' . $this->q('ordering') . ' ASC', $this->orderOf('ordering', 'asc'));
+        $this->assertSame('ORDER BY ' . $this->q('ordering') . ' DESC', $this->orderOf('ordering', 'desc'));
+    }
+
+    #[TestDox('A column not on the whitelist falls back to the default column')]
+    public function testNonWhitelistedColumnFallsBack(): void
+    {
+        $this->assertSame('ORDER BY ' . $this->q('study.studydate') . ' DESC', $this->orderOf("study.id); DROP TABLE x --", 'DESC'));
+    }
+
+    #[TestDox('A null column and null direction give the default column, ASC')]
+    public function testNullsGiveDefaults(): void
+    {
+        $this->assertSame('ORDER BY ' . $this->q('study.studydate') . ' ASC', $this->orderOf(null, null));
+    }
+
+    #[TestDox('A combined "column direction" pair (list.fullordering) is split and validated')]
+    public function testCompoundFullorderingIsSplit(): void
+    {
+        // list.fullordering arrives as one string with no separate direction.
+        $this->assertSame('ORDER BY ' . $this->q('teacher.teachername') . ' DESC', $this->orderOf('teacher.teachername DESC', ''));
+        // …and the column half is still whitelisted.
+        $this->assertSame('ORDER BY ' . $this->q('study.studydate') . ' ASC', $this->orderOf('bogus.column ASC', ''));
+    }
+
+    #[TestDox('A garbage direction becomes ASC rather than reaching the SQL')]
+    public function testGarbageDirectionIsNeutralised(): void
+    {
+        $this->assertSame('ORDER BY ' . $this->q('ordering') . ' ASC', $this->orderOf('ordering', 'DESC; DROP TABLE x'));
+    }
+}


### PR DESCRIPTION
Phase 3 of #1994.

Fifteen list models built their ORDER BY as `->order($db->escape($orderCol) . ' ' . $db->escape($orderDirn))`. `escape()` is for a **quoted string** context; an ORDER BY value is unquoted, so it did nothing. The real safety lives upstream — core's `ListModel::populateState()` whitelists `list.ordering` against `filter_fields` and `list.direction` against ASC/DESC — but it was invisible at the call site.

## Change
- New `CwmdbHelper::orderByWhitelisted()` re-checks the column against the model's `filter_fields` at the point of use, quotes it as the identifier it is (`quoteName`), and sanitises the direction. It also splits a combined `list.fullordering` "column direction" pair — a live path: core stores `list.fullordering` (the `setState('list.' . $name, $value)` line), and `CwmseriesdisplaysModel`/`CwmsermonsModel` read it directly.
- 14 sites call it. `CwmmediafilesModel` keeps its composite-sort remaps (which build the ORDER BY from constants) and only drops the no-op `escape()` and sanitises the direction — remap branches unchanged, byte for byte.

## The subtle bug this had to avoid
An **empty** direction is preserved as **ASC**. Core explicitly permits `list.direction = ''` (the `direction` case only overrides a *truthy* invalid value), `Registry::get()` returns it verbatim (not the default), and the old unquoted clause let MySQL apply ASC implicitly. A naive ASC/DESC check would fall back to the model's default and **silently flip every descending list** — a user-visible regression in a "no behaviour change" PR.

## Testing
- `OrderByWhitelistTest` — 7 cases incl. the empty-direction discriminator, the fullordering split, and injection-shaped garbage.
- Full suite green (3612 tests, +7); 58 integration model tests execute the real `getListQuery()` against the DB.
- **End-to-end empty-direction proof** on the DESC-default locations list (j6-dev): `list[direction]=DESC` → row ids `[4,3,2,1]`; `list[direction]=` → `[1,2,3,4]` (ascending, not flipped to the DESC default). Confirms `''` both *arrives* from a request and maps to ASC.
- Affected admin lists (simple + mediafiles composite-remap) render with no error alerts.

## Phase 4 retired
`GROUP_CONCAT`/PostgreSQL (Phase 4) is **out of scope permanently**: #1857 closed NOT_PLANNED (MySQL/MariaDB only), so there is no non-MySQL target to port to. The #1994 plan should drop that phase.

## Remaining in #1994
Only Phase 1 (107 `quote($var)` → `bind()`, by file) is left after this. Not release-blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)