### PR TITLE
refactor(query): bind the schema.org helper's context/schema values (#1994 phase 1)

### DIFF
--- a/admin/src/Helper/CwmschemaorgHelper.php
+++ b/admin/src/Helper/CwmschemaorgHelper.php
@@ -21,6 +21,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Uri\Uri;
 use Joomla\Database\DatabaseInterface;
+use Joomla\Database\ParameterType;
 
 /**
  * Schema.org JSON-LD structured data helper.
@@ -501,7 +502,8 @@ class CwmschemaorgHelper
                 ->select('COUNT(*)')
                 ->from($db->quoteName('#__schemaorg'))
                 ->where($db->quoteName('itemId') . ' = ' . $itemId)
-                ->where($db->quoteName('context') . ' = ' . $db->quote($context));
+                ->where($db->quoteName('context') . ' = :context')
+                ->bind(':context', $context, ParameterType::STRING);
             $db->setQuery($query);
 
             return (int) $db->loadResult() > 0;
@@ -733,7 +735,8 @@ class CwmschemaorgHelper
             ->select($db->quoteName(['id', 'schema']))
             ->from($db->quoteName('#__schemaorg'))
             ->where($db->quoteName('itemId') . ' = ' . $sermonId)
-            ->where($db->quoteName('context') . ' = ' . $db->quote($context));
+            ->where($db->quoteName('context') . ' = :context')
+            ->bind(':context', $context, ParameterType::STRING);
         $row = $db->setQuery($query)->loadObject();
 
         if (!$row) {
@@ -991,8 +994,9 @@ class CwmschemaorgHelper
         $query = $db->createQuery()
             ->select([$db->quoteName('id'), $db->quoteName('itemId'), $db->quoteName('schema')])
             ->from($db->quoteName('#__schemaorg'))
-            ->where($db->quoteName('context') . ' = ' . $db->quote($context))
-            ->whereIn($db->quoteName('itemId'), $itemIds);
+            ->where($db->quoteName('context') . ' = :context')
+            ->whereIn($db->quoteName('itemId'), $itemIds)
+            ->bind(':context', $context, ParameterType::STRING);
 
         $rows = [];
 
@@ -1252,7 +1256,8 @@ class CwmschemaorgHelper
             ->select($db->quoteName('schema'))
             ->from($db->quoteName('#__schemaorg'))
             ->where($db->quoteName('itemId') . ' = ' . $itemId)
-            ->where($db->quoteName('context') . ' = ' . $db->quote($context));
+            ->where($db->quoteName('context') . ' = :context')
+            ->bind(':context', $context, ParameterType::STRING);
         return self::isSchemaManuallyEdited($db->setQuery($query)->loadResult());
     }
 
@@ -1658,7 +1663,8 @@ class CwmschemaorgHelper
                 ->select($db->quoteName('id'))
                 ->from($db->quoteName('#__schemaorg'))
                 ->where($db->quoteName('itemId') . ' = ' . $itemId)
-                ->where($db->quoteName('context') . ' = ' . $db->quote($context));
+                ->where($db->quoteName('context') . ' = :context')
+                ->bind(':context', $context, ParameterType::STRING);
             $existingId = (int) $db->setQuery($query)->loadResult();
         }
 
@@ -1671,10 +1677,13 @@ class CwmschemaorgHelper
             $query = $db->createQuery()
                 ->update($db->quoteName('#__schemaorg'))
                 ->set($db->quoteName('itemId') . ' = ' . $itemId)
-                ->set($db->quoteName('context') . ' = ' . $db->quote($context))
-                ->set($db->quoteName('schemaType') . ' = ' . $db->quote($schemaType))
-                ->set($db->quoteName('schema') . ' = ' . $db->quote($json))
-                ->where($db->quoteName('id') . ' = ' . $existingId);
+                ->set($db->quoteName('context') . ' = :context')
+                ->set($db->quoteName('schemaType') . ' = :schemaType')
+                ->set($db->quoteName('schema') . ' = :schema')
+                ->where($db->quoteName('id') . ' = ' . $existingId)
+                ->bind(':context', $context, ParameterType::STRING)
+                ->bind(':schemaType', $schemaType, ParameterType::STRING)
+                ->bind(':schema', $json, ParameterType::STRING);
         } else {
             $query = $db->createQuery()
                 ->insert($db->quoteName('#__schemaorg'))
@@ -1689,9 +1698,12 @@ class CwmschemaorgHelper
                 ->values(
                     implode(
                         ',',
-                        [$itemId, $db->quote($context), $db->quote($schemaType), $db->quote($json)]
+                        [(int) $itemId, ':context', ':schemaType', ':schema']
                     )
-                );
+                )
+                ->bind(':context', $context, ParameterType::STRING)
+                ->bind(':schemaType', $schemaType, ParameterType::STRING)
+                ->bind(':schema', $json, ParameterType::STRING);
         }
 
         $db->setQuery($query)->execute();

--- a/tests/integration/Admin/Helper/CwmschemaorgHelperIntegrationTest.php
+++ b/tests/integration/Admin/Helper/CwmschemaorgHelperIntegrationTest.php
@@ -248,6 +248,47 @@ class CwmschemaorgHelperIntegrationTest extends IntegrationTestCase
     }
 
     /**
+     * hasJoomlaSchema() swallows any query exception and returns false, so a
+     * broken context match is invisible unless a seeded row is asserted present.
+     *
+     * @return  void
+     */
+    #[TestDox('hasJoomlaSchema() finds a seeded row by its exact itemId and context, and only that pair')]
+    public function testHasJoomlaSchemaMatchesOnItemIdAndContext(): void
+    {
+        $itemId = $this->insertSchemaRow('com_proclaim.cwmmessage', 'CreativeWork', ['@type' => 'CreativeWork', 'name' => 'X']);
+
+        $this->assertTrue(CwmschemaorgHelper::hasJoomlaSchema($itemId, 'com_proclaim.cwmmessage'));
+        // A different context must not match the same itemId — proves the
+        // context predicate is actually applied, not swallowed.
+        $this->assertFalse(CwmschemaorgHelper::hasJoomlaSchema($itemId, 'com_proclaim.other'));
+        $this->assertFalse(CwmschemaorgHelper::hasJoomlaSchema($itemId + 777, 'com_proclaim.cwmmessage'));
+    }
+
+    /**
+     * ensureSermonAuthor() reads the sermon's schema row by (itemId, context)
+     * and, when it has no author, writes the linked teacher names in. A broken
+     * context match reads no row and silently leaves the schema untouched.
+     *
+     * @return  void
+     */
+    #[TestDox('ensureSermonAuthor() writes the linked teacher as author on an author-less sermon schema')]
+    public function testEnsureSermonAuthorFillsAuthorFromTeachers(): void
+    {
+        $context = 'com_proclaim.cwmmessage';
+        $itemId  = $this->insertSchemaRow($context, 'CreativeWork', ['@type' => 'CreativeWork', 'name' => 'A sermon']);
+
+        // ensureSermonAuthor() joins study_teachers -> teachers on the itemId.
+        $teacherId = $this->insertTeacher('Jane Preacher');
+        $this->insertStudyTeacher($itemId, $teacherId, 0);
+
+        CwmschemaorgHelper::ensureSermonAuthor($itemId);
+
+        $schema = $this->loadStoredSchema($itemId, $context);
+        $this->assertSame('Jane Preacher', $schema['author']['name'] ?? null);
+    }
+
+    /**
      * @param   int     $itemId   Item ID.
      * @param   string  $context  Context string.
      *


### PR DESCRIPTION
Continues #1994 Phase 1 (`quote($var)` → `bind()`, by file). `CwmschemaorgHelper` held **9** `$db->quote($var)` calls across five DB-touching methods — `hasJoomlaSchema`, `ensureSermonAuthor`, `prefetchSchemaRows`, `isManuallyEdited`, `upsertSchemaRow`. Each context/schemaType/schema value is now a bound parameter (`ParameterType::STRING`); the `(int)` itemId/existingId concatenations are left as-is, matching the phase-1 files merged in #2064.

## Coverage — every one of the 9 sites is exercised, and shown to be
- **`hasJoomlaSchema` / `ensureSermonAuthor`** had **no** executing coverage (⚠️ `hasJoomlaSchema` swallows query exceptions and returns false; its only caller `inject()` passes `itemId=0` and short-circuits before the query). Seeded integration tests for both were added **first** and shown to pass against the *unconverted* code, so they are real coverage, not a vacuous pass.
- **`isManuallyEdited`** — covered by the existing `invokeIsManuallyEdited()` test.
- **`upsertSchemaRow` (INSERT + UPDATE branches) and `prefetchSchemaRows`** — coverage **mutation-proven**: breaking each placeholder name one at a time (`:context` → `:contextBROKEN`, and the two other UPDATE `set()` binds, and prefetch's `:context`) makes `--filter CwmschemaorgHelper` error, so each site is genuinely reached (the UPDATE branch runs because `syncAll` re-syncs the dev DB's existing rows; INSERT via `syncOne` on a fresh item).

## Verified
28 schemaorg tests (unit + integration) green; 79 across the schemaorg plugin + message model; full suite green (3614, +2 seeded); PhpStorm inspection clean; a broken bind would throw at execute and fail these round-trip tests.

## #1994 Phase 1 remaining
Re-counted (not subtracted): **98** `quote($var)` across `admin/src`+`site/src`+`api/src`. Heaviest next is `admin/src/Lib/Cwmassets.php` (9). Not release-blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)