### PR TITLE
fix(stats): date-range filter used a non-existent column, + bind Cwmstats values (#1994 phase 1)

### DIFF
--- a/admin/src/Lib/Cwmstats.php
+++ b/admin/src/Lib/Cwmstats.php
@@ -159,12 +159,12 @@ class Cwmstats
             CwmlocationHelper::applySecurityFilter($query, 's');
 
             if (!empty($start)) {
-                $query->where($db->quoteName('s.time') . ' > UNIX_TIMESTAMP(:start)')
+                $query->where($db->quoteName('s.studydate') . ' > :start')
                     ->bind(':start', $start, ParameterType::STRING);
             }
 
             if (!empty($end)) {
-                $query->where($db->quoteName('s.time') . ' < UNIX_TIMESTAMP(:end)')
+                $query->where($db->quoteName('s.studydate') . ' < :end')
                     ->bind(':end', $end, ParameterType::STRING);
             }
 
@@ -215,12 +215,12 @@ class Cwmstats
             CwmlocationHelper::applySecurityFilter($query, 's');
 
             if (!empty($start)) {
-                $query->where($db->quoteName('s.time') . ' > UNIX_TIMESTAMP(:start)')
+                $query->where($db->quoteName('s.studydate') . ' > :start')
                     ->bind(':start', $start, ParameterType::STRING);
             }
 
             if (!empty($end)) {
-                $query->where($db->quoteName('s.time') . ' < UNIX_TIMESTAMP(:end)')
+                $query->where($db->quoteName('s.studydate') . ' < :end')
                     ->bind(':end', $end, ParameterType::STRING);
             }
 

--- a/admin/src/Lib/Cwmstats.php
+++ b/admin/src/Lib/Cwmstats.php
@@ -26,6 +26,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 use Joomla\Database\DatabaseInterface;
+use Joomla\Database\ParameterType;
 use Joomla\Registry\Registry;
 
 /**
@@ -158,11 +159,13 @@ class Cwmstats
             CwmlocationHelper::applySecurityFilter($query, 's');
 
             if (!empty($start)) {
-                $query->where($db->quoteName('s.time') . ' > UNIX_TIMESTAMP(' . $db->quote($start) . ')');
+                $query->where($db->quoteName('s.time') . ' > UNIX_TIMESTAMP(:start)')
+                    ->bind(':start', $start, ParameterType::STRING);
             }
 
             if (!empty($end)) {
-                $query->where($db->quoteName('s.time') . ' < UNIX_TIMESTAMP(' . $db->quote($end) . ')');
+                $query->where($db->quoteName('s.time') . ' < UNIX_TIMESTAMP(:end)')
+                    ->bind(':end', $end, ParameterType::STRING);
             }
 
             $db->setQuery($query);
@@ -212,11 +215,13 @@ class Cwmstats
             CwmlocationHelper::applySecurityFilter($query, 's');
 
             if (!empty($start)) {
-                $query->where($db->quoteName('s.time') . ' > UNIX_TIMESTAMP(' . $db->quote($start) . ')');
+                $query->where($db->quoteName('s.time') . ' > UNIX_TIMESTAMP(:start)')
+                    ->bind(':start', $start, ParameterType::STRING);
             }
 
             if (!empty($end)) {
-                $query->where($db->quoteName('s.time') . ' < UNIX_TIMESTAMP(' . $db->quote($end) . ')');
+                $query->where($db->quoteName('s.time') . ' < UNIX_TIMESTAMP(:end)')
+                    ->bind(':end', $end, ParameterType::STRING);
             }
 
             $db->setQuery($query);
@@ -333,7 +338,8 @@ class Cwmstats
                 ->from($db->quoteName('#__bsms_studies', 's'))
                 ->whereIn($db->quoteName('s.published'), [1, 2])
                 ->where($db->quoteName('s.hits') . ' > 0')
-                ->where($db->quoteName('s.studydate') . ' > ' . $db->quote($last_month));
+                ->where($db->quoteName('s.studydate') . ' > :lastMonth')
+                ->bind(':lastMonth', $last_month, ParameterType::STRING);
 
             // Apply hybrid security filter: location-based + Joomla view-level access
             CwmlocationHelper::applySecurityFilter($query, 's');
@@ -473,7 +479,8 @@ class Cwmstats
                 ->leftJoin($db->quoteName('#__bsms_studies', 's') . ' ON ' . $db->quoteName('mf.study_id') . ' = ' . $db->quoteName('s.id'))
                 ->whereIn($db->quoteName('mf.published'), [1, 2])
                 ->where($db->quoteName('mf.downloads') . ' > 0')
-                ->where($db->quoteName('mf.createdate') . ' > ' . $db->quote($lastmonth));
+                ->where($db->quoteName('mf.createdate') . ' > :lastMonth')
+                ->bind(':lastMonth', $lastmonth, ParameterType::STRING);
 
             // Apply hybrid security filter: location-based + Joomla view-level access
             CwmlocationHelper::applySecurityFilter($query, 's');

--- a/tests/integration/Admin/Lib/CwmstatsDateBindTest.php
+++ b/tests/integration/Admin/Lib/CwmstatsDateBindTest.php
@@ -1,0 +1,86 @@
+<?php
+
+/**
+ * Cwmstats filters its aggregates by a date range bound into the query. The
+ * range comes in as a parameter (an admin date filter), so it is exactly the
+ * kind of value that should be bound rather than interpolated. These run the
+ * date-filtered paths against the real DB so a mis-bound placeholder throws.
+ *
+ * @package    Proclaim.IntegrationTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ *
+ * @since __DEPLOY_VERSION__
+ */
+
+namespace CWM\Component\Proclaim\Tests\Integration\Admin\Lib;
+
+use CWM\Component\Proclaim\Administrator\Lib\Cwmstats;
+use CWM\Component\Proclaim\Tests\Integration\IntegrationTestCase;
+use Joomla\CMS\Factory;
+use Joomla\CMS\User\User;
+use PHPUnit\Framework\Attributes\TestDox;
+
+/**
+ * @since __DEPLOY_VERSION__
+ */
+class CwmstatsDateBindTest extends IntegrationTestCase
+{
+    /**
+     * @var User|null
+     * @since __DEPLOY_VERSION__
+     */
+    private ?User $savedIdentity = null;
+
+    /**
+     * @return  void
+     * @since __DEPLOY_VERSION__
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (!\defined('PROCLAIM_TEST_DB_AVAILABLE') || !PROCLAIM_TEST_DB_AVAILABLE) {
+            $this->markTestSkipped('Database not available for integration tests');
+        }
+
+        // These stats methods read the current identity for the access filter;
+        // the harness has none, so stand in a guest and restore afterwards.
+        $app                 = Factory::getApplication();
+        $this->savedIdentity = $app->getIdentity();
+        $app->loadIdentity(new User());
+    }
+
+    /**
+     * @return  void
+     * @since __DEPLOY_VERSION__
+     */
+    protected function tearDown(): void
+    {
+        if ($this->savedIdentity !== null) {
+            Factory::getApplication()->loadIdentity($this->savedIdentity);
+        }
+
+        parent::tearDown();
+    }
+
+    /**
+     * A fresh range differs from the cached one, so the guard re-runs the query
+     * instead of returning a memoised count -- which is what reaches the bind.
+     *
+     * @return  void
+     * @since __DEPLOY_VERSION__
+     */
+    #[TestDox('getTotalMessages()/getTotalTopics() date-range filter executes with bound values')]
+    public function testDateRangeBindsExecute(): void
+    {
+        $start = '2000-01-01 00:00:00';
+        $end   = '2035-01-01 00:00:00';
+
+        // Both throw "Unknown column 's.time'" before the fix, and throw on a
+        // mis-bound :start/:end after it — a clean run returns a count.
+        $this->assertIsInt(Cwmstats::getTotalMessages($start, $end));
+        $this->assertIsInt(Cwmstats::getTotalTopics($start, $end));
+    }
+}


### PR DESCRIPTION
Two commits, one PR. The **bug** is the interesting half.

## fix(stats): the date-range filter referenced a column that does not exist
`getTotalMessages()` / `getTotalTopics()` filtered their range with `s.time > UNIX_TIMESTAMP(:start)` — but `#__bsms_studies` **has no `time` column and never did** (no CREATE, no retiring migration). Any call with a non-empty range threw `Unknown column 's.time'`.

It went unnoticed because the path is **dead**: the only caller in the tree (the control panel) passes no range, and `getTotalTopics()` has no caller at all (verified across `admin/site/plugins/modules/api/components`). So this is a latent defect, not a shipped one — but it means the range feature has never worked.

Fixed to filter on `s.studydate` directly (a `DATETIME`, exactly as `getTopThirtyDays()` already does); `UNIX_TIMESTAMP()` dropped.

## refactor(query): bind Cwmstats' date values (#1994 phase 1)
The six `$db->quote($var)` calls (the range, plus two computed cut-offs) become bound parameters.

## Coverage
The new integration test runs both range methods against the real DB and is **mutation-confirmed in both directions**: breaking `:start` errors, and reverting the column to `s.time` errors — so neither the bind nor the column fix can silently regress.

The two computed-cut-off binds (`getTopThirtyDays`/`getDownloadsLastThreeMonths`) sit inside a `CallbackController`-cached closure that only runs on a cold cache, so they're converted but not executing-tested here — a computed non-input date, same immediate-execute pattern.

## Verified
Full suite green (3618), PhpStorm inspection clean, `lint`/`lint:comments` clean.

## Remaining #1994 Phase 1
Convertible `quote($var)`: **~81**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)