### PR TITLE
fix(admin,site): two runtime fatals from symbols that never resolve (#2075, #2076)

### DIFF
--- a/admin/src/Model/CwmsetupwizardModel.php
+++ b/admin/src/Model/CwmsetupwizardModel.php
@@ -16,7 +16,9 @@ namespace CWM\Component\Proclaim\Administrator\Model;
 use CWM\Component\Proclaim\Administrator\Helper\CwmsetupwizardHelper;
 use Joomla\CMS\Date\Date;
 use Joomla\CMS\Factory;
+use Joomla\CMS\Log\Log;
 use Joomla\CMS\MVC\Model\BaseDatabaseModel;
+use Joomla\CMS\Uri\Uri;
 use Joomla\Database\DatabaseInterface;
 use Joomla\Database\ParameterType;
 use Joomla\Registry\Registry;
@@ -901,12 +903,16 @@ class CwmsetupwizardModel extends BaseDatabaseModel
         $userId  = Factory::getApplication()->getIdentity()->id ?? 0;
 
         $row = (object) [
-            'title'                  => $title,
-            'description'            => trim($data['podcast_description'] ?? '') ?: '<p>Sermons from ' . $orgName . '</p>',
-            'website'                => Factory::getApplication()->get('live_site', '') ?: Factory::getUri()->root(),
-            'author'                 => $author,
-            'editor_name'            => $author,
-            'editor_email'           => trim($data['podcast_email'] ?? ''),
+            'title'        => $title,
+            'description'  => trim($data['podcast_description'] ?? '') ?: '<p>Sermons from ' . $orgName . '</p>',
+            'website'      => Factory::getApplication()->get('live_site', '') ?: Uri::root(),
+            'author'       => $author,
+            'editor_name'  => $author,
+            'editor_email' => trim($data['podcast_email'] ?? ''),
+            // Legacy feed-link column. Sites upgraded through the era when it
+            // was added carry it NOT NULL with no default, so omitting it makes
+            // the insert fail on exactly the installs most likely to run this.
+            'podcastlink'            => '',
             'filename'               => 'podcast',
             'podcastlimit'           => 50,
             'published'              => 1,
@@ -928,7 +934,11 @@ class CwmsetupwizardModel extends BaseDatabaseModel
             $db->insertObject('#__bsms_podcast', $row);
 
             return (int) $db->insertid();
-        } catch (\Throwable) {
+        } catch (\Throwable $e) {
+            // Returning 0 leaves the wizard reporting no podcast; without this
+            // line the reason never surfaced anywhere.
+            Log::add('Setup wizard could not create the podcast: ' . $e->getMessage(), Log::ERROR, 'com_proclaim');
+
             return 0;
         }
     }

--- a/site/src/Model/CwmsermonModel.php
+++ b/site/src/Model/CwmsermonModel.php
@@ -22,6 +22,7 @@ use CWM\Component\Proclaim\Administrator\Helper\Cwmtranslated;
 use Joomla\CMS\Date\Date;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Form\Form;
+use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\Model\FormModel;
 use Joomla\CMS\User\User;
 use Joomla\Database\ParameterType;

