### PR TITLE
docs(claude-md): state the Joomla 5.4 floor instead of 'Joomla 4+'

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Proclaim (CWM Proclaim) is a Joomla 4+ component for managing and displaying Bible studies/sermons. It supports teachers, series, topics, locations, media files, podcasting, and social sharing with customizable templates.
+Proclaim (CWM Proclaim) is a Joomla 5+ component (minimum 5.4.0, Joomla 6 supported) for managing and displaying Bible studies/sermons. It supports teachers, series, topics, locations, media files, podcasting, and social sharing with customizable templates.
 
 **PHP Requirement:** 8.3.0+
 **Namespace:** `CWM\Component\Proclaim`


### PR DESCRIPTION
CLAUDE.md's project overview still called Proclaim a Joomla 4+ component. The floor is 5.4.0 (#1965) with Joomla 6 supported; Joomla 4 is not. One-line correction so the guidance file matches the platform-targets reality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012VghnistxaSNKvhWYrtjGJ