### PR TITLE
refactor(query): bind the location wizard's params/rules values (#1994 phase 1)

### DIFF
--- a/admin/src/Model/CwmlocationwizardModel.php
+++ b/admin/src/Model/CwmlocationwizardModel.php
@@ -22,6 +22,7 @@ use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\MVC\Model\BaseDatabaseModel;
 use Joomla\Database\DatabaseInterface;
+use Joomla\Database\ParameterType;
 
 /**
  * Location Setup Wizard model
@@ -272,11 +273,13 @@ class CwmlocationwizardModel extends BaseDatabaseModel
         $params->set('enable_location_filtering', 1);
         $params->set('location_system_dismissed', 0);
 
-        $query = $db->createQuery()
+        $paramsJson = $params->toString();
+        $query      = $db->createQuery()
             ->update($db->quoteName('#__extensions'))
-            ->set($db->quoteName('params') . ' = ' . $db->quote($params->toString()))
+            ->set($db->quoteName('params') . ' = :params')
             ->where($db->quoteName('element') . ' = ' . $db->quote('com_proclaim'))
-            ->where($db->quoteName('type') . ' = ' . $db->quote('component'));
+            ->where($db->quoteName('type') . ' = ' . $db->quote('component'))
+            ->bind(':params', $paramsJson, ParameterType::STRING);
 
         $db->setQuery($query);
         $db->execute();
@@ -376,8 +379,9 @@ class CwmlocationwizardModel extends BaseDatabaseModel
         // Save updated rules
         $query = $db->createQuery()
             ->update($db->quoteName('#__assets'))
-            ->set($db->quoteName('rules') . ' = ' . $db->quote($encoded))
-            ->where($db->quoteName('id') . ' = ' . (int) $asset->id);
+            ->set($db->quoteName('rules') . ' = :rules')
+            ->where($db->quoteName('id') . ' = ' . (int) $asset->id)
+            ->bind(':rules', $encoded, ParameterType::STRING);
 
         $db->setQuery($query);
         $db->execute();
@@ -401,11 +405,13 @@ class CwmlocationwizardModel extends BaseDatabaseModel
 
         $params->set('location_system_dismissed', 1);
 
-        $query = $db->createQuery()
+        $paramsJson = $params->toString();
+        $query      = $db->createQuery()
             ->update($db->quoteName('#__extensions'))
-            ->set($db->quoteName('params') . ' = ' . $db->quote($params->toString()))
+            ->set($db->quoteName('params') . ' = :params')
             ->where($db->quoteName('element') . ' = ' . $db->quote('com_proclaim'))
-            ->where($db->quoteName('type') . ' = ' . $db->quote('component'));
+            ->where($db->quoteName('type') . ' = ' . $db->quote('component'))
+            ->bind(':params', $paramsJson, ParameterType::STRING);
 
         $db->setQuery($query);
         $db->execute();

--- a/tests/integration/Admin/Model/CwmlocationwizardBindTest.php
+++ b/tests/integration/Admin/Model/CwmlocationwizardBindTest.php
@@ -1,0 +1,122 @@
+<?php
+
+/**
+ * The location wizard writes component params and asset rules through bound
+ * UPDATEs. All three sites live in methods with no test caller, so these invoke
+ * them against the real DB — a mis-bound placeholder throws instead of passing.
+ *
+ * @package    Proclaim.IntegrationTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ *
+ * @since __DEPLOY_VERSION__
+ */
+
+namespace CWM\Component\Proclaim\Tests\Integration\Admin\Model;
+
+use CWM\Component\Proclaim\Administrator\Model\CwmlocationwizardModel;
+use CWM\Component\Proclaim\Tests\Integration\IntegrationTestCase;
+use Joomla\CMS\Factory;
+use Joomla\Database\DatabaseInterface;
+use PHPUnit\Framework\Attributes\TestDox;
+
+/**
+ * @since __DEPLOY_VERSION__
+ */
+class CwmlocationwizardBindTest extends IntegrationTestCase
+{
+    /**
+     * @var DatabaseInterface|null
+     * @since __DEPLOY_VERSION__
+     */
+    private ?DatabaseInterface $db = null;
+
+    /**
+     * @return  void
+     * @since __DEPLOY_VERSION__
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (!\defined('PROCLAIM_TEST_DB_AVAILABLE') || !PROCLAIM_TEST_DB_AVAILABLE) {
+            $this->markTestSkipped('Database not available for integration tests');
+        }
+
+        $this->db = Factory::getContainer()->get(DatabaseInterface::class);
+        // Every method here UPDATEs #__extensions params or #__assets rules.
+        $this->db->transactionStart(true);
+    }
+
+    /**
+     * @return  void
+     * @since __DEPLOY_VERSION__
+     */
+    protected function tearDown(): void
+    {
+        if ($this->db !== null) {
+            try {
+                $this->db->transactionRollback(true);
+            } catch (\Throwable) {
+                // Connection may have gone away.
+            }
+        }
+
+        parent::tearDown();
+    }
+
+    /**
+     * @param   string  $method  Method name.
+     * @param   mixed   ...$args Arguments.
+     *
+     * @return  mixed
+     *
+     * @since __DEPLOY_VERSION__
+     */
+    private function invoke(string $method, ...$args): mixed
+    {
+        $model = (new \ReflectionClass(CwmlocationwizardModel::class))->newInstanceWithoutConstructor();
+        $ref   = new \ReflectionMethod(CwmlocationwizardModel::class, $method);
+
+        return $ref->invoke($model, ...$args);
+    }
+
+    /**
+     * @return  void
+     * @since __DEPLOY_VERSION__
+     */
+    #[TestDox("dismiss()'s bound :params UPDATE executes")]
+    public function testDismissBindExecutes(): void
+    {
+        $this->invoke('dismiss');
+
+        $this->assertTrue(true, 'dismiss() ran without a bind error');
+    }
+
+    /**
+     * @return  void
+     * @since __DEPLOY_VERSION__
+     */
+    #[TestDox("applyWizard()'s bound :params UPDATE executes")]
+    public function testApplyWizardBindExecutes(): void
+    {
+        $this->invoke('applyWizard', [], []);
+
+        $this->assertTrue(true, 'applyWizard() ran without a bind error');
+    }
+
+    /**
+     * @return  void
+     * @since __DEPLOY_VERSION__
+     */
+    #[TestDox("applyPermissions()'s bound :rules UPDATE executes against the component asset")]
+    public function testApplyPermissionsBindExecutes(): void
+    {
+        // 'editor' is a real preset; the com_proclaim asset exists, so this
+        // reaches the rules UPDATE rather than the no-asset early return.
+        $this->invoke('applyPermissions', [1 => 'editor']);
+
+        $this->assertTrue(true, 'applyPermissions() ran without a bind error');
+    }
+}


