### PR TITLE
refactor(query): bind the guided-tour helper's uid/title_key lookups (#1994 phase 1)

### DIFF
--- a/admin/src/Helper/CwmguidedtourHelper.php
+++ b/admin/src/Helper/CwmguidedtourHelper.php
@@ -20,6 +20,7 @@ use Joomla\CMS\Date\Date;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Log\Log;
 use Joomla\Database\DatabaseInterface;
+use Joomla\Database\ParameterType;
 
 /**
  * Helper class for creating and managing guided tours and announcements.
@@ -591,8 +592,9 @@ class CwmguidedtourHelper
         $query = $this->db->createQuery()
             ->select($this->db->quoteName('id'))
             ->from($this->db->quoteName('#__guidedtours'))
-            ->where($this->db->quoteName('uid') . ' = ' . $this->db->quote($uid))
-            ->order($this->db->quoteName('id') . ' ASC');
+            ->where($this->db->quoteName('uid') . ' = :uid')
+            ->order($this->db->quoteName('id') . ' ASC')
+            ->bind(':uid', $uid, ParameterType::STRING);
         $this->db->setQuery($query);
 
         return array_map('intval', $this->db->loadColumn() ?: []);
@@ -680,7 +682,8 @@ class CwmguidedtourHelper
         $query = $this->db->createQuery()
             ->select('COUNT(*)')
             ->from($this->db->quoteName('#__guidedtours'))
-            ->where($this->db->quoteName('uid') . ' = ' . $this->db->quote($uid));
+            ->where($this->db->quoteName('uid') . ' = :uid')
+            ->bind(':uid', $uid, ParameterType::STRING);
         $this->db->setQuery($query);
 
         return (int) $this->db->loadResult() > 0;
@@ -702,7 +705,8 @@ class CwmguidedtourHelper
         $query = $this->db->createQuery()
             ->select('COUNT(*)')
             ->from($this->db->quoteName('#__postinstall_messages'))
-            ->where($this->db->quoteName('title_key') . ' = ' . $this->db->quote($titleKey));
+            ->where($this->db->quoteName('title_key') . ' = :titleKey')
+            ->bind(':titleKey', $titleKey, ParameterType::STRING);
         $this->db->setQuery($query);
 
         return (int) $this->db->loadResult() > 0;

--- a/tests/integration/Admin/Helper/CwmguidedtourHelperTest.php
+++ b/tests/integration/Admin/Helper/CwmguidedtourHelperTest.php
@@ -351,4 +351,22 @@ class CwmguidedtourHelperTest extends IntegrationTestCase
 
         $this->assertSame(0, $ref->invoke($this->helper(), self::UID));
     }
+
+    /**
+     * The uid lookups are covered by the tour tests above; this pins the one
+     * other bound query — the post-install message existence check by title_key.
+     *
+     * @return  void
+     * @since __DEPLOY_VERSION__
+     */
+    #[TestDox("postInstallMessageExists() runs its bound title_key query")]
+    public function testPostInstallMessageExistsBindExecutes(): void
+    {
+        $ref    = new \ReflectionMethod(CwmguidedtourHelper::class, 'postInstallMessageExists');
+        $result = $ref->invoke($this->helper(), 'com_proclaim_no_such_title_key');
+
+        // A broken :titleKey bind throws before it can answer; a clean run
+        // returns a bool (false for this deliberately-absent key).
+        $this->assertIsBool($result);
+    }
 }


### PR DESCRIPTION
Continues #1994 Phase 1 (`quote($var)` → `bind()`, by file). `CwmguidedtourHelper` held **3** `$db->quote($var)` calls; **all 3 convert** — the tour `uid` (in `getTourId()` and the delete-by-uid existence check) and the post-install message `title_key`. `$uid`/`$titleKey` are plain string params, so they bind directly.

## Coverage
- The `uid` lookups were already exercised end-to-end by the existing tour tests — breaking `:uid` errors **seven** of them.
- The `title_key` path had no coverage, so a new test reflection-invokes `postInstallMessageExists()` against the real DB and is **mutation-confirmed** (breaking `:titleKey` errors it).

## Verified
Full suite green (3624), PhpStorm inspection clean, `lint`/`lint:comments` clean.

## Remaining #1994 Phase 1: ~73 — mostly constant/raw-string/SQL-generation that stays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)