### PR TITLE
ci: run the PR checks on pull requests into main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
       - 'admin/language/**'
       - '.claude/**'
   pull_request:
-    branches: [ "development", "10.x", "11.0.0-dev" ]
+    branches: [ "main", "development", "10.x", "11.0.0-dev" ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,7 +15,7 @@ on:
   push:
     branches: [ "development", "10.x", "11.0.0-dev" ]
   pull_request:
-    branches: [ "development", "10.x", "11.0.0-dev" ]
+    branches: [ "main", "development", "10.x", "11.0.0-dev" ]
   schedule:
     - cron: '15 6 * * 5'
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -24,7 +24,7 @@ on:
     # Nightly, 05:17 UTC — off the busy top-of-hour cron load.
     - cron: '17 5 * * *'
   pull_request:
-    branches: [ "development", "10.x", "11.0.0-dev" ]
+    branches: [ "main", "development", "10.x", "11.0.0-dev" ]
     # ⚠️ No paths: filter, deliberately.
     #
     # This job was gated on an allow-list that grew by one entry each time it


### PR DESCRIPTION
A release is reviewed as a PR from `development` into `main` — but every workflow's `pull_request` trigger listed only `development`, `10.x` and `11.0.0-dev`.

So #2094, the v10.7.0 review PR, shows **seven checks it inherited from the development push and none of its own**. Most importantly the **clean-install job never ran against it** — the one check a release most needs, since it is what proves the built package installs and migrates.

Adds `main` to the `pull_request` branch lists for CI, E2E and CodeQL.

⚠️ **Deliberately not added to the `push` triggers.** The release pipeline pushes to `main` several times in a row (version bump, changelog entry, tag), and each push would start a build the next one immediately supersedes — the same churn visible as cancelled runs in the scripture repos during their releases.

## Meanwhile
I dispatched E2E manually against `development` so the release code has a real result now rather than waiting on this:

```
CLEAN-INSTALL TEST PASSED for 10.7.0
com_proclaim      schema=10.5.8-20260811   ok=166  error=0
lib_cwmscripture  schema=1.1.6             ok=1    error=0
REST API acceptance: 6 passed
```

Once this merges, #2094 will pick up the full set on its next update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)