### PR DESCRIPTION
Continues #1994 Phase 1 (`quote($var)` → `bind()`, by file). `CwmlocationwizardModel` held **3** `$db->quote($var)` calls; **all 3 convert** — the component params in `applyWizard()` and `dismiss()`, and the asset rules in `applyPermissions()`. The `$params->toString()` method-call value goes through a local first so `bind()`'s by-reference argument is a variable.

## Coverage
All three live in methods with no test caller. New integration test reflection-invokes each against the real DB (rolled-back transaction) and is **mutation-confirmed**: breaking `:params` errors the two params UPDATEs, breaking `:rules` errors `applyPermissions()` (which reaches its UPDATE by loading the real `com_proclaim` asset with the `editor` preset).

## Verified
Full suite green (3623), PhpStorm inspection clean, `lint`/`lint:comments` clean.

## Note on Cwmlanding (skipped)
I started `Cwmlanding` first but backed out: its `getLandingData` UNIONs per-type queries that each bind the same `:nullDate`/`:nowDate`, and reused param names collide across a UNION (my single-query test missed it; it broke the live landing page). Binding those needs per-subquery unique names — disproportionate for a constant null-date — and its language filter feeds 21 `IN (...)` sites. Left for a dedicated pass if ever.

## Remaining #1994 Phase 1: ~79 (much of it constant/raw-string/SQL-generation that stays).

🤖 Generated with [Claude Code](https://claude.com/claude-code)