--- a/tests/integration/Admin/Model/CwmsetupwizardPodcastTest.php
+++ b/tests/integration/Admin/Model/CwmsetupwizardPodcastTest.php
@@ -1,0 +1,121 @@
+<?php
+
+/**
+ * The setup wizard's podcast step falls back to the site root when no live_site
+ * is configured — the normal case. That fallback called a Joomla 3 method that
+ * does not exist on the versions Proclaim supports, so the wizard fataled and
+ * no test noticed, because nothing ran the method.
+ *
+ * @package    Proclaim.IntegrationTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ *
+ * @since __DEPLOY_VERSION__
+ */
+
+namespace CWM\Component\Proclaim\Tests\Integration\Admin\Model;
+
+use CWM\Component\Proclaim\Administrator\Model\CwmsetupwizardModel;
+use CWM\Component\Proclaim\Tests\Integration\IntegrationTestCase;
+use Joomla\CMS\Factory;
+use Joomla\Database\DatabaseInterface;
+use PHPUnit\Framework\Attributes\TestDox;
+
+/**
+ * @since __DEPLOY_VERSION__
+ */
+class CwmsetupwizardPodcastTest extends IntegrationTestCase
+{
+    /**
+     * @var DatabaseInterface|null
+     * @since __DEPLOY_VERSION__
+     */
+    private ?DatabaseInterface $db = null;
+
+    /**
+     * @var mixed
+     * @since __DEPLOY_VERSION__
+     */
+    private mixed $previousFactoryLanguage = null;
+
+    /**
+     * @var mixed
+     * @since __DEPLOY_VERSION__
+     */
+    private mixed $previousLiveSite = null;
+
+    /**
+     * @return  void
+     * @since __DEPLOY_VERSION__
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (!\defined('PROCLAIM_TEST_DB_AVAILABLE') || !PROCLAIM_TEST_DB_AVAILABLE) {
+            $this->markTestSkipped('Database not available for integration tests');
+        }
+
+        $this->previousFactoryLanguage = $this->silenceDateLanguageWarnings();
+
+        $app                    = Factory::getApplication();
+        $this->previousLiveSite = $app->get('live_site', '');
+        // The bug only shows when live_site is empty, so the root fallback runs.
+        $app->set('live_site', '');
+
+        $this->db = Factory::getContainer()->get(DatabaseInterface::class);
+        $this->db->transactionStart(true);
+    }
+
+    /**
+     * @return  void
+     * @since __DEPLOY_VERSION__
+     */
+    protected function tearDown(): void
+    {
+        if ($this->db !== null) {
+            try {
+                $this->db->transactionRollback(true);
+            } catch (\Throwable) {
+                // Connection may have gone away.
+            }
+        }
+
+        Factory::getApplication()->set('live_site', $this->previousLiveSite);
+        Factory::$language = $this->previousFactoryLanguage;
+
+        parent::tearDown();
+    }
+
+    /**
+     * @return  void
+     * @since __DEPLOY_VERSION__
+     */
+    #[TestDox('createPodcastRecord() falls back to the site root when live_site is empty')]
+    public function testCreatePodcastRecordFallsBackToSiteRoot(): void
+    {
+        // The method skips when a podcast already exists, so clear them inside
+        // the transaction to reach the insert.
+        $this->db->setQuery('DELETE FROM ' . $this->db->quoteName('#__bsms_podcast'))->execute();
+
+        $ref = new \ReflectionMethod(CwmsetupwizardModel::class, 'createPodcastRecord');
+        $id  = $ref->invoke(
+            (new \ReflectionClass(CwmsetupwizardModel::class))->newInstanceWithoutConstructor(),
+            ['podcast_title' => 'zz wizard podcast', 'podcast_email' => 'zz@example.org']
+        );
+
+        $this->assertGreaterThan(0, $id, 'The podcast row should have been created');
+
+        $website = $this->db->setQuery(
+            $this->db->createQuery()
+                ->select($this->db->quoteName('website'))
+                ->from($this->db->quoteName('#__bsms_podcast'))
+                ->where($this->db->quoteName('id') . ' = ' . (int) $id)
+        )->loadResult();
+
+        // Before the fix this line was never reached: the undefined Joomla 3
+        // method threw first.
+        $this->assertNotSame('', (string) $website, 'The podcast website should carry the site root');
+    }
+}

