### PR TITLE
refactor(query): bind the setup wizard's params/type/menu values (#1994 phase 1)

### DIFF
--- a/admin/src/Model/CwmsetupwizardModel.php
+++ b/admin/src/Model/CwmsetupwizardModel.php
@@ -18,6 +18,7 @@ use Joomla\CMS\Date\Date;
 use Joomla\CMS\Factory;
 use Joomla\CMS\MVC\Model\BaseDatabaseModel;
 use Joomla\Database\DatabaseInterface;
+use Joomla\Database\ParameterType;
 use Joomla\Registry\Registry;
 
 /**
@@ -59,11 +60,13 @@ class CwmsetupwizardModel extends BaseDatabaseModel
      */
     private function saveAdminParams(Registry $params): void
     {
-        $db    = Factory::getContainer()->get(DatabaseInterface::class);
-        $query = $db->createQuery()
+        $db         = Factory::getContainer()->get(DatabaseInterface::class);
+        $paramsJson = $params->toString();
+        $query      = $db->createQuery()
             ->update($db->quoteName('#__bsms_admin'))
-            ->set($db->quoteName('params') . ' = ' . $db->quote($params->toString()))
-            ->where($db->quoteName('id') . ' = 1');
+            ->set($db->quoteName('params') . ' = :params')
+            ->where($db->quoteName('id') . ' = 1')
+            ->bind(':params', $paramsJson, ParameterType::STRING);
         $db->setQuery($query);
         $db->execute();
     }
@@ -95,11 +98,13 @@ class CwmsetupwizardModel extends BaseDatabaseModel
         $params = new Registry($json ?: '{}');
         $params->set($key, $value);
 
-        $query = $db->createQuery()
+        $paramsJson = $params->toString();
+        $query      = $db->createQuery()
             ->update($db->quoteName('#__extensions'))
-            ->set($db->quoteName('params') . ' = ' . $db->quote($params->toString()))
+            ->set($db->quoteName('params') . ' = :params')
             ->where($db->quoteName('element') . ' = ' . $db->quote('com_proclaim'))
-            ->where($db->quoteName('type') . ' = ' . $db->quote('component'));
+            ->where($db->quoteName('type') . ' = ' . $db->quote('component'))
+            ->bind(':params', $paramsJson, ParameterType::STRING);
         $db->setQuery($query);
         $db->execute();
     }
@@ -374,8 +379,9 @@ class CwmsetupwizardModel extends BaseDatabaseModel
             $query = $db->createQuery()
                 ->select('COUNT(*)')
                 ->from($db->quoteName('#__bsms_servers'))
