### PR TITLE
fix(admin): keep UTF-8 intact when trimming dangling separators (#2077)

### DIFF
--- a/admin/src/Helper/CwmdescriptionHelper.php
+++ b/admin/src/Helper/CwmdescriptionHelper.php
@@ -184,7 +184,15 @@ class CwmdescriptionHelper
         $result = strtr($format, $replacements);
 
         // Clean up dangling separators left by empty placeholders (e.g. "Title — ")
-        $result = preg_replace('/\s*[—–\-]+\s*$/m', '', $result);
+        // ⚠️ /u is load-bearing: the class holds an em and an en dash, and
+        // without it PCRE matches their individual bytes, so any character
+        // whose encoding ends in 0x80/0x93/0x94 (À, Ô, œ, Cyrillic Г/Д …) loses
+        // its trailing byte at end of line and the string stops being UTF-8.
+        $cleaned = preg_replace('/\s*[—–\-]+\s*$/mu', '', $result);
+
+        // preg_replace returns null when the subject is not valid UTF-8; keep
+        // the uncleaned text rather than blanking the whole description.
+        $result = $cleaned ?? $result;
 
         // Clean up lines that are only labels with empty values (e.g. "Topics: ")
         $result = preg_replace('/^\S+:\s*$/m', '', $result);

--- a/tests/unit/Admin/Helper/CwmdescriptionUtf8Test.php
+++ b/tests/unit/Admin/Helper/CwmdescriptionUtf8Test.php
@@ -1,0 +1,110 @@
+<?php
+
+/**
+ * The description template's separator cleanup ate the last byte of multibyte
+ * characters at end of line.
+ *
+ * Its class holds an em and an en dash, but the pattern had no /u, so PCRE
+ * matched their individual bytes — E2 80 94, E2 80 93 and 2D. Any character
+ * whose UTF-8 encoding ends in 0x80, 0x93 or 0x94 therefore matched at end of
+ * line and lost its trailing byte, leaving a string that is no longer UTF-8:
+ * À (C3 80), Ô (C3 94), œ (C5 93), Cyrillic Г/Д (D0 93/94), and others.
+ *
+ * @package    Proclaim.UnitTest
+ * @copyright  (C) 2026 CWM Team All rights reserved
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       https://www.christianwebministries.org
+ *
+ * @since __DEPLOY_VERSION__
+ */
+
+namespace CWM\Component\Proclaim\Tests\Admin\Helper;
+
+use CWM\Component\Proclaim\Administrator\Helper\CwmdescriptionHelper;
+use CWM\Component\Proclaim\Tests\ProclaimTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\TestDox;
+
+/**
+ * @since __DEPLOY_VERSION__
+ */
+class CwmdescriptionUtf8Test extends ProclaimTestCase
+{
+    /**
+     * Characters whose encoding ends in one of the bytes the dash class held.
+     *
+     * @return  array<string, array{0: string}>
+     * @since __DEPLOY_VERSION__
+     */
+    public static function trailingByteProvider(): array
+    {
+        return [
+            'oe ligature (C5 93)'  => ['Bœ'],
+            'A grave (C3 80)'      => ['À'],
+            'O circumflex (C3 94)' => ['Ô'],
+            'Cyrillic Ge (D0 93)'  => ['Г'],
+            'Cyrillic De (D0 94)'  => ['Д'],
+        ];
+    }
+
+    /**
+     * @param   string  $title  A title ending in a vulnerable character.
+     *
+     * @return  void
+     * @since __DEPLOY_VERSION__
+     */
+    #[DataProvider('trailingByteProvider')]
+    #[TestDox('A title ending in a multibyte character survives the separator cleanup')]
+    public function testMultibyteTitleSurvives(string $title): void
+    {
+        $result = $this->applyTemplate('{title}', ['title' => $title]);
+
+        $this->assertTrue(mb_check_encoding($result, 'UTF-8'), 'The result must still be valid UTF-8');
+        $this->assertSame($title, $result, 'No byte of the title may be stripped');
+    }
+
+    /**
+     * @return  void
+     * @since __DEPLOY_VERSION__
+     */
+    #[TestDox('A genuine trailing separator is still removed')]
+    public function testTrailingSeparatorIsStillStripped(): void
+    {
+        $this->assertSame('Sermon', $this->applyTemplate('{title} — ', ['title' => 'Sermon']));
+        $this->assertSame('Sermon', $this->applyTemplate('{title} - ', ['title' => 'Sermon']));
+        $this->assertSame('Sermon', $this->applyTemplate('{title} – ', ['title' => 'Sermon']));
+    }
+
+    /**
+     * With /u, preg_replace returns null on a subject that is not valid UTF-8.
+     * The helper is typed to return a string, so it must keep the text rather
+     * than blank the description.
+     *
+     * @return  void
+     * @since __DEPLOY_VERSION__
+     */
+    #[TestDox('Input that is already invalid UTF-8 is preserved, not blanked')]
+    public function testInvalidUtf8InputIsNotBlanked(): void
+    {
+        // A lone continuation byte: never valid UTF-8.
+        $broken = "Title \xC3";
+
+        $result = $this->applyTemplate('{title}', ['title' => $broken]);
+
+        $this->assertNotSame('', $result, 'A broken title must not blank the whole description');
+        $this->assertStringContainsString('Title', $result);
+    }
+
+    /**
+     * @param   string                $format  Template format string.
+     * @param   array<string, string> $data    Placeholder values.
+     *
+     * @return  string
+     * @since __DEPLOY_VERSION__
+     */
+    private function applyTemplate(string $format, array $data): string
+    {
+        return (new \ReflectionMethod(CwmdescriptionHelper::class, 'applyTemplate'))
+            ->invoke(null, $format, $data);
+    }
+}


### PR DESCRIPTION
Closes #2077.

`CwmdescriptionHelper::applyTemplate()` trims dangling separators with a class holding an em dash, an en dash and a hyphen — but the pattern had no `/u`. PCRE therefore matched their individual bytes (`E2 80 94`, `E2 80 93`, `2D`), so **any character whose UTF-8 encoding ends in `0x80`, `0x93` or `0x94`** matched at end of line and lost its trailing byte: `À` (C3 80), `Ô` (C3 94), `œ` (C5 93), Cyrillic `Г`/`Д` (D0 93/94). A title ending in one came out no longer valid UTF-8.

## Change
Add `/u` — **plus a guard the issue didn't call for**: with `/u`, `preg_replace` returns `null` for a subject that is *already* invalid UTF-8, and the method is typed `: string`, so a bare `/u` would turn a slightly-broken title into a **blank description**. The uncleaned text is kept in that case instead.

## Coverage
A data-provider test over all five characters, a check that a genuine trailing separator (`—`, `–`, `-`) is still stripped, and one for already-broken input. **Both halves mutation-confirmed**: removing `/u` fails five cases; removing the null guard fails the invalid-input case.

## Verified
Full suite green (3634), `lint`/`lint:comments` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)