### PR TITLE
refactor(query): bind the asset-lib's convertible values (#1994 phase 1)

### DIFF
--- a/admin/src/Lib/Cwmassets.php
+++ b/admin/src/Lib/Cwmassets.php
@@ -504,9 +504,9 @@ class Cwmassets
             ->values(
                 (int) $rootId . ', 0, 0, 1, ' .
                 $db->quote('com_proclaim') . ', ' .
-                $db->quote('com_proclaim') . ', ' .
-                $db->quote($defaultRules)
-            );
+                $db->quote('com_proclaim') . ', :rules'
+            )
+            ->bind(':rules', $defaultRules, ParameterType::STRING);
 
         try {
             $db->setQuery($query);
@@ -973,6 +973,10 @@ class Cwmassets
      */
     public static function hasAnyDrift(DatabaseInterface $db, int $parentId): bool
     {
+        // Left interpolated on purpose: EMPTY_RULE_VARIANTS is a fixed
+        // constant, not input, so quoting it carries no escaping responsibility
+        // to move to a bind — and it feeds raw CASE/IN expressions below where a
+        // placeholder cannot go.
         $emptyQuoted = implode(
             ',',
             array_map(static fn ($v) => $db->quote($v), self::EMPTY_RULE_VARIANTS)
@@ -1035,14 +1039,16 @@ class Cwmassets
 
         foreach ($orphanMap as $prefix => $sourceTable) {
             try {
-                $query = $db->createQuery()
+                $namePattern = $prefix . '%';
+                $query       = $db->createQuery()
                     ->select('COUNT(*)')
                     ->from($db->quoteName('#__assets'))
-                    ->where($db->quoteName('name') . ' LIKE ' . $db->quote($prefix . '%'))
+                    ->where($db->quoteName('name') . ' LIKE :namePattern')
                     ->where(
                         'CAST(SUBSTRING(' . $db->quoteName('name') . ', ' . (\strlen($prefix) + 1) . ') AS UNSIGNED)'
                         . ' NOT IN (SELECT ' . $db->quoteName('id') . ' FROM ' . $db->quoteName($sourceTable) . ')'
-                    );
+                    )
+                    ->bind(':namePattern', $namePattern, ParameterType::STRING);
                 $db->setQuery($query);
 
                 if ((int) $db->loadResult() > 0) {
@@ -1076,6 +1082,10 @@ class Cwmassets
     public static function pruneEmptyAssetRows(DatabaseInterface $db): int
     {
         $deleted     = 0;
+        // Left interpolated on purpose: EMPTY_RULE_VARIANTS is a fixed
+        // constant, not input, so quoting it carries no escaping responsibility
+        // to move to a bind — and it feeds raw CASE/IN expressions below where a
+        // placeholder cannot go.
         $emptyQuoted = implode(
             ',',
             array_map(static fn ($v) => $db->quote($v), self::EMPTY_RULE_VARIANTS)
@@ -1338,7 +1348,8 @@ class Cwmassets
             $query = $db->createQuery()
                 ->select($db->quoteName(['id', 'rules']))
                 ->from($db->quoteName('#__assets'))
-                ->where($db->quoteName('name') . ' = ' . $db->quote($assetFullName));
+                ->where($db->quoteName('name') . ' = :assetName')
+                ->bind(':assetName', $assetFullName, ParameterType::STRING);
             $db->setQuery($query);
             $existing = $db->loadObject();
 
@@ -1407,8 +1418,9 @@ class Cwmassets
 
             $query = $db->createQuery()
                 ->update($db->quoteName('#__assets'))
-                ->set($db->quoteName('name') . ' = ' . $db->quote($assetFullName))
-                ->where($db->quoteName('id') . ' = ' . (int) $item->asset_id);
+                ->set($db->quoteName('name') . ' = :assetName')
+                ->where($db->quoteName('id') . ' = ' . (int) $item->asset_id)
+                ->bind(':assetName', $assetFullName, ParameterType::STRING);
             $db->setQuery($query);
             $db->execute();
 
@@ -1440,9 +1452,11 @@ class Cwmassets
 
         foreach ($assetMap as $prefix => $sourceTable) {
             try {
-                $query = $db->createQuery()
+                $namePattern = $prefix . '%';
+                $query       = $db->createQuery()
                     ->delete($db->quoteName('#__assets'))
-                    ->where($db->quoteName('name') . ' LIKE ' . $db->quote($prefix . '%'))
+                    ->where($db->quoteName('name') . ' LIKE :namePattern')
+                    ->bind(':namePattern', $namePattern, ParameterType::STRING)
                     ->where(
                         'CAST(SUBSTRING(' . $db->quoteName('name') . ', ' . (\strlen($prefix) + 1) . ') AS UNSIGNED)'
                         . ' NOT IN (SELECT ' . $db->quoteName('id') . ' FROM ' . $db->quoteName($sourceTable) . ')'
@@ -1572,6 +1586,10 @@ class Cwmassets
         $parentMap = self::sectionParentMap($db, $parentId);
         $status    = [];
 
+        // Left interpolated on purpose: EMPTY_RULE_VARIANTS is a fixed
+        // constant, not input, so quoting it carries no escaping responsibility
+        // to move to a bind — and it feeds raw CASE/IN expressions below where a
+        // placeholder cannot go.
         $emptyQuoted = implode(
             ',',
             array_map(static fn ($v) => $db->quote($v), self::EMPTY_RULE_VARIANTS)
@@ -1626,6 +1644,10 @@ class Cwmassets
             $prefixLen = \strlen($prefix) + 1;
 
             try {
+                // Raw string query (setQuery has no query object to bind on);
+                // the prefix stays quoted rather than bound. Moving it to a
+                // placeholder would mean rebuilding this LEFT JOIN + CAST as a
+                // builder query — out of scope for a value-binding pass.
                 $db->setQuery(
                     'SELECT COUNT(*) FROM ' . $db->quoteName('#__assets', 'a')
                     . ' LEFT JOIN ' . $db->quoteName($sourceTbl, 's')

--- a/tests/integration/Admin/Lib/CwmassetsOrphanCleanupTest.php
+++ b/tests/integration/Admin/Lib/CwmassetsOrphanCleanupTest.php
@@ -1,0 +1,124 @@
+<?php
+
+/**
+ * cleanOrphanedAssets() removes #__assets rows whose content record is gone.
+ *
+ * Its DELETE matches the asset name with a bound LIKE pattern built inside a
+ * foreach over the section prefixes -- the one genuinely new failure mode in
+ * the quote()->bind() conversion, since bind() takes its value by reference and
+ * the loop reassigns it. This exercises that path against a real orphan so a
+ * mis-bound pattern deletes nothing and fails here.
+ *
+ * @package    Proclaim.IntegrationTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ *
+ * @since __DEPLOY_VERSION__
+ */
+
+namespace CWM\Component\Proclaim\Tests\Integration\Admin\Lib;
+
+use CWM\Component\Proclaim\Administrator\Lib\Cwmassets;
+use CWM\Component\Proclaim\Tests\Integration\IntegrationTestCase;
+use Joomla\CMS\Factory;
+use Joomla\Database\DatabaseInterface;
+use PHPUnit\Framework\Attributes\TestDox;
+
+/**
+ * @since __DEPLOY_VERSION__
+ */
+class CwmassetsOrphanCleanupTest extends IntegrationTestCase
+{
+    /**
+     * @var DatabaseInterface|null
+     * @since __DEPLOY_VERSION__
+     */
+    private ?DatabaseInterface $db = null;
+
+    /**
+     * @return  void
+     * @since __DEPLOY_VERSION__
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (!\defined('PROCLAIM_TEST_DB_AVAILABLE') || !PROCLAIM_TEST_DB_AVAILABLE) {
+            $this->markTestSkipped('Database not available for integration tests');
+        }
+
+        $this->db = Factory::getContainer()->get(DatabaseInterface::class);
+        // Everything below is rolled back -- cleanOrphanedAssets() runs a real
+        // DELETE, and the dev DB may hold other orphans it would also remove.
+        $this->db->transactionStart(true);
+    }
+
+    /**
+     * @return  void
+     * @since __DEPLOY_VERSION__
+     */
+    protected function tearDown(): void
+    {
+        if ($this->db !== null) {
+            try {
+                $this->db->transactionRollback(true);
+            } catch (\Throwable) {
+                // Connection may have gone away -- nothing to roll back.
+            }
+        }
+
+        parent::tearDown();
+    }
+
+    /**
+     * @return  void
+     * @since __DEPLOY_VERSION__
+     */
+    #[TestDox('cleanOrphanedAssets() removes an asset whose location record no longer exists')]
+    public function testCleanOrphanedAssetsRemovesAnOrphanByBoundLikePattern(): void
+    {
+        Cwmassets::seedSections();
+        $parentId = Cwmassets::parentId();
+        $this->assertGreaterThan(0, $parentId, 'Expected a com_proclaim parent asset');
+
+        // A location id that cannot exist in #__bsms_locations.
+        $orphanId   = 990041;
+        $orphanName = 'com_proclaim.location.' . $orphanId;
+
+        $row            = new \stdClass();
+        $row->parent_id = $parentId;
+        $row->lft       = 0;
+        $row->rgt       = 0;
+        $row->level     = 2;
+        $row->name      = $orphanName;
+        $row->title     = $orphanName;
+        $row->rules     = '{}';
+        $this->db->insertObject('#__assets', $row, 'id');
+
+        $this->assertSame(1, $this->countAssetsNamed($orphanName), 'Fixture orphan should exist before cleanup');
+
+        $removed = Cwmassets::cleanOrphanedAssets($this->db);
+
+        $this->assertGreaterThanOrEqual(1, $removed, 'cleanOrphanedAssets() should report removing at least the seeded orphan');
+        $this->assertSame(0, $this->countAssetsNamed($orphanName), 'The seeded orphan must be gone after cleanup');
+    }
+
+    /**
+     * @param   string  $name  Exact asset name.
+     *
+     * @return  int  Number of #__assets rows with that name.
+     *
+     * @since __DEPLOY_VERSION__
+     */
+    private function countAssetsNamed(string $name): int
+    {
+        $query = $this->db->createQuery()
+            ->select('COUNT(*)')
+            ->from($this->db->quoteName('#__assets'))
+            ->where($this->db->quoteName('name') . ' = :name')
+            ->bind(':name', $name, \Joomla\Database\ParameterType::STRING);
+
+        return (int) $this->db->setQuery($query)->loadResult();
+    }
+}


### PR DESCRIPTION
Continues #1994 Phase 1 (`quote($var)` → `bind()`, by file). `Cwmassets` held **9** `$db->quote($var)` calls; **5 convert**, **4 stay** — and this file is where "Phase 1 = zero `quote($var)`" stops being the right definition (see the issue comment).

## Converted (5)
The parent-asset rules INSERT, `fixSingleRecord`'s name lookup + rename, and the orphan `LIKE` patterns in `hasAnyDrift` and `cleanOrphanedAssets`. Each now binds a genuine variable value (`ParameterType::STRING`).

## Deliberately left (4), each commented in place
- **3×** build a quoted list from `EMPTY_RULE_VARIANTS` — a **compile-time constant** threaded into raw `CASE`/`IN` expressions. No input path, and a placeholder can't go where those strings do. Binding is churn with a behaviour-change surface and zero benefit (the plan says Phase 1 "is not a security fix").
- **1×** is a raw `setQuery()` string (a `LEFT JOIN` + `CAST/SUBSTRING`) — no query object to bind on. Converting means rebuilding it as a builder query, a different change than a value-binding pass.

## Coverage — stated honestly
The two `LIKE` patterns bind **inside a `foreach` and reassign the bound variable each pass** — the one genuinely new failure mode here (`bind()` is by-reference). A new integration test (`CwmassetsOrphanCleanupTest`) seeds a real orphan asset, runs `cleanOrphanedAssets()`, and asserts removal; **mutation-confirmed** — breaking the placeholder makes it error. `hasAnyDrift` shares that loop-bind shape exactly.

The parent-asset INSERT and `fixSingleRecord`'s two sites are **converted but not covered by an executing test** — reaching them needs multi-table, branch-specific fixtures, and their bound values (`'com_proclaim.<section>.<int id>'`, a constant rules string) carry no input path. The pattern is identical to the verified sites; there is nothing new for a test to catch. Not claiming "verified" for those three.

## Verified
32 Cwmassets tests green, full suite green (3615), PhpStorm inspection clean, `lint`/`lint:comments` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)