### PR TITLE
refactor(query): bind the YouTube addon's params/tag values (#1994 phase 1)

### DIFF
--- a/admin/src/Addons/Servers/Youtube/CWMAddonYoutube.php
+++ b/admin/src/Addons/Servers/Youtube/CWMAddonYoutube.php
@@ -47,6 +47,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\Database\DatabaseInterface;
+use Joomla\Database\ParameterType;
 use Joomla\Input\Input;
 use Joomla\Registry\Registry;
 
@@ -1959,8 +1960,9 @@ class CWMAddonYoutube extends CWMAddon
             $insert->insert($db->quoteName('#__bsms_topics'))
                 ->columns($db->quoteName(['topic_text', 'published', 'language']))
                 ->values(
-                    $db->quote($tag) . ', 1, ' . $db->quote('*')
-                );
+                    ':tag, 1, ' . $db->quote('*')
+                )
+                ->bind(':tag', $tag, ParameterType::STRING);
             $db->setQuery($insert);
 
             try {
@@ -2192,10 +2194,12 @@ class CWMAddonYoutube extends CWMAddon
         $params->set('live_stream_key', $details['stream_key']);
         $params->set('live_rtmp_url', $details['rtmp_url']);
 
-        $update = $db->createQuery()
+        $paramsJson = $params->toString();
+        $update     = $db->createQuery()
             ->update($db->quoteName('#__bsms_servers'))
-            ->set($db->quoteName('params') . ' = ' . $db->quote($params->toString()))
-            ->where($db->quoteName('id') . ' = ' . (int) $serverId);
+            ->set($db->quoteName('params') . ' = :params')
+            ->where($db->quoteName('id') . ' = ' . (int) $serverId)
+            ->bind(':params', $paramsJson, ParameterType::STRING);
         $db->setQuery($update);
         $db->execute();
 
@@ -2237,10 +2241,12 @@ class CWMAddonYoutube extends CWMAddon
         // Set a simple flag for the status field to detect connection
         $params->set('access_token', $tokenData['access_token'] ?? '1');
 
-        $update = $db->createQuery()
+        $paramsJson = $params->toString();
+        $update     = $db->createQuery()
             ->update($db->quoteName('#__bsms_servers'))
-            ->set($db->quoteName('params') . ' = ' . $db->quote($params->toString()))
-            ->where($db->quoteName('id') . ' = ' . (int) $serverId);
+            ->set($db->quoteName('params') . ' = :params')
+            ->where($db->quoteName('id') . ' = ' . (int) $serverId)
+            ->bind(':params', $paramsJson, ParameterType::STRING);
         $db->setQuery($update);
         $db->execute();
 
@@ -2271,10 +2277,12 @@ class CWMAddonYoutube extends CWMAddon
         $params->remove('oauth_refresh_token');
         $params->remove('access_token');
 
-        $update = $db->createQuery()
+        $paramsJson = $params->toString();
+        $update     = $db->createQuery()
             ->update($db->quoteName('#__bsms_servers'))
-            ->set($db->quoteName('params') . ' = ' . $db->quote($params->toString()))
-            ->where($db->quoteName('id') . ' = ' . (int) $serverId);
+            ->set($db->quoteName('params') . ' = :params')
+            ->where($db->quoteName('id') . ' = ' . (int) $serverId)
+            ->bind(':params', $paramsJson, ParameterType::STRING);
         $db->setQuery($update);
         $db->execute();
 

--- a/tests/integration/Admin/Addons/CWMAddonYoutubeTagBindTest.php
+++ b/tests/integration/Admin/Addons/CWMAddonYoutubeTagBindTest.php
@@ -1,0 +1,105 @@
+<?php
+
+/**
+ * importTagsAsTopics() inserts a new topic with the YouTube tag bound into the
+ * VALUES list. The three params UPDATEs elsewhere in the addon are the same
+ * bound-set-params shape already proven executing in the setup/location wizards
+ * and CWMAddon; this pins the one new shape — a bound value in a builder INSERT.
+ *
+ * @package    Proclaim.IntegrationTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ *
+ * @since __DEPLOY_VERSION__
+ */
+
+namespace CWM\Component\Proclaim\Tests\Integration\Admin\Addons;
+
+use CWM\Component\Proclaim\Administrator\Addons\Servers\Youtube\CWMAddonYoutube;
+use CWM\Component\Proclaim\Tests\Integration\IntegrationTestCase;
+use Joomla\CMS\Factory;
+use Joomla\Database\DatabaseInterface;
+use Joomla\Database\ParameterType;
+use PHPUnit\Framework\Attributes\TestDox;
+
+/**
+ * @since __DEPLOY_VERSION__
+ */
+class CWMAddonYoutubeTagBindTest extends IntegrationTestCase
+{
+    /**
+     * @var DatabaseInterface|null
+     * @since __DEPLOY_VERSION__
+     */
+    private ?DatabaseInterface $db = null;
+
+    /**
+     * @var mixed
+     * @since __DEPLOY_VERSION__
+     */
+    private mixed $previousFactoryLanguage = null;
+
+    /**
+     * @return  void
+     * @since __DEPLOY_VERSION__
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (!\defined('PROCLAIM_TEST_DB_AVAILABLE') || !PROCLAIM_TEST_DB_AVAILABLE) {
+            $this->markTestSkipped('Database not available for integration tests');
+        }
+
+        // The topic-suggestion path reaches Factory::getDate(); give the
+        // language a tag so it does not print a warning that fails CI.
+        $this->previousFactoryLanguage = $this->silenceDateLanguageWarnings();
+
+        $this->db = Factory::getContainer()->get(DatabaseInterface::class);
+        $this->db->transactionStart(true);
+    }
+
+    /**
+     * @return  void
+     * @since __DEPLOY_VERSION__
+     */
+    protected function tearDown(): void
+    {
+        if ($this->db !== null) {
+            try {
+                $this->db->transactionRollback(true);
+            } catch (\Throwable) {
+                // Connection may have gone away.
+            }
+        }
+
+        Factory::$language = $this->previousFactoryLanguage;
+
+        parent::tearDown();
+    }
+
+    /**
+     * @return  void
+     * @since __DEPLOY_VERSION__
+     */
+    #[TestDox("importTagsAsTopics() inserts a topic with the tag bound into the VALUES list")]
+    public function testImportTagsAsTopicsBindsTheInsert(): void
+    {
+        // A tag unlikely to match an existing topic, so the code reaches the
+        // bound INSERT rather than the de-dup skip.
+        $tag = 'zz youtube tag ' . uniqid('', true);
+
+        $model = (new \ReflectionClass(CWMAddonYoutube::class))->newInstanceWithoutConstructor();
+        $ref   = new \ReflectionMethod(CWMAddonYoutube::class, 'importTagsAsTopics');
+        $ref->invoke($model, [$tag]);
+
+        $query = $this->db->createQuery()
+            ->select('COUNT(*)')
+            ->from($this->db->quoteName('#__bsms_topics'))
+            ->where($this->db->quoteName('topic_text') . ' = :tag')
+            ->bind(':tag', $tag, ParameterType::STRING);
+
+        $this->assertSame(1, (int) $this->db->setQuery($query)->loadResult(), 'The tag should have been inserted as a topic');
+    }
+}


### PR DESCRIPTION
Continues #1994 Phase 1 (`quote($var)` → `bind()`, by file). `CWMAddonYoutube` held **4** `$db->quote($var)` calls; **all 4 convert** — the server-params UPDATE in `ensurePersistentStream()` / `saveOAuthTokens()` / `disconnectOAuth()`, and the tag in `importTagsAsTopics()`'s topic INSERT (which already binds `:tag` in its de-dup COUNT right above, so this is consistent). The `$params->toString()` value goes through a local first so `bind()`'s by-reference arg is a variable.

## Coverage
- The three `set(params)` UPDATEs are the identical shape already proven executing in #2072 / #2081 / #2074 — converted without a new bespoke test.
- The INSERT is the one new shape (a bound value in a builder VALUES list), so a test reflection-invokes `importTagsAsTopics()` against the real DB and is **mutation-confirmed** (breaking `:tag` errors it).
- ⚠️ `setUp` forces a language tag (`silenceDateLanguageWarnings`): the topic-suggestion path reaches `Factory::getDate()`, whose warning fails CI under `failOnWarning`.

## Verified
Full suite green (3625), inspection clean on the changed lines, `lint`/`lint:comments` clean. (A pre-existing `mkdir` EA suggestion at line 3134 is unrelated and untouched.)

## Remaining #1994 Phase 1: ~69.

🤖 Generated with [Claude Code](https://claude.com/claude-code)