### PR TITLE
fix(site): drop the series dropdown that reads data the view never builds (#2079)

### DIFF
--- a/site/src/View/Cwmseriesdisplays/HtmlView.php
+++ b/site/src/View/Cwmseriesdisplays/HtmlView.php
@@ -194,7 +194,6 @@ class HtmlView extends BaseHtmlView
 
         $uri_tostring = $uri->toString();
 
-        // $this->lists = $lists;
         $this->request_url = $uri_tostring;
 
         // Pre-create helpers for template use

--- a/site/tmpl/cwmseriesdisplays/default_custom.php
+++ b/site/tmpl/cwmseriesdisplays/default_custom.php
@@ -55,15 +55,6 @@ if ($this->params->get('show_series_title') > 0) {
 ?>
             </h1>
             <!--header-->
-            <div id="bsdropdownmenu">
-                <?php
-//                @todo Need to find the correct solution for this section, as it looks to be broken.
-if ($this->params->get('search_series') > 0) {
-    echo $this->lists['seriesid'];
-}
-?>
-            </div>
-            <!--dropdownmenu-->
             <?php
             switch ($this->params->get('series_wrapcode')) {
                 case '0':


### PR DESCRIPTION
Works the first of #2079's two remaining removals — and it turned out to be a **live defect, not dead code**.

`site/tmpl/cwmseriesdisplays/default_custom.php` echoed `$this->lists['seriesid']` behind a `search_series > 0` guard. The view's only mention of `$lists` is a **commented-out** assignment (`HtmlView.php:197`) and nothing ever builds it, so the property does not exist — the block can only emit *Undefined property* and *Trying to access array offset on null*.

## ⚠️ Why "unreachable" was wrong
#2079 described it as reachable "only through the legacy `search_series` template param, which no form exposes". No form does expose it — but `install.mysql.utf8.sql` **seeds it as `"1"`**, and it is still `1` in both dev databases. So the guard is **true on a default install** and the block runs whenever this template renders.

That is the same shape as the seeded `css` param that made the "legacy only" `#__bsms_styles` path run on every clean install (#1918/#1926) — a param no UI exposes is not the same as a param nobody has.

## Why removal, not restoration
Restoring the assignment is not available: `$lists` is never constructed anywhere in the view, so there is nothing to assign. The dropdown was never implemented — which is what its own `@todo` was recording. The commented assignment goes too, since it is the only thing that made the feature look restorable.

## Verified
Full suite green (3636); no reference to `$this->lists` remains in the site tree; `lint`/`lint:comments` clean.

Leaves one item on #2079 — `Cwmmedia::convertVimeo()`, which I'd argue should **stay** until 11.0.0; see the issue comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)