--- a/tests/integration/Site/Model/CwmsermonUnpublishedGuardTest.php
+++ b/tests/integration/Site/Model/CwmsermonUnpublishedGuardTest.php
@@ -1,0 +1,177 @@
+<?php
+
+/**
+ * Asking for a sermon whose published state does not match the requested filter
+ * is meant to queue "item not published" and return nothing. The model used
+ * Text::_() without importing Text, so PHP looked for the class in the model's
+ * own namespace and the visitor got a 500 instead of the message. php -l and the
+ * suite both passed, because the name is only resolved when the branch runs.
+ *
+ * @package    Proclaim.IntegrationTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ *
+ * @since __DEPLOY_VERSION__
+ */
+
+namespace CWM\Component\Proclaim\Tests\Integration\Site\Model;
+
+use CWM\Component\Proclaim\Site\Model\CwmsermonModel;
+use CWM\Component\Proclaim\Tests\Integration\IntegrationTestCase;
+use Joomla\CMS\Factory;
+use Joomla\CMS\Form\FormFactoryInterface;
+use Joomla\CMS\MVC\Factory\MVCFactory;
+use Joomla\CMS\User\User;
+use Joomla\Database\DatabaseInterface;
+use Joomla\Event\DispatcherInterface;
+use PHPUnit\Framework\Attributes\TestDox;
+
+/**
+ * @since __DEPLOY_VERSION__
+ */
+class CwmsermonUnpublishedGuardTest extends IntegrationTestCase
+{
+    /**
+     * @var DatabaseInterface|null
+     * @since __DEPLOY_VERSION__
+     */
+    private ?DatabaseInterface $db = null;
+
+    /**
+     * @var mixed
+     * @since __DEPLOY_VERSION__
+     */
+    private mixed $previousFactoryLanguage = null;
+
+    /**
+     * @var User|null
+     * @since __DEPLOY_VERSION__
+     */
+    private ?User $savedIdentity = null;
+
+    /**
+     * @return  void
+     * @since __DEPLOY_VERSION__
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (!\defined('PROCLAIM_TEST_DB_AVAILABLE') || !PROCLAIM_TEST_DB_AVAILABLE) {
+            $this->markTestSkipped('Database not available for integration tests');
+        }
+
+        $this->previousFactoryLanguage = $this->silenceDateLanguageWarnings();
+
+        // The access filter reads the current identity; the issue is about what
+        // a guest sees, so stand one in and restore it afterwards.
+        $app                 = Factory::getApplication();
+        $this->savedIdentity = $app->getIdentity();
+        $app->loadIdentity(new User());
+
+        $this->db = Factory::getContainer()->get(DatabaseInterface::class);
+        $this->db->transactionStart(true);
+    }
+
+    /**
+     * @return  void
+     * @since __DEPLOY_VERSION__
+     */
+    protected function tearDown(): void
+    {
+        if ($this->db !== null) {
+            try {
+                $this->db->transactionRollback(true);
+            } catch (\Throwable) {
+                // Connection may have gone away.
+            }
+        }
+
+        if ($this->savedIdentity !== null) {
+            Factory::getApplication()->loadIdentity($this->savedIdentity);
+        }
+
+        Factory::$language = $this->previousFactoryLanguage;
+
+        parent::tearDown();
+    }
+
+    /**
+     * @return  void
+     * @since __DEPLOY_VERSION__
+     */
+    #[TestDox('A sermon that fails the published filter queues a message instead of throwing')]
+    public function testMismatchedPublishedStateQueuesAMessage(): void
+    {
+        $studyId = $this->seedStudy();
+
+        $model = $this->createModel();
+        $model->setState('study.id', $studyId);
+        // Only a numeric filter.published narrows the SQL, so leaving it unset
+        // and setting the archived filter lets the row load and then fail the
+        // PHP state check — the branch that used the unimported Text.
+        $model->setState('filter.archived', 2);
+
+        // ⚠️ enqueueMessage() ignores a message already in the queue, so a
+        // count comparison is order-dependent — drain first and look for the
+        // message itself.
+        Factory::getApplication()->getMessageQueue(true);
+
+        // Before the fix this threw Error: Class "...Site\Model\Text" not found.
+        $item = $model->getItem();
+
+        $this->assertNull($item, 'A sermon failing the published filter must not be returned');
+
+        // Not matched by text: the model translates with the site language
+        // loaded, a test does not, so the two renderings differ.
+        $this->assertNotEmpty(
+            Factory::getApplication()->getMessageQueue(),
+            'The visitor should get a queued message rather than an exception'
+        );
+    }
+
+    /**
+     * @return  int  Seeded study id.
+     * @since __DEPLOY_VERSION__
+     */
+    private function seedStudy(): int
+    {
+        $row = (object) [
+            'studytitle' => 'zz guard study ' . uniqid('', true),
+            'alias'      => 'zz-guard-study-' . uniqid('', true),
+            'studydate'  => '2026-01-15 10:00:00',
+            'booknumber' => 101,
+            'published'  => 1,
+            'access'     => 1,
+            'language'   => '*',
+            'ordering'   => 0,
+            'params'     => '{}',
+        ];
+
+        $this->db->insertObject('#__bsms_studies', $row);
+
+        return (int) $this->db->insertid();
+    }
+
+    /**
+     * @return  CwmsermonModel
+     * @since __DEPLOY_VERSION__
+     */
+    private function createModel(): CwmsermonModel
+    {
+        $container = Factory::getContainer();
+
+        $factory = new MVCFactory('CWM\\Component\\Proclaim');
+        $factory->setDatabase($container->get(DatabaseInterface::class));
+        $factory->setDispatcher($container->get(DispatcherInterface::class));
+        $factory->setFormFactory($container->get(FormFactoryInterface::class));
+
+        /** @var CwmsermonModel $model */
+        $model = $factory->createModel('Cwmsermon', 'Site', ['ignore_request' => true]);
+
+        $this->assertInstanceOf(CwmsermonModel::class, $model);
+
+        return $model;
+    }
+}


### PR DESCRIPTION
Closes #2075. Closes #2076.

Both are the shape CLAUDE.md documents: the file parses, the symbol is only resolved when the line runs, and no test ran the line.

## #2075 — setup wizard podcast step
`Factory::getUri()` is a Joomla 3 method removed in 4.0; it ran on the branch taken when `live_site` is empty (the normal case). Now `Uri::root()`.

**A second defect surfaced while writing the test.** The inserted row omits `podcastlink`. Sites upgraded through the era when that column was added carry it **NOT NULL with no default** — it was added by an `ALTER … NOT NULL` (see 62f2363d6), while today's install SQL declares it nullable. On those sites the insert throws, and `catch (\Throwable) { return 0; }` swallowed it, so the wizard reported no podcast and the reason appeared nowhere. Both dev databases here are in that state, so it is the likely condition of most upgraded installs. The column is now supplied and the failure logged.

## #2076 — unpublished sermon as a guest
`CwmsermonModel` used `Text::_()` without importing `Text`, so PHP resolved it in the model's own namespace and the visitor got a 500 instead of the "item not published" message. Import added.

## Coverage
Two executing integration tests, both **mutation-confirmed**:
- reverting `Uri::root()` → errors; dropping `podcastlink` → fails;
- removing the `Text` import reproduces the issue's exact error, `Class "CWM\Component\Proclaim\Site\Model\Text" not found`.

⚠️ The sermon test **drains the message queue before acting**: `enqueueMessage()` ignores a message already in the queue, so asserting "the queue grew" is order-dependent — it passed in isolation and failed in a full run, and had been passing for the wrong reason (an unrelated queued message).

## Verified
Full suite green (3627), `lint`/`lint:comments` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)