### PR TITLE
refactor(query): bind the platform-stats sync's values (#1994 phase 1)

### DIFF
--- a/admin/src/Addons/CWMAddon.php
+++ b/admin/src/Addons/CWMAddon.php
@@ -23,6 +23,7 @@ use CWM\Component\Proclaim\Site\Helper\Cwmpodcast;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\Database\DatabaseInterface;
+use Joomla\Database\ParameterType;
 use Joomla\Filesystem\Path;
 use Joomla\Http\HttpFactory;
 use Joomla\Http\Response;
@@ -1281,6 +1282,10 @@ abstract class CWMAddon
         $db  = Factory::getContainer()->get(DatabaseInterface::class);
         $now = Factory::getDate()->toSql();
 
+        // Assembled as a raw string, not the builder: this is an
+        // INSERT ... ON DUPLICATE KEY UPDATE with a column set that varies per
+        // call, which the query builder cannot express — so setQuery() gets a
+        // string and there is no query object to bind these values on.
         $columns = ['media_id', 'server_id', 'platform', 'platform_id', 'synced_at'];
         $values  = [
             (int) $mediaId,
@@ -1336,8 +1341,9 @@ abstract class CWMAddon
         $now   = Factory::getDate()->toSql();
         $query = $db->createQuery()
             ->update($db->quoteName('#__bsms_servers'))
-            ->set($db->quoteName('stats_synced_at') . ' = ' . $db->quote($now))
-            ->where($db->quoteName('id') . ' = ' . $serverId);
+            ->set($db->quoteName('stats_synced_at') . ' = :now')
+            ->where($db->quoteName('id') . ' = ' . $serverId)
+            ->bind(':now', $now, ParameterType::STRING);
         $db->setQuery($query)->execute();
     }
 
@@ -1382,8 +1388,9 @@ abstract class CWMAddon
             $query->leftJoin(
                 $db->quoteName('#__bsms_platform_stats', 'ps')
                 . ' ON ' . $db->quoteName('ps.media_id') . ' = ' . $db->quoteName('m.id')
-                . ' AND ' . $db->quoteName('ps.platform') . ' = ' . $db->quote($platform)
-            );
+                . ' AND ' . $db->quoteName('ps.platform') . ' = :platform'
+            )
+                ->bind(':platform', $platform, ParameterType::STRING);
 
             // Never-synced first (NULL synced_at), then oldest-synced
             $query->order($db->quoteName('ps.synced_at') . ' IS NULL DESC')

