### PR TITLE
chore: clear the safe half of the Qodana housekeeping list (#2079)

### DIFF
--- a/admin/src/Addons/Servers/Youtube/CWMAddonYoutube.php
+++ b/admin/src/Addons/Servers/Youtube/CWMAddonYoutube.php
@@ -3130,8 +3130,10 @@ class CWMAddonYoutube extends CWMAddon
             // Save VTT file
             $subtitleDir = JPATH_ROOT . '/media/biblestudy/subtitles';
 
-            if (!is_dir($subtitleDir)) {
-                mkdir($subtitleDir, 0755, true);
+            // Re-check after mkdir: a concurrent request may have created it
+            // between the test and the call, which is not a failure.
+            if (!is_dir($subtitleDir) && !mkdir($subtitleDir, 0755, true) && !is_dir($subtitleDir)) {
+                return ['success' => false, 'error' => 'Could not create the subtitle directory'];
             }
 
             $safeLang = preg_replace('/[^a-zA-Z0-9_-]/', '', $srclang);

--- a/admin/src/Controller/CwmassetsController.php
+++ b/admin/src/Controller/CwmassetsController.php
@@ -157,6 +157,8 @@ class CwmassetsController extends BaseController
             $asset['realname'] = Text::_($asset['realname']);
         }
 
+        unset($asset);
+
         $this->sendJsonResponse(true, '', ['assets' => $assets]);
     }
 

--- a/admin/src/Controller/CwmmediafileController.php
+++ b/admin/src/Controller/CwmmediafileController.php
@@ -22,6 +22,7 @@ use CWM\Component\Proclaim\Administrator\Controller\Trait\SectionAccessTrait;
 use CWM\Component\Proclaim\Administrator\Helper\CwmactionlogHelper;
 use CWM\Component\Proclaim\Administrator\Helper\CwmcaptionValidator;
 use CWM\Component\Proclaim\Administrator\Helper\CwmprotectedMove;
+use CWM\Component\Proclaim\Administrator\Model\CwmmediafileModel;
 use CWM\Component\Proclaim\Administrator\Table\CwmmediafileTable;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;

--- a/admin/src/Controller/CwmsetupwizardController.php
+++ b/admin/src/Controller/CwmsetupwizardController.php
@@ -14,6 +14,7 @@ namespace CWM\Component\Proclaim\Administrator\Controller;
 // phpcs:enable PSR1.Files.SideEffects
 
 use CWM\Component\Proclaim\Administrator\Controller\Trait\CwmJsonResponseTrait;
+use CWM\Component\Proclaim\Administrator\Model\CwmsetupwizardModel;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\Controller\BaseController;

--- a/admin/src/Helper/CwmcsvimportHelper.php
+++ b/admin/src/Helper/CwmcsvimportHelper.php
@@ -15,6 +15,7 @@ namespace CWM\Component\Proclaim\Administrator\Helper;
 \defined('_JEXEC') or die;
 // phpcs:enable PSR1.Files.SideEffects
 
+use CWM\Library\Scripture\Helper\ScriptureReference;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Filter\OutputFilter;
 use Joomla\CMS\Language\Text;

--- a/admin/src/Lib/Cwmssconvert.php
+++ b/admin/src/Lib/Cwmssconvert.php
@@ -311,6 +311,10 @@ class Cwmssconvert
             $sermonscripture->chapter_end   = '';
             $sermonscripture->verse_begin   = '';
             $sermonscripture->verse_end     = '';
+
+            // Without this the empties are overwritten below, and every
+            // string call downstream is handed null.
+            return $sermonscripture;
         }
 
         $bookname = substr_count(strtolower($sermon), 'genesis');

--- a/admin/src/Model/CwmmessageModel.php
+++ b/admin/src/Model/CwmmessageModel.php
@@ -29,6 +29,7 @@ use CWM\Component\Proclaim\Administrator\Helper\Cwmthumbnail;
 use CWM\Component\Proclaim\Administrator\Helper\CwmtopicSuggestionHelper;
 use CWM\Component\Proclaim\Administrator\Helper\Cwmtranslated;
 use CWM\Component\Proclaim\Administrator\Helper\CwmyoutubeFileCache;
+use CWM\Component\Proclaim\Administrator\Table\CwmmessageTable;
 use CWM\Library\Scripture\Helper\ScriptureReference;
 use Joomla\CMS\Application\ApplicationHelper;
 use Joomla\CMS\Date\Date;

--- a/admin/src/Model/CwmmessagetypeModel.php
+++ b/admin/src/Model/CwmmessagetypeModel.php
@@ -16,6 +16,7 @@ namespace CWM\Component\Proclaim\Administrator\Model;
 
 // phpcs:enable PSR1.Files.SideEffects
 
+use CWM\Component\Proclaim\Administrator\Table\CwmmessageTable;
 use Joomla\CMS\Application\ApplicationHelper;
 use Joomla\CMS\Date\Date;
 use Joomla\CMS\Factory;

--- a/admin/src/Model/CwmtemplateModel.php
+++ b/admin/src/Model/CwmtemplateModel.php
@@ -17,6 +17,7 @@ namespace CWM\Component\Proclaim\Administrator\Model;
 // phpcs:enable PSR1.Files.SideEffects
 
 use CWM\Component\Proclaim\Administrator\Helper\CwmlocationHelper;
+use CWM\Component\Proclaim\Administrator\Table\CwmtemplateTable;
 use Joomla\CMS\Date\Date;
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;

--- a/plugins/schemaorg/proclaim/src/Extension/Proclaim.php
+++ b/plugins/schemaorg/proclaim/src/Extension/Proclaim.php
@@ -468,6 +468,8 @@ final class Proclaim extends CMSPlugin implements SubscriberInterface
             $entry = self::sanitizeForScriptEmbedding($entry);
         }
 
+        unset($entry);
+
         $schema->set('@graph', $graph);
     }
 


### PR DESCRIPTION
Works four of the #2079 checklist items. Deliberately **not** closing the issue — the two larger items are left to follow-ups.

## Done
- **Race-safe `mkdir`** — the YouTube caption download tested `is_dir()` then called `mkdir()` bare, so a concurrent request between the two produced a warning and a silent write failure. Uses the re-checking form the rest of the codebase already uses, and now reports the failure instead of writing on.
- **`Cwmssconvert::getVerses(null)`** — filled its fields with empties, then carried on into `strtolower($sermon)` with null (deprecated since 8.1) and overwrote the empties it had just set. Returns early.
- **Two by-reference `foreach` loops** (schema.org graph sanitiser, asset realname translation) left the reference live, where the next write to that variable corrupts the last element. `unset()` on both.
- **Six unresolvable `@var` docblocks** — `CwmmessageTable`, `CwmtemplateTable`, `CwmsetupwizardModel`, `CwmmediafileModel`, `ScriptureReference` named without an import. This is the one with teeth: an unresolvable `@var` stops the IDE resolving the variable at all, which is exactly what hides the "undefined method" warnings CLAUDE.md asks to be read before pushing. Verified the imports survive PHP CS Fixer (it keeps docblock-only uses) and that the IDE now reports clean.

## Left for follow-ups
- The **95 `json_encode`/`json_decode`** calls missing `JSON_THROW_ON_ERROR` — big enough to want its own PR and the [[json-throw-contract]] treatment.
- The **two dead-code removals** (`convertVimeo()`, the `$this->lists` block) — deletions want their own reachability check rather than riding along here; grep alone is not proof.

## Verified
Full suite green (3629), PhpStorm inspection clean on the touched files, `lint`/`lint:comments` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)