-                ->where($db->quoteName('type') . ' = ' . $db->quote($type))
-                ->where($db->quoteName('published') . ' >= 0');
+                ->where($db->quoteName('type') . ' = :type')
+                ->where($db->quoteName('published') . ' >= 0')
+                ->bind(':type', $type, ParameterType::STRING);
             $db->setQuery($query);
 
             if ((int) $db->loadResult() > 0) {
@@ -654,10 +660,12 @@ class CwmsetupwizardModel extends BaseDatabaseModel
             $task = $taskMap[$key];
 
             // Check if this task type already exists
-            $query = $db->createQuery()
+            $taskType = $task['type'];
+            $query    = $db->createQuery()
                 ->select('COUNT(*)')
                 ->from($db->quoteName('#__scheduler_tasks'))
-                ->where($db->quoteName('type') . ' = ' . $db->quote($task['type']));
+                ->where($db->quoteName('type') . ' = :type')
+                ->bind(':type', $taskType, ParameterType::STRING);
             $db->setQuery($query);
 
             if ((int) $db->loadResult() > 0) {
@@ -794,8 +802,9 @@ class CwmsetupwizardModel extends BaseDatabaseModel
         $query = $db->createQuery()
             ->select($db->quoteName('id'))
             ->from($db->quoteName('#__menu'))
-            ->where($db->quoteName('menutype') . ' = ' . $db->quote($menuType))
-            ->where($db->quoteName('level') . ' = 0');
+            ->where($db->quoteName('menutype') . ' = :menutype')
+            ->where($db->quoteName('level') . ' = 0')
+            ->bind(':menutype', $menuType, ParameterType::STRING);
         $db->setQuery($query, 0, 1);
         $parentId = (int) $db->loadResult() ?: 1;
 
@@ -972,10 +981,12 @@ class CwmsetupwizardModel extends BaseDatabaseModel
         $params->set('show_comments', !empty($data['enable_comments']) ? '1' : '');
 
         // Save
-        $query = $db->createQuery()
+        $paramsJson = $params->toString();
+        $query      = $db->createQuery()
             ->update($db->quoteName('#__bsms_templates'))
-            ->set($db->quoteName('params') . ' = ' . $db->quote($params->toString()))
-            ->where($db->quoteName('id') . ' = 1');
+            ->set($db->quoteName('params') . ' = :params')
+            ->where($db->quoteName('id') . ' = 1')
+            ->bind(':params', $paramsJson, ParameterType::STRING);
         $db->setQuery($query);
         $db->execute();
     }

--- a/tests/integration/Admin/Model/CwmsetupwizardModelBindTest.php
+++ b/tests/integration/Admin/Model/CwmsetupwizardModelBindTest.php
@@ -1,0 +1,115 @@
+<?php
+
+/**
+ * The setup wizard's default-creation loops build a bound COUNT before each
+ * insert. Both bind the row type inside a foreach — the failure mode a source-
+ * text test cannot see. These invoke the two private loops against the real DB
+ * so a mis-bound placeholder throws instead of passing silently.
+ *
+ * @package    Proclaim.IntegrationTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ *
+ * @since __DEPLOY_VERSION__
+ */
+
+namespace CWM\Component\Proclaim\Tests\Integration\Admin\Model;
+
+use CWM\Component\Proclaim\Administrator\Model\CwmsetupwizardModel;
+use CWM\Component\Proclaim\Tests\Integration\IntegrationTestCase;
+use Joomla\CMS\Factory;
+use Joomla\Database\DatabaseInterface;
+use PHPUnit\Framework\Attributes\TestDox;
+
+/**
+ * @since __DEPLOY_VERSION__
+ */
+class CwmsetupwizardModelBindTest extends IntegrationTestCase
+{
+    /**
+     * @var DatabaseInterface|null
+     * @since __DEPLOY_VERSION__
+     */
+    private ?DatabaseInterface $db = null;
+
+    /**
+     * @return  void
+     * @since __DEPLOY_VERSION__
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (!\defined('PROCLAIM_TEST_DB_AVAILABLE') || !PROCLAIM_TEST_DB_AVAILABLE) {
+            $this->markTestSkipped('Database not available for integration tests');
+        }
+
+        $this->db = Factory::getContainer()->get(DatabaseInterface::class);
+        // Both methods insert when nothing exists yet; roll it all back.
+        $this->db->transactionStart(true);
+    }
+
+    /**
+     * @return  void
+     * @since __DEPLOY_VERSION__
+     */
+    protected function tearDown(): void
+    {
+        if ($this->db !== null) {
+            try {
+                $this->db->transactionRollback(true);
+            } catch (\Throwable) {
+                // Connection may have gone away.
+            }
+        }
+
+        parent::tearDown();
+    }
+
+    /**
+     * Neither method touches $this, so an unconstructed instance is enough to
+     * reach the private loop.
+     *
+     * @param   string  $method  Private method name.
+     * @param   mixed   ...$args Arguments.
+     *
+     * @return  mixed
+     *
+     * @since __DEPLOY_VERSION__
+     */
+    private function invoke(string $method, ...$args): mixed
+    {
+        $model = (new \ReflectionClass(CwmsetupwizardModel::class))->newInstanceWithoutConstructor();
+        $ref   = new \ReflectionMethod(CwmsetupwizardModel::class, $method);
+
+        return $ref->invoke($model, ...$args);
+    }
+
+    /**
+     * @return  void
+     * @since __DEPLOY_VERSION__
+     */
+    #[TestDox("createDefaultServers()'s bound per-type existence check executes")]
+    public function testCreateDefaultServersBoundTypeCheckExecutes(): void
+    {
+        // A broken ':type' bind makes the COUNT query throw; a clean run
+        // returns the array of created (or already-present, hence skipped)
+        // servers.
+        $created = $this->invoke('createDefaultServers', 'local', []);
+
+        $this->assertIsArray($created);
+    }
+
+    /**
+     * @return  void
+     * @since __DEPLOY_VERSION__
+     */
+    #[TestDox("registerScheduledTasks()'s bound per-type existence check executes")]
+    public function testRegisterScheduledTasksBoundTypeCheckExecutes(): void
+    {
+        $created = $this->invoke('registerScheduledTasks', ['backup']);
+
+        $this->assertIsArray($created);
+    }
+}


### PR DESCRIPTION
Continues #1994 Phase 1 (`quote($var)` → `bind()`, by file). `CwmsetupwizardModel` held **6** `$db->quote($var)` calls; **all 6 convert** — three params-JSON UPDATEs (admin / component / template), the two per-type existence `COUNT`s in `createDefaultServers`/`registerScheduledTasks`, and the root-menu lookup.

Values that are method-call results (`$params->toString()`) or array elements (`$task['type']`) are pulled into a local variable first, so `bind()`'s by-reference argument is a real variable, not a temporary (avoids the "Only variables should be passed by reference" notice).

## Coverage
The two `COUNT`s bind their type **inside a `foreach`** — the one shape a by-reference bind can get wrong. New integration test `CwmsetupwizardModelBindTest` invokes both private loops against the real DB (neither touches `$this`, so `newInstanceWithoutConstructor` reaches them) and is **mutation-confirmed**: breaking `':type'` errors both tests.

The three params UPDATEs and the menu SELECT are non-loop, execute immediately, and carry config-derived values with no input path — same bind pattern, converted without a bespoke executing test (per the Phase 1 definition on the issue).

## Verified
38 setup-wizard tests green, full suite green (3617), PhpStorm inspection clean, `lint`/`lint:comments` clean.

## Remaining
Convertible `quote($var)`: **~87**. Next: `Cwmstats`, `CWMAddon` (6 each). Not release-blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)