--- a/tests/integration/Admin/Addons/CWMAddonStatsBindTest.php
+++ b/tests/integration/Admin/Addons/CWMAddonStatsBindTest.php
@@ -1,0 +1,123 @@
+<?php
+
+/**
+ * The platform-stats sync binds two values into builder queries: the sync
+ * timestamp on a server UPDATE, and the platform name in a LEFT JOIN condition.
+ * Both live in protected static methods with no test caller, so these invoke
+ * them against the real DB — a mis-bound placeholder throws instead of passing.
+ *
+ * @package    Proclaim.IntegrationTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ *
+ * @since __DEPLOY_VERSION__
+ */
+
+namespace CWM\Component\Proclaim\Tests\Integration\Admin\Addons;
+
+use CWM\Component\Proclaim\Administrator\Addons\CWMAddon;
+use CWM\Component\Proclaim\Tests\Integration\IntegrationTestCase;
+use Joomla\CMS\Factory;
+use Joomla\Database\DatabaseInterface;
+use PHPUnit\Framework\Attributes\TestDox;
+
+/**
+ * @since __DEPLOY_VERSION__
+ */
+class CWMAddonStatsBindTest extends IntegrationTestCase
+{
+    /**
+     * @var DatabaseInterface|null
+     * @since __DEPLOY_VERSION__
+     */
+    private ?DatabaseInterface $db = null;
+
+    /**
+     * @var mixed
+     * @since __DEPLOY_VERSION__
+     */
+    private mixed $previousFactoryLanguage = null;
+
+    /**
+     * @return  void
+     * @since __DEPLOY_VERSION__
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (!\defined('PROCLAIM_TEST_DB_AVAILABLE') || !PROCLAIM_TEST_DB_AVAILABLE) {
+            $this->markTestSkipped('Database not available for integration tests');
+        }
+
+        // updateServerSyncTimestamp() stamps with Factory::getDate(); give the
+        // language a tag so that path does not print a warning and fail CI.
+        $this->previousFactoryLanguage = $this->silenceDateLanguageWarnings();
+
+        $this->db = Factory::getContainer()->get(DatabaseInterface::class);
+        $this->db->transactionStart(true);
+    }
+
+    /**
+     * @return  void
+     * @since __DEPLOY_VERSION__
+     */
+    protected function tearDown(): void
+    {
+        if ($this->db !== null) {
+            try {
+                $this->db->transactionRollback(true);
+            } catch (\Throwable) {
+                // Connection may have gone away.
+            }
+        }
+
+        Factory::$language = $this->previousFactoryLanguage;
+
+        parent::tearDown();
+    }
+
+    /**
+     * Both methods are protected static and take no $this.
+     *
+     * @param   string  $method  Method name.
+     * @param   mixed   ...$args Arguments.
+     *
+     * @return  mixed
+     *
+     * @since __DEPLOY_VERSION__
+     */
+    private function invoke(string $method, ...$args): mixed
+    {
+        return (new \ReflectionMethod(CWMAddon::class, $method))->invoke(null, ...$args);
+    }
+
+    /**
+     * @return  void
+     * @since __DEPLOY_VERSION__
+     */
+    #[TestDox("updateServerSyncTimestamp()'s bound :now UPDATE executes")]
+    public function testUpdateServerSyncTimestampBindExecutes(): void
+    {
+        // No server with this id, so the UPDATE matches nothing -- but a broken
+        // :now bind makes it throw before it can match nothing.
+        $this->invoke('updateServerSyncTimestamp', 999142);
+
+        $this->assertTrue(true, 'updateServerSyncTimestamp() ran without a bind error');
+    }
+
+    /**
+     * @return  void
+     * @since __DEPLOY_VERSION__
+     */
+    #[TestDox("getMediaVideoIds()'s bound :platform LEFT JOIN executes")]
+    public function testGetMediaVideoIdsPlatformJoinExecutes(): void
+    {
+        // A non-empty platform and a batch limit take the LEFT JOIN branch that
+        // carries the :platform bind.
+        $rows = $this->invoke('getMediaVideoIds', 999142, 'filename', 10, 'youtube', true);
+
+        $this->assertIsArray($rows);
+    }
+}


### PR DESCRIPTION
Continues #1994 Phase 1 (`quote($var)` → `bind()`, by file). `CWMAddon` held **6** `$db->quote($var)` calls; **2 convert**, **4 stay**.

## Converted (2)
- `updateServerSyncTimestamp()` — the sync-timestamp UPDATE.
- `getMediaVideoIds()` — the platform name in a `LEFT JOIN` condition (a placeholder is fine inside the join string; the bind rides on the query object).

## Deliberately left (4), commented
`upsertPlatformStats()` builds an `INSERT ... ON DUPLICATE KEY UPDATE` with a per-call-varying column set as a **raw string** — the builder can't express that, so `setQuery()` gets a string and there's no query object to bind on. Same category as the raw-string sites in #2071.

## Coverage
Both converted methods are `protected static` with no test caller. New integration test invokes each against the real DB (the timestamp UPDATE and the platform `LEFT JOIN` branch) and is **mutation-confirmed**: breaking `:now` or `:platform` errors the matching test.

⚠️ One gotcha handled: `updateServerSyncTimestamp()` stamps with `Factory::getDate()`, whose language-tag path prints a warning that **fails CI** under `failOnWarning`. `setUp()` forces a tag via the existing `silenceDateLanguageWarnings()` helper.

## Verified
Full suite green (3620), PhpStorm inspection clean, `lint`/`lint:comments` clean.

## Remaining #1994 Phase 1: ~79.

🤖 Generated with [Claude Code](https://claude.com/